### PR TITLE
added context to html map

### DIFF
--- a/src/helpers.js
+++ b/src/helpers.js
@@ -12,31 +12,37 @@ const getDatasetHtml = (data) =>
     ""
   );
 
-const setClassList = classList => classList && Array.isArray(classList)
-  ? ` class="${classList.join(" ")}" `
-  : ` class="${classList}" `;
+const setClassList = (classList) =>
+  classList && Array.isArray(classList)
+    ? ` class="${classList.join(" ")}" `
+    : ` class="${classList}" `;
 
-const setElementAttributes = ({
-  classList,
-  id,
-  props,
-  dataset
-}) => `${setClassList(classList)}${id && `id="${id}" `}${getAttributesHtml(props)}${getDatasetHtml(dataset)}`;
+const setElementAttributes = ({ classList, id, props, dataset }) =>
+  `${setClassList(classList)}${id && `id="${id}" `}${getAttributesHtml(
+    props
+  )}${getDatasetHtml(dataset)}`;
 
-export const createElement = (
-  {
-    tagName = "div",
-    classList = "",
-    id = "",
-    props = {},
-    dataset = {},
-    children = ""
-  }
-) => `<${tagName || "div"}${setElementAttributes({classList,id,props,dataset})}>${children}</${tagName || "div"}>`;
+export const createElement = ({
+  tagName = "div",
+  classList = "",
+  id = "",
+  props = {},
+  dataset = {},
+  children = "",
+}) =>
+  `<${tagName || "div"}${setElementAttributes({
+    classList,
+    id,
+    props,
+    dataset,
+  })}>${children}</${tagName || "div"}>`;
 
 export const mapHtml = ({ props, htmlMap }) => {
   const { type, subtype } = props;
-  const setDefaultClassList = (type, subtype) => [...(type ? [type] : []), ...(subtype ? [subtype.replace(":", " ")] : [])];
+  const setDefaultClassList = (type, subtype) => [
+    ...(type ? [type] : []),
+    ...(subtype ? [subtype.replace(":", " ")] : []),
+  ];
 
   if (!htmlMap) return { classList: setDefaultClassList(type, subtype) };
 
@@ -44,26 +50,35 @@ export const mapHtml = ({ props, htmlMap }) => {
     htmlMap[type]?.[subtype],
     htmlMap["*"]?.[subtype],
     htmlMap[type]?.["*"],
-    htmlMap["*"]?.["*"]
+    htmlMap["*"]?.["*"],
   ];
 
-  const getClassList = (classList) => classList && (Array.isArray(classList) ? classList : [classList]); 
-  const result = maps.reduce((_result, map) => {
-    const _map = map || {};
-    const { classList, tagName, id } = (typeof _map === 'function') ? _map(props) : _map;
+  const getClassList = (classList) =>
+    classList && (Array.isArray(classList) ? classList : [classList]);
+  const result = maps.reduce(
+    (_result, map) => {
+      const _map = map || {};
+      const { classList, tagName, id } =
+        typeof _map === "function" ? _map(props) : _map;
 
-    _result.classList = _result.classList.concat(getClassList(classList) || []);
-    if (!_result.tagName && tagName) _result.tagName = tagName;
-    if (!_result.id && id) _result.id = id;
-    return _result;
-  }, { classList: [], tagName: ""});
+      _result.classList = _result.classList.concat(
+        getClassList(classList) || []
+      );
+      if (!_result.tagName && tagName) _result.tagName = tagName;
+      if (!_result.id && id) _result.id = id;
+      return _result;
+    },
+    { classList: [], tagName: "" }
+  );
 
   return {
-    classList: result.classList.length ? [...new Set(result.classList)] : setDefaultClassList(type, subtype),
+    classList: result.classList.length
+      ? [...new Set(result.classList)]
+      : setDefaultClassList(type, subtype),
     tagName: result.tagName,
-    id: result.id
-  }
-}
+    id: result.id,
+  };
+};
 
 export const handleAtts = (atts) =>
   atts

--- a/src/htmlmap.js
+++ b/src/htmlmap.js
@@ -1,35 +1,49 @@
-export default ({
+export default (context) => ({
   "*": {
     "*": {
-      "tagName": "span"
+      tagName: "span",
     },
-    "sequence":{
-      "tagName": "section"
-    }
+    sequence: {
+      tagName: "section",
+    },
   },
-  "paragraph": {
+  paragraph: {
     "*": {
-      "tagName": "p"
-    }
+      tagName: "p",
+    },
   },
-  "mark": {
+  mark: {
     "*": {
-      "tagName": "span"
+      tagName: "span",
     },
-    "chapter": ({ atts }) => ({
-      classList: ['mark', 'chapter', `chapter-${atts.number}`],
-      id: `chapter-${atts.number}`,
-    })
+    chapter: ({ atts }) => {
+      context.lastChap = atts.number;
+      return {
+        classList: ["mark", "chapter", `chapter-${atts.number}`],
+        id: `chapter-${atts.number}`,
+      };
+    },
+    verses: ({ atts }) => {
+      return {
+        classList: [
+          "mark",
+          "verse",
+          `verse-${atts.number}`,
+          `ref-ch${context.lastChap}v${atts.number}`,
+        ],
+        id: `verse-${atts.number}`,
+      };
+    },
   },
-  "graft":{
-    "heading": {
-      "tagName": "div"
+  graft: {
+    heading: {
+      tagName: "div",
     },
-    "title": {
-      "tagName": "div"
+    title: {
+      tagName: "div",
     },
-    "introduction": {
-      "tagName": "div"
-    }
-  }
-})
+    introduction: {
+      tagName: "div",
+    },
+  },
+});

--- a/src/index.js
+++ b/src/index.js
@@ -1,74 +1,79 @@
 import Epitelete from "epitelete";
-import perf2html from "./perf2html"
-import html2perf from "./html2perf"
+import perf2html from "./perf2html";
+import html2perf from "./html2perf";
 
 class EpiteletePerfHtml extends Epitelete {
+  constructor({ proskomma = null, docSetId, htmlMap, options = {} }) {
+    super({ proskomma, docSetId, options });
+    this.htmlMap = htmlMap;
+  }
 
-    constructor({proskomma=null, docSetId, htmlMap, options={}}) {
-        super({ proskomma, docSetId, options });
-        this.htmlMap = htmlMap
-    }
+  _outputHtml(perfDocument) {
+    const sequencesHtml = Object.keys(perfDocument.sequences).reduce(
+      (sequences, sequenceId) => {
+        sequences[sequenceId] = perf2html({
+          perfDocument,
+          sequenceId,
+          htmlMap: this.htmlMap,
+        });
+        return sequences;
+      },
+      {}
+    );
+    return {
+      docSetId: this.docSetId,
+      mainSequenceId: perfDocument.main_sequence_id,
+      schema: perfDocument.schema,
+      metadata: perfDocument.metadata,
+      sequencesHtml,
+    };
+  }
 
-    _outputHtml(doc) {
-        const sequencesHtml = Object.keys(doc.sequences).reduce((sequences, seqId) => {
-            sequences[seqId] = perf2html(doc, seqId, this.htmlMap);
-            return sequences;
-        }, {});
-        return {
-            docSetId: this.docSetId,
-            mainSequenceId: doc.main_sequence_id,
-            schema: doc.schema,
-            metadata: doc.metadata,
-            sequencesHtml,
-        };
-    }
+  /**
+   * Return current perfHtmlContainer
+   * @param {string} bookCode
+   * @param {object} [options]
+   * @param {string} options.readPipeline - the name of the read pipeline
+   */
+  async readHtml(bookCode, options = {}) {
+    return this._outputHtml(await this.readPerf(bookCode, options));
+  }
 
-    /**
-     * Return current perfHtmlContainer
-     * @param {string} bookCode
-     * @param {object} [options]
-     * @param {string} options.readPipeline - the name of the read pipeline
-     */
-    async readHtml(bookCode, options = {}) {
-        return this._outputHtml(await this.readPerf(bookCode, options));
-    }
+  /**
+   * Returns previous perfHtmlContainer in history
+   * @param {string} bookCode
+   * @param {object} [options]
+   * @param {string} options.readPipeline - the name of the read pipeline
+   */
+  async undoHtml(bookCode, options = {}) {
+    return this._outputHtml(await this.undoPerf(bookCode, options));
+  }
 
-    /**
-     * Returns previous perfHtmlContainer in history
-     * @param {string} bookCode
-     * @param {object} [options]
-     * @param {string} options.readPipeline - the name of the read pipeline
-     */
-    async undoHtml(bookCode, options = {}) {
-        return this._outputHtml(await this.undoPerf(bookCode, options));
-    }
+  /**
+   * Returns next perfHtmlContainer in history
+   * @param {string} bookCode
+   * @param {object} [options]
+   * @param {string} options.readPipeline - the name of the read pipeline
+   */
+  async redoHtml(bookCode, options = {}) {
+    return this._outputHtml(await this.redoPerf(bookCode, options));
+  }
 
-    /**
-     * Returns next perfHtmlContainer in history
-     * @param {string} bookCode
-     * @param {object} [options]
-     * @param {string} options.readPipeline - the name of the read pipeline
-     */
-    async redoHtml(bookCode, options = {}) {
-        return this._outputHtml(await this.redoPerf(bookCode, options));
-    }
-
-    /**
-     * Saves current perfHtmlContainer
-     * @param {string} bookCode
-     * @param {string} sequenceId
-     * @param {object} perfHtml
-     * @param {object} [options]
-     * @param {string} options.writePipeline - the name of the write pipeline
-     * @param {string} options.readPipeline - the name of the read pipeline
-     */
-    async writeHtml(bookCode, sequenceId, perfHtml, options = {}) {
-        const { writePipeline, readPipeline } = options;
-        const perf = html2perf(perfHtml, sequenceId);
-        await this.writePerf(bookCode,sequenceId,perf, {writePipeline});
-        return await this.readHtml(bookCode, {readPipeline});
-    }
-
+  /**
+   * Saves current perfHtmlContainer
+   * @param {string} bookCode
+   * @param {string} sequenceId
+   * @param {object} perfHtml
+   * @param {object} [options]
+   * @param {string} options.writePipeline - the name of the write pipeline
+   * @param {string} options.readPipeline - the name of the read pipeline
+   */
+  async writeHtml(bookCode, sequenceId, perfHtml, options = {}) {
+    const { writePipeline, readPipeline } = options;
+    const perf = html2perf(perfHtml, sequenceId);
+    await this.writePerf(bookCode, sequenceId, perf, { writePipeline });
+    return await this.readHtml(bookCode, { readPipeline });
+  }
 }
 
 export default EpiteletePerfHtml;

--- a/src/perf2html.js
+++ b/src/perf2html.js
@@ -1,8 +1,9 @@
 import defaultHtmlMap from "./htmlmap.js";
 import { createElement, handleAtts, handleSubtypeNS, mapHtml } from "./helpers";
 
-const map =
-  typeof defaultHtmlMap === "function" ? defaultHtmlMap({}) : defaultHtmlMap;
+function getMap(htmlMap) {
+  return typeof htmlMap === "function" ? htmlMap({}) : htmlMap;
+}
 
 function perf2html({ perfDocument, sequenceId, htmlMap = map }) {
   const { sequences, ...parent } = perfDocument;
@@ -49,9 +50,10 @@ export const contentElementHtml = ({ element, parent = {}, htmlMap = map }) => {
   const attsProps = handleAtts(atts);
   const subtypes = handleSubtypeNS(subtype);
   const currentProps = { type, subtype, atts, ...props, parent };
+  const _htmlmap = getMap(htmlMap);
   const { classList, tagName, id } = mapHtml({
     props: currentProps,
-    htmlMap,
+    htmlMap: _htmlmap,
   });
   const innerHtml = (content) => {
     const getters = {
@@ -63,7 +65,7 @@ export const contentElementHtml = ({ element, parent = {}, htmlMap = map }) => {
           content: meta_content,
           className: "meta-content",
           parent: currentProps,
-          htmlMap,
+          htmlMap: _htmlmap,
         }),
     };
     const getContentHtml = getters[`${type}Html`];
@@ -84,16 +86,21 @@ export const blockHtml = ({ block, parent = {}, htmlMap = map }) => {
   const attsProps = handleAtts(atts);
   const subtypes = handleSubtypeNS(subtype);
   const currentProps = { type, subtype, atts, ...props, parent };
+  const _htmlmap = getMap(htmlMap);
   const { classList, tagName, id } = mapHtml({
     props: currentProps,
-    htmlMap,
+    htmlMap: _htmlmap,
   });
   return createElement({
     tagName,
     id,
     classList,
     dataset: { type, ...subtypes, ...attsProps, ...props },
-    children: contentChildren({ content, htmlMap, parent: currentProps }),
+    children: contentChildren({
+      content,
+      htmlMap: _htmlmap,
+      parent: currentProps,
+    }),
   });
 };
 
@@ -105,9 +112,10 @@ export const sequenceHtml = ({
 }) => {
   const { blocks, ...props } = perfSequence;
   const currentProps = { ...props, subtype: "sequence", parent };
+  const _htmlmap = getMap(htmlMap);
   const { classList, tagName } = mapHtml({
     props: currentProps,
-    htmlMap,
+    htmlMap: _htmlmap,
   });
   return createElement({
     tagName,
@@ -116,7 +124,11 @@ export const sequenceHtml = ({
     dataset: props,
     children: blocks?.reduce(
       (blocksHtml, block) =>
-        (blocksHtml += blockHtml({ block, htmlMap, parent: currentProps })),
+        (blocksHtml += blockHtml({
+          block,
+          htmlMap: _htmlmap,
+          parent: currentProps,
+        })),
       ""
     ),
   });

--- a/src/perf2html.js
+++ b/src/perf2html.js
@@ -1,95 +1,125 @@
 import defaultHtmlMap from "./htmlmap.js";
-import {
-  createElement,
-  handleAtts,
-  handleSubtypeNS,
-  mapHtml
-} from "./helpers";
+import { createElement, handleAtts, handleSubtypeNS, mapHtml } from "./helpers";
 
-function perf2html(perfDocument, sequenceId, htmlMap = defaultHtmlMap) {
-  const contentChildren = (content) => content?.reduce(
+const map =
+  typeof defaultHtmlMap === "function" ? defaultHtmlMap({}) : defaultHtmlMap;
+
+function perf2html({ perfDocument, sequenceId, htmlMap = map }) {
+  const { sequences, ...parent } = perfDocument;
+  const perfSequence = sequences[sequenceId];
+  return sequenceHtml({ perfSequence, sequenceId, htmlMap, parent });
+}
+
+export const contentChildren = ({ content, parent = {}, htmlMap = map }) =>
+  content?.reduce(
     (contentHtml, element) =>
-      contentHtml += (typeof element === "string")
-        ? element
-        : contentElementHtml(element),
+      (contentHtml +=
+        typeof element === "string"
+          ? element
+          : contentElementHtml({ element, parent, htmlMap })),
     ""
   ) ?? "";
 
-  const contentHtml = (content, className) =>
-    content
-      ? createElement({
-          tagName: "span",
-          classList: [className],
-          children: content?.reduce(
-            (contentsHtml, element) =>
-              typeof element === "string"
-                ? (contentsHtml += element)
-                : (contentsHtml += contentElementHtml(element)),
-            ""
-          )
-        })
-      : "";
+export const contentHtml = ({
+  content,
+  className,
+  parent = {},
+  htmlMap = map,
+}) =>
+  content
+    ? createElement({
+        tagName: "span",
+        classList: [className],
+        children: content?.reduce(
+          (contentsHtml, element) =>
+            typeof element === "string"
+              ? (contentsHtml += element)
+              : (contentsHtml += contentElementHtml({
+                  element,
+                  parent,
+                  htmlMap,
+                })),
+          ""
+        ),
+      })
+    : "";
 
-  const contentElementHtml = (element) => {
-    const {
-      type,
-      subtype,
-      content,
-      meta_content,
-      atts,
-      ...props
-    } = element;
-    const attsProps = handleAtts(atts);
-    const subtypes = handleSubtypeNS(subtype);
-    const { classList, tagName, id } = mapHtml({ props:{ type, subtype, atts, ...props }, htmlMap });
-    const innerHtml = (content) => {
-      const getters = {
-        markHtml: () => ["chapter", "verses"].includes(subtype) ? atts.number : "",
-        wrapperHtml: () => contentChildren(content) + contentHtml(meta_content, "meta-content")
-      };
-      const getContentHtml = getters[`${type}Html`];
-      return typeof getContentHtml === "function" ? getContentHtml() : "";
+export const contentElementHtml = ({ element, parent = {}, htmlMap = map }) => {
+  const { type, subtype, content, meta_content, atts, ...props } = element;
+  const attsProps = handleAtts(atts);
+  const subtypes = handleSubtypeNS(subtype);
+  const currentProps = { type, subtype, atts, ...props, parent };
+  const { classList, tagName, id } = mapHtml({
+    props: currentProps,
+    htmlMap,
+  });
+  const innerHtml = (content) => {
+    const getters = {
+      markHtml: () =>
+        ["chapter", "verses"].includes(subtype) ? atts.number : "",
+      wrapperHtml: () =>
+        contentChildren({ content, htmlMap, parent: currentProps }) +
+        contentHtml({
+          content: meta_content,
+          className: "meta-content",
+          parent: currentProps,
+          htmlMap,
+        }),
     };
-
-    return createElement({
-      tagName,
-      id,
-      classList,
-      dataset: { type, ...subtypes, ...attsProps, ...props},
-      children: innerHtml(content)
-    });
+    const getContentHtml = getters[`${type}Html`];
+    return typeof getContentHtml === "function" ? getContentHtml() : "";
   };
 
-  const blockHtml = (block) => {
-    const { type, subtype, atts, content, ...props } = block;
-    const attsProps = handleAtts(atts);
-    const subtypes = handleSubtypeNS(subtype);
-    const { classList, tagName, id } = mapHtml({ props:{ type, subtype, atts, ...props }, htmlMap });
-    return createElement({
-      tagName,
-      id,
-      classList,
-      dataset: { type, ...subtypes, ...attsProps, ...props },
-      children: contentChildren(content)
-    });
-  };
+  return createElement({
+    tagName,
+    id,
+    classList,
+    dataset: { type, ...subtypes, ...attsProps, ...props },
+    children: innerHtml(content),
+  });
+};
 
-  const sequenceHtml = (perfSequence, sequenceId) => {
-    const { blocks, ...props } = perfSequence;
-    const { classList, tagName } = mapHtml({ props: {...props, subtype: "sequence"}, htmlMap });
-    return createElement({
-      tagName,
-      id: `${sequenceId}`,
-      classList: classList,
-      dataset: props,
-      children: blocks?.reduce(
-        (blocksHtml, block) => (blocksHtml += blockHtml(block)),
-        ""
-      )
-    });
-  };
-  const perfSequence = perfDocument.sequences[sequenceId];
-  return sequenceHtml(perfSequence, sequenceId);
-}
+export const blockHtml = ({ block, parent = {}, htmlMap = map }) => {
+  const { type, subtype, atts, content, ...props } = block;
+  const attsProps = handleAtts(atts);
+  const subtypes = handleSubtypeNS(subtype);
+  const currentProps = { type, subtype, atts, ...props, parent };
+  const { classList, tagName, id } = mapHtml({
+    props: currentProps,
+    htmlMap,
+  });
+  return createElement({
+    tagName,
+    id,
+    classList,
+    dataset: { type, ...subtypes, ...attsProps, ...props },
+    children: contentChildren({ content, htmlMap, parent: currentProps }),
+  });
+};
+
+export const sequenceHtml = ({
+  perfSequence,
+  sequenceId,
+  parent = {},
+  htmlMap = map,
+}) => {
+  const { blocks, ...props } = perfSequence;
+  const currentProps = { ...props, subtype: "sequence", parent };
+  const { classList, tagName } = mapHtml({
+    props: currentProps,
+    htmlMap,
+  });
+  return createElement({
+    tagName,
+    id: `${sequenceId}`,
+    classList: classList,
+    dataset: props,
+    children: blocks?.reduce(
+      (blocksHtml, block) =>
+        (blocksHtml += blockHtml({ block, htmlMap, parent: currentProps })),
+      ""
+    ),
+  });
+};
 
 export default perf2html;

--- a/test/code/htmlMap.cjs
+++ b/test/code/htmlMap.cjs
@@ -1,31 +1,35 @@
 const test = require("tape");
 const path = require("path");
 const fse = require("fs-extra");
-const {UWProskomma} = require("uw-proskomma");
-const {fail} = require("assert");
+const { UWProskomma } = require("uw-proskomma");
+const { fail } = require("assert");
 const EpiteletePerfHtml = require("../../src/index").default;
 
 const testGroup = "htmlMap";
 
 const pk = new UWProskomma();
-const succinctJson = fse.readJsonSync(path.resolve(path.join(__dirname, "..", "test_data", "eng_engWEBBE_succinct.json")));
+const succinctJson = fse.readJsonSync(
+  path.resolve(
+    path.join(__dirname, "..", "test_data", "eng_engWEBBE_succinct.json")
+  )
+);
 pk.loadSuccinctDocSet(succinctJson);
 
 test(`Maps correctly with htmlMap (${testGroup})`, async function (t) {
   t.plan(3);
   try {
-    const newClass = "test-seq-123"
+    const newClass = "test-seq-123";
     const instance = new EpiteletePerfHtml({
       proskomma: pk,
       docSetId: "DBL/eng_engWEBBE",
       htmlMap: {
         "*": {
           sequence: {
-            classList: newClass
+            classList: newClass,
           },
           verses: {
-            tagName:"custom1"
-          }
+            tagName: "custom1",
+          },
         },
         main: {
           "*": {
@@ -34,18 +38,79 @@ test(`Maps correctly with htmlMap (${testGroup})`, async function (t) {
         },
         paragraph: {
           "usfm:p": {
-            tagName: "custom3"
-          }
-        }
-      }
+            tagName: "custom3",
+          },
+        },
+      },
     });
-    const bookCode = "LUK"
+    const bookCode = "LUK";
     const html = await instance.readHtml(bookCode);
     t.ok(html.sequencesHtml[html.mainSequenceId].includes(newClass));
     t.notOk(html.sequencesHtml[html.mainSequenceId].includes("sequence"));
 
-    t.ok(["<custom1", "<custom2", "<custom3"].every((value) => html.sequencesHtml[html.mainSequenceId].includes(value)));
+    t.ok(
+      ["<custom1", "<custom2", "<custom3"].every((value) =>
+        html.sequencesHtml[html.mainSequenceId].includes(value)
+      )
+    );
   } catch (err) {
     console.log(err);
   }
-},);
+});
+
+test(`Mapped html contains parents (${testGroup})`, async function (t) {
+  t.plan(1);
+  try {
+    const instance = new EpiteletePerfHtml({
+      proskomma: pk,
+      docSetId: "DBL/eng_engWEBBE",
+      htmlMap: {
+        mark: {
+          verses: ({ atts, parent }) => ({
+            classList: `verses-subtype-${parent.subtype}`,
+          }),
+        },
+      },
+    });
+    const bookCode = "TIT";
+    const html = await instance.readHtml(bookCode);
+    t.ok(
+      html.sequencesHtml[html.mainSequenceId].includes("verses-subtype-usfm:p")
+    );
+  } catch (err) {
+    console.log(err);
+  }
+  t.end();
+});
+
+test(`htmlMap feature can receive functions (${testGroup})`, async function (t) {
+  t.plan(1);
+  try {
+    const instance = new EpiteletePerfHtml({
+      proskomma: pk,
+      docSetId: "DBL/eng_engWEBBE",
+      htmlMap: (ctx) => ({
+        mark: {
+          chapter: ({ atts }) => {
+            ctx.lastChapter = atts.number;
+            return {};
+          },
+          verses: ({ atts }) => ({
+            classList: `ch-${ctx.lastChapter}-v-${atts.number}`,
+          }),
+        },
+      }),
+    });
+    const bookCode = "TIT";
+    const html = await instance.readHtml(bookCode);
+    console.log(html);
+    t.ok(
+      ["ch-1-v-1", "ch-1-v-2", "ch-2-v-5", "ch-3-v-15"].every((value) =>
+        html.sequencesHtml[html.mainSequenceId].includes(value)
+      )
+    );
+  } catch (err) {
+    console.log(err);
+  }
+  t.end();
+});

--- a/test/test_data/mrk_perf.json
+++ b/test/test_data/mrk_perf.json
@@ -54,7 +54,8 @@
           "type": "graft",
           "subtype": "heading",
           "target": "MWFhMDQ1ODAt"
-        }, {
+        },
+        {
           "type": "paragraph",
           "subtype": "usfm:p",
           "content": [
@@ -82,7 +83,8 @@
             },
             "Selon ce qui est écrit dans Ésaïe, le prophète:"
           ]
-        }, {
+        },
+        {
           "type": "paragraph",
           "subtype": "usfm:q",
           "content": [
@@ -93,11 +95,15 @@
             },
             "Voici, j’envoie devant toi mon messager,"
           ]
-        }, {
+        },
+        {
           "type": "paragraph",
           "subtype": "usfm:q",
-          "content": ["Qui préparera ton chemin;"]
-        }, {
+          "content": [
+            "Qui préparera ton chemin;"
+          ]
+        },
+        {
           "type": "paragraph",
           "subtype": "usfm:q",
           "content": [
@@ -107,22 +113,30 @@
               "atts": {
                 "number": "3"
               }
-            }, {
+            },
+            {
               "type": "graft",
               "subtype": "xref",
               "target": "MjI3YjAyZDct"
             },
             "C’est la voix de celui qui crie dans le désert:"
           ]
-        }, {
+        },
+        {
           "type": "paragraph",
           "subtype": "usfm:q",
-          "content": ["Préparez le chemin du Seigneur,"]
-        }, {
+          "content": [
+            "Préparez le chemin du Seigneur,"
+          ]
+        },
+        {
           "type": "paragraph",
           "subtype": "usfm:q",
-          "content": ["Aplanissez ses sentiers."]
-        }, {
+          "content": [
+            "Aplanissez ses sentiers."
+          ]
+        },
+        {
           "type": "paragraph",
           "subtype": "usfm:m",
           "content": [
@@ -145,73 +159,77 @@
               "atts": {
                 "number": "5"
               }
-            }, {
+            },
+            {
               "type": "graft",
               "subtype": "xref",
               "target": "MDZjMjM3YjIt"
             },
-            "Tout le pays de Judée et tous les habitants de Jérusalem se rendaient auprès de lui; et, confessant leurs péchés, ils se faisaient baptiser par lui dans le fleuve du Jourdain. ", {
-              "type": "wrapper",
-              "subtype": "meta_content",
-              "meta_content": ["<== Long verse (32 words)"]
-            }, {
+            "Tout le pays de Judée et tous les habitants de Jérusalem se rendaient auprès de lui; et, confessant leurs péchés, ils se faisaient baptiser par lui dans le fleuve du Jourdain. ",
+            {
               "type": "mark",
               "subtype": "verses",
               "atts": {
                 "number": "6"
               }
-            }, {
+            },
+            {
               "type": "graft",
               "subtype": "xref",
               "target": "ZGY0ZmJmZGUt"
             },
-            "Jean avait un vêtement de poils de chameau, et une ceinture de cuir autour des reins. Il se nourrissait de ", {
+            "Jean avait un vêtement de poils de chameau, et une ceinture de cuir autour des reins. Il se nourrissait de ",
+            {
               "type": "graft",
               "subtype": "xref",
               "target": "NzU4YWVlNGQt"
             },
-            "sauterelles et de miel sauvage. ", {
+            "sauterelles et de miel sauvage. ",
+            {
               "type": "mark",
               "subtype": "verses",
               "atts": {
                 "number": "7"
               }
-            }, {
+            },
+            {
               "type": "graft",
               "subtype": "xref",
               "target": "NjA5NGNmZDAt"
             },
-            "Il prêchait, disant: Il vient après moi celui qui est plus puissant que moi, et je ne suis pas digne de délier, en me baissant, la courroie de ses souliers. ", {
-              "type": "wrapper",
-              "subtype": "meta_content",
-              "meta_content": ["<== Long verse (31 words)"]
-            }, {
+            "Il prêchait, disant: Il vient après moi celui qui est plus puissant que moi, et je ne suis pas digne de délier, en me baissant, la courroie de ses souliers. ",
+            {
               "type": "mark",
               "subtype": "verses",
               "atts": {
                 "number": "8"
               }
-            }, {
+            },
+            {
               "type": "graft",
               "subtype": "xref",
               "target": "NmI1YmZiYWEt"
             },
-            "Moi, je vous ai baptisés d’eau; lui, il vous baptisera ", {
+            "Moi, je vous ai baptisés d’eau; lui, il vous baptisera ",
+            {
               "type": "graft",
               "subtype": "xref",
               "target": "YjFhODgwZjMt"
             },
             "du Saint-Esprit."
           ]
-        }, {
+        },
+        {
           "type": "graft",
           "subtype": "heading",
           "target": "M2Y3N2Q3YWUt"
-        }, {
+        },
+        {
           "type": "graft",
           "subtype": "heading",
           "target": "ODAzNTNkNTIt"
-        }, {
+        },
+        {
           "type": "paragraph",
           "subtype": "usfm:p",
           "content": [
@@ -235,30 +253,35 @@
               "subtype": "xref",
               "target": "NmRmMzcxYmYt"
             },
-            "Au moment où il sortait de l’eau, il vit les cieux s’ouvrir, et l’Esprit descendre sur lui comme une colombe. ", {
+            "Au moment où il sortait de l’eau, il vit les cieux s’ouvrir, et l’Esprit descendre sur lui comme une colombe. ",
+            {
               "type": "mark",
               "subtype": "verses",
               "atts": {
                 "number": "11"
               }
             },
-            "Et une voix fit entendre des cieux ces paroles: ", {
+            "Et une voix fit entendre des cieux ces paroles: ",
+            {
               "type": "graft",
               "subtype": "xref",
               "target": "YzI5MmM4NmUt"
             },
-            "Tu es mon Fils bien-aimé, en toi j’ai mis toute mon affection. ", {
+            "Tu es mon Fils bien-aimé, en toi j’ai mis toute mon affection. ",
+            {
               "type": "mark",
               "subtype": "verses",
               "atts": {
                 "number": "12"
               }
-            }, {
+            },
+            {
               "type": "graft",
               "subtype": "xref",
               "target": "NmE5MmYxNDYt"
             },
-            "Aussitôt, l’Esprit poussa Jésus dans le désert, ", {
+            "Aussitôt, l’Esprit poussa Jésus dans le désert, ",
+            {
               "type": "mark",
               "subtype": "verses",
               "atts": {
@@ -267,15 +290,18 @@
             },
             "où il passa quarante jours, tenté par Satan. Il était avec les bêtes sauvages, et les anges le servaient."
           ]
-        }, {
+        },
+        {
           "type": "graft",
           "subtype": "heading",
           "target": "M2IyYmY1MTEt"
-        }, {
+        },
+        {
           "type": "graft",
           "subtype": "heading",
           "target": "ZGJlM2M1YjUt"
-        }, {
+        },
+        {
           "type": "paragraph",
           "subtype": "usfm:p",
           "content": [
@@ -299,29 +325,39 @@
                 "number": "15"
               }
             },
-            "Il disait: ", {
+            "Il disait: ",
+            {
               "type": "wrapper",
-              "subtype": "usfm:wj",
-              "content": ["Le temps est accompli, et le royaume de Dieu est proche."]
-            }, {
+              "subtype": "usfm:span",
+              "content": [
+                "Le temps est accompli, et le royaume de Dieu est proche."
+              ]
+            },
+            {
               "type": "graft",
               "subtype": "xref",
               "target": "MzM2OWVkZGUt"
-            }, {
+            },
+            {
               "type": "wrapper",
-              "subtype": "usfm:wj",
-              "content": ["Repentez-vous, et croyez à la bonne nouvelle."]
+              "subtype": "usfm:span",
+              "content": [
+                "Repentez-vous, et croyez à la bonne nouvelle."
+              ]
             }
           ]
-        }, {
+        },
+        {
           "type": "graft",
           "subtype": "heading",
           "target": "NDY4MzJjZTQt"
-        }, {
+        },
+        {
           "type": "graft",
           "subtype": "heading",
           "target": "YzRhMzFlMTkt"
-        }, {
+        },
+        {
           "type": "paragraph",
           "subtype": "usfm:p",
           "content": [
@@ -339,52 +375,60 @@
             },
             "Comme il passait le long de la mer de Galilée, il vit Simon et André, frère de Simon, qui jetaient un filet dans la mer; car ils étaient pêcheurs. ",
             {
-              "type": "wrapper",
-              "subtype": "meta_content",
-              "meta_content": ["<== Long verse (30 words)"]
-            }, {
               "type": "mark",
               "subtype": "verses",
               "atts": {
                 "number": "17"
               }
             },
-            "Jésus leur dit: ", {
+            "Jésus leur dit: ",
+            {
               "type": "wrapper",
-              "subtype": "usfm:wj",
-              "content": ["Suivez-moi, et je vous ferai pêcheurs"]
-            }, {
+              "subtype": "usfm:span",
+              "content": [
+                "Suivez-moi, et je vous ferai pêcheurs"
+              ]
+            },
+            {
               "type": "graft",
               "subtype": "xref",
               "target": "ZmIwNjUxN2Qt"
-            }, {
-              "type": "wrapper",
-              "subtype": "usfm:wj",
-              "content": ["d’hommes."]
             },
-            " ", {
+            {
+              "type": "wrapper",
+              "subtype": "usfm:span",
+              "content": [
+                "d’hommes."
+              ]
+            },
+            " ",
+            {
               "type": "mark",
               "subtype": "verses",
               "atts": {
                 "number": "18"
               }
-            }, {
+            },
+            {
               "type": "graft",
               "subtype": "xref",
               "target": "Zjg2MjY3YWUt"
             },
-            "Aussitôt, ils laissèrent leurs filets, et le suivirent. ", {
+            "Aussitôt, ils laissèrent leurs filets, et le suivirent. ",
+            {
               "type": "mark",
               "subtype": "verses",
               "atts": {
                 "number": "19"
               }
-            }, {
+            },
+            {
               "type": "graft",
               "subtype": "xref",
               "target": "ZDU0NTQ3MjMt"
             },
-            "Étant allé un peu plus loin, il vit Jacques, fils de Zébédée, et Jean, son frère, qui, eux aussi, étaient dans une barque et réparaient les filets. ", {
+            "Étant allé un peu plus loin, il vit Jacques, fils de Zébédée, et Jean, son frère, qui, eux aussi, étaient dans une barque et réparaient les filets. ",
+            {
               "type": "mark",
               "subtype": "verses",
               "atts": {
@@ -393,15 +437,18 @@
             },
             "Aussitôt, il les appela; et, laissant leur père Zébédée dans la barque avec les ouvriers, ils le suivirent."
           ]
-        }, {
+        },
+        {
           "type": "graft",
           "subtype": "heading",
           "target": "ZjI5MTkzOWMt"
-        }, {
+        },
+        {
           "type": "graft",
           "subtype": "heading",
           "target": "MGMyYTg5Mzgt"
-        }, {
+        },
+        {
           "type": "paragraph",
           "subtype": "usfm:p",
           "content": [
@@ -424,60 +471,67 @@
               "atts": {
                 "number": "22"
               }
-            }, {
+            },
+            {
               "type": "graft",
               "subtype": "xref",
               "target": "MjY4YjJjYjYt"
             },
-            "Ils étaient frappés de sa doctrine; car il enseignait comme ayant autorité, et non pas comme les scribes. ", {
+            "Ils étaient frappés de sa doctrine; car il enseignait comme ayant autorité, et non pas comme les scribes. ",
+            {
               "type": "mark",
               "subtype": "verses",
               "atts": {
                 "number": "23"
               }
-            }, {
+            },
+            {
               "type": "graft",
               "subtype": "xref",
               "target": "NzIxNzU0MmQt"
             },
-            "Il se trouva dans leur synagogue un homme qui avait un esprit impur, et qui s’écria: ", {
+            "Il se trouva dans leur synagogue un homme qui avait un esprit impur, et qui s’écria: ",
+            {
               "type": "mark",
               "subtype": "verses",
               "atts": {
                 "number": "24"
               }
             },
-            "Qu’y a-t-il entre nous et toi, Jésus de Nazareth? Tu es venu pour nous perdre. Je sais qui tu es: le Saint de Dieu. ", {
+            "Qu’y a-t-il entre nous et toi, Jésus de Nazareth? Tu es venu pour nous perdre. Je sais qui tu es: le Saint de Dieu. ",
+            {
               "type": "mark",
               "subtype": "verses",
               "atts": {
                 "number": "25"
               }
             },
-            "Jésus le menaça, disant: ", {
+            "Jésus le menaça, disant: ",
+            {
               "type": "wrapper",
-              "subtype": "usfm:wj",
-              "content": ["Tais-toi, et sors de cet homme."]
+              "subtype": "usfm:span",
+              "content": [
+                "Tais-toi, et sors de cet homme."
+              ]
             },
-            " ", {
+            " ",
+            {
               "type": "mark",
               "subtype": "verses",
               "atts": {
                 "number": "26"
               }
             },
-            "Et l’esprit impur sortit de cet homme, en l’agitant avec violence, et en poussant un grand cri. ", {
+            "Et l’esprit impur sortit de cet homme, en l’agitant avec violence, et en poussant un grand cri. ",
+            {
               "type": "mark",
               "subtype": "verses",
               "atts": {
                 "number": "27"
               }
             },
-            "Tous furent saisis de stupéfaction, de sorte qu’ils se demandaient les uns aux autres: Qu’est-ce que ceci? Une nouvelle doctrine! Il commande avec autorité même aux esprits impurs, et ils lui obéissent! ", {
-              "type": "wrapper",
-              "subtype": "meta_content",
-              "meta_content": ["<== Long verse (33 words)"]
-            }, {
+            "Tous furent saisis de stupéfaction, de sorte qu’ils se demandaient les uns aux autres: Qu’est-ce que ceci? Une nouvelle doctrine! Il commande avec autorité même aux esprits impurs, et ils lui obéissent! ",
+            {
               "type": "mark",
               "subtype": "verses",
               "atts": {
@@ -486,15 +540,18 @@
             },
             "Et sa renommée se répandit aussitôt dans tous les lieux environnants de la Galilée."
           ]
-        }, {
+        },
+        {
           "type": "graft",
           "subtype": "heading",
           "target": "NzRjM2JiZjct"
-        }, {
+        },
+        {
           "type": "graft",
           "subtype": "heading",
           "target": "NWJlMzZhOTEt"
-        }, {
+        },
+        {
           "type": "paragraph",
           "subtype": "usfm:p",
           "content": [
@@ -518,7 +575,8 @@
                 "number": "30"
               }
             },
-            "La belle-mère de Simon était couchée, ayant la fièvre; et aussitôt on parla d’elle à Jésus. ", {
+            "La belle-mère de Simon était couchée, ayant la fièvre; et aussitôt on parla d’elle à Jésus. ",
+            {
               "type": "mark",
               "subtype": "verses",
               "atts": {
@@ -527,11 +585,13 @@
             },
             "S’étant approché, il la fit lever en lui prenant la main, et à l’instant la fièvre la quitta. Puis elle les servit."
           ]
-        }, {
+        },
+        {
           "type": "graft",
           "subtype": "heading",
           "target": "OTVkYTRkMWMt"
-        }, {
+        },
+        {
           "type": "paragraph",
           "subtype": "usfm:p",
           "content": [
@@ -555,68 +615,84 @@
                 "number": "33"
               }
             },
-            "Et toute la ville était rassemblée devant sa porte. ", {
+            "Et toute la ville était rassemblée devant sa porte. ",
+            {
               "type": "mark",
               "subtype": "verses",
               "atts": {
                 "number": "34"
               }
             },
-            "Il guérit beaucoup de gens qui avaient diverses maladies; il chassa aussi beaucoup de démons, et il ne permettait pas aux démons de parler, parce qu’ils le connaissaient. ", {
+            "Il guérit beaucoup de gens qui avaient diverses maladies; il chassa aussi beaucoup de démons, et il ne permettait pas aux démons de parler, parce qu’ils le connaissaient. ",
+            {
               "type": "mark",
               "subtype": "verses",
               "atts": {
                 "number": "35"
               }
-            }, {
+            },
+            {
               "type": "graft",
               "subtype": "xref",
               "target": "MWZiNmM3YmEt"
             },
-            "Vers le matin, pendant qu’il faisait encore très sombre, il se leva, et sortit pour aller dans un lieu désert, ", {
+            "Vers le matin, pendant qu’il faisait encore très sombre, il se leva, et sortit pour aller dans un lieu désert, ",
+            {
               "type": "graft",
               "subtype": "xref",
               "target": "NGY1OGI2MGYt"
             },
-            "où il pria. ", {
+            "où il pria. ",
+            {
               "type": "mark",
               "subtype": "verses",
               "atts": {
                 "number": "36"
               }
             },
-            "Simon et ceux qui étaient avec lui se mirent à sa recherche; ", {
+            "Simon et ceux qui étaient avec lui se mirent à sa recherche; ",
+            {
               "type": "mark",
               "subtype": "verses",
               "atts": {
                 "number": "37"
               }
             },
-            "et, quand ils l’eurent trouvé, ils lui dirent: Tous te cherchent. ", {
+            "et, quand ils l’eurent trouvé, ils lui dirent: Tous te cherchent. ",
+            {
               "type": "mark",
               "subtype": "verses",
               "atts": {
                 "number": "38"
               }
             },
-            "Il leur répondit: ", {
+            "Il leur répondit: ",
+            {
               "type": "graft",
               "subtype": "xref",
               "target": "M2E5MzYxMmIt"
-            }, {
+            },
+            {
               "type": "wrapper",
-              "subtype": "usfm:wj",
-              "content": ["Allons ailleurs, dans les bourgades voisines, afin que j’y prêche aussi;"]
-            }, {
+              "subtype": "usfm:span",
+              "content": [
+                "Allons ailleurs, dans les bourgades voisines, afin que j’y prêche aussi;"
+              ]
+            },
+            {
               "type": "graft",
               "subtype": "xref",
               "target": "YzE3NzBiNGYt"
-            }, {
-              "type": "wrapper",
-              "subtype": "usfm:wj",
-              "content": ["car c’est pour cela que je suis sorti."]
             },
-            " ", {
+            {
+              "type": "wrapper",
+              "subtype": "usfm:span",
+              "content": [
+                "car c’est pour cela que je suis sorti."
+              ]
+            },
+            " ",
+            {
               "type": "mark",
               "subtype": "verses",
               "atts": {
@@ -625,15 +701,18 @@
             },
             "Et il alla prêcher dans les synagogues, par toute la Galilée, et il chassa les démons."
           ]
-        }, {
+        },
+        {
           "type": "graft",
           "subtype": "heading",
           "target": "ZmQ4MTk4NTMt"
-        }, {
+        },
+        {
           "type": "graft",
           "subtype": "heading",
           "target": "NjJjYjE3N2Mt"
-        }, {
+        },
+        {
           "type": "paragraph",
           "subtype": "usfm:p",
           "content": [
@@ -657,50 +736,60 @@
                 "number": "41"
               }
             },
-            "Jésus, ému de compassion, étendit la main, le toucha, et dit: ", {
+            "Jésus, ému de compassion, étendit la main, le toucha, et dit: ",
+            {
               "type": "wrapper",
-              "subtype": "usfm:wj",
-              "content": ["Je le veux, sois pur."]
+              "subtype": "usfm:span",
+              "content": [
+                "Je le veux, sois pur."
+              ]
             },
-            " ", {
+            " ",
+            {
               "type": "mark",
               "subtype": "verses",
               "atts": {
                 "number": "42"
               }
             },
-            "Aussitôt la lèpre le quitta, et il fut purifié. ", {
+            "Aussitôt la lèpre le quitta, et il fut purifié. ",
+            {
               "type": "mark",
               "subtype": "verses",
               "atts": {
                 "number": "43"
               }
             },
-            "Jésus le renvoya sur-le-champ, avec de sévères recommandations, ", {
+            "Jésus le renvoya sur-le-champ, avec de sévères recommandations, ",
+            {
               "type": "mark",
               "subtype": "verses",
               "atts": {
                 "number": "44"
               }
             },
-            "et lui dit: ", {
+            "et lui dit: ",
+            {
               "type": "wrapper",
-              "subtype": "usfm:wj",
-              "content": ["Garde-toi de rien dire à personne; mais va te montrer au sacrificateur, et offre pour ta purification ce que"]
-            }, {
+              "subtype": "usfm:span",
+              "content": [
+                "Garde-toi de rien dire à personne; mais va te montrer au sacrificateur, et offre pour ta purification ce que"
+              ]
+            },
+            {
               "type": "graft",
               "subtype": "xref",
               "target": "MzUzZjlmMWEt"
-            }, {
-              "type": "wrapper",
-              "subtype": "usfm:wj",
-              "content": ["Moïse a prescrit, afin que cela leur serve de témoignage."]
             },
-            " ", {
+            {
               "type": "wrapper",
-              "subtype": "meta_content",
-              "meta_content": ["<== Long verse (35 words)"]
-            }, {
+              "subtype": "usfm:span",
+              "content": [
+                "Moïse a prescrit, afin que cela leur serve de témoignage."
+              ]
+            },
+            " ",
+            {
               "type": "mark",
               "subtype": "verses",
               "atts": {
@@ -709,15 +798,18 @@
             },
             "Mais cet homme, s’en étant allé, se mit à publier hautement la chose et à la divulguer, de sorte que Jésus ne pouvait plus entrer publiquement dans une ville. Il se tenait dehors, dans des lieux déserts, et l’on venait à lui de toutes parts."
           ]
-        }, {
+        },
+        {
           "type": "graft",
           "subtype": "heading",
           "target": "MTc4YmE5YzYt"
-        }, {
+        },
+        {
           "type": "graft",
           "subtype": "heading",
           "target": "ZGI4ODE1ZDUt"
-        }, {
+        },
+        {
           "type": "paragraph",
           "subtype": "usfm:p",
           "content": [
@@ -727,11 +819,6 @@
               "atts": {
                 "number": "2"
               }
-            },
-            {
-              "type": "wrapper",
-              "subtype": "meta_content",
-              "meta_content": ["<== Long verse (45 words)"]
             },
             {
               "type": "mark",
@@ -745,80 +832,92 @@
               "subtype": "xref",
               "target": "M2Y2YmU5NGIt"
             },
-            "Quelques jours après, Jésus revint à Capernaüm. On apprit qu’il était à la maison, ", {
+            "Quelques jours après, Jésus revint à Capernaüm. On apprit qu’il était à la maison, ",
+            {
               "type": "mark",
               "subtype": "verses",
               "atts": {
                 "number": "2"
               }
             },
-            "et il s’assembla un si grand nombre de personnes que l’espace devant la porte ne pouvait plus les contenir. Il leur annonçait la parole. ", {
+            "et il s’assembla un si grand nombre de personnes que l’espace devant la porte ne pouvait plus les contenir. Il leur annonçait la parole. ",
+            {
               "type": "mark",
               "subtype": "verses",
               "atts": {
                 "number": "3"
               }
-            }, {
+            },
+            {
               "type": "graft",
               "subtype": "xref",
               "target": "N2EyODIwZjMt"
             },
-            "Des gens vinrent à lui, amenant un paralytique porté par quatre hommes. ", {
+            "Des gens vinrent à lui, amenant un paralytique porté par quatre hommes. ",
+            {
               "type": "mark",
               "subtype": "verses",
               "atts": {
                 "number": "4"
               }
             },
-            "Comme ils ne pouvaient l’aborder, à cause de la foule, ils découvrirent le toit de la maison où il était, et ils descendirent par cette ouverture le lit sur lequel le paralytique était couché. ", {
-              "type": "wrapper",
-              "subtype": "meta_content",
-              "meta_content": ["<== Long verse (35 words)"]
-            }, {
+            "Comme ils ne pouvaient l’aborder, à cause de la foule, ils découvrirent le toit de la maison où il était, et ils descendirent par cette ouverture le lit sur lequel le paralytique était couché. ",
+            {
               "type": "mark",
               "subtype": "verses",
               "atts": {
                 "number": "5"
               }
             },
-            "Jésus, voyant leur foi, dit au paralytique: ", {
+            "Jésus, voyant leur foi, dit au paralytique: ",
+            {
               "type": "wrapper",
-              "subtype": "usfm:wj",
-              "content": ["Mon enfant, tes péchés sont pardonnés."]
+              "subtype": "usfm:span",
+              "content": [
+                "Mon enfant, tes péchés sont pardonnés."
+              ]
             },
-            " ", {
+            " ",
+            {
               "type": "mark",
               "subtype": "verses",
               "atts": {
                 "number": "6"
               }
             },
-            "Il y avait là quelques scribes, qui étaient assis, et qui se disaient au-dedans d’eux: ", {
+            "Il y avait là quelques scribes, qui étaient assis, et qui se disaient au-dedans d’eux: ",
+            {
               "type": "mark",
               "subtype": "verses",
               "atts": {
                 "number": "7"
               }
             },
-            "Comment cet homme parle-t-il ainsi? Il blasphème. ", {
+            "Comment cet homme parle-t-il ainsi? Il blasphème. ",
+            {
               "type": "graft",
               "subtype": "xref",
               "target": "ZWFhYTlmOGMt"
             },
-            "Qui peut pardonner les péchés, si ce n’est Dieu seul? ", {
+            "Qui peut pardonner les péchés, si ce n’est Dieu seul? ",
+            {
               "type": "mark",
               "subtype": "verses",
               "atts": {
                 "number": "8"
               }
             },
-            "Jésus, ayant aussitôt connu par son esprit ce qu’ils pensaient au-dedans d’eux, leur dit: ", {
+            "Jésus, ayant aussitôt connu par son esprit ce qu’ils pensaient au-dedans d’eux, leur dit: ",
+            {
               "type": "wrapper",
-              "subtype": "usfm:wj",
-              "content": ["Pourquoi avez-vous de telles pensées dans vos cœurs?"]
+              "subtype": "usfm:span",
+              "content": [
+                "Pourquoi avez-vous de telles pensées dans vos cœurs?"
+              ]
             }
           ]
-        }, {
+        },
+        {
           "type": "paragraph",
           "subtype": "usfm:p",
           "content": [
@@ -831,8 +930,10 @@
             },
             {
               "type": "wrapper",
-              "subtype": "usfm:wj",
-              "content": ["Lequel est le plus aisé, de dire au paralytique: Tes péchés sont pardonnés, ou de dire: Lève-toi, prends ton lit, et marche?"]
+              "subtype": "usfm:span",
+              "content": [
+                "Lequel est le plus aisé, de dire au paralytique: Tes péchés sont pardonnés, ou de dire: Lève-toi, prends ton lit, et marche?"
+              ]
             },
             " ",
             {
@@ -841,28 +942,39 @@
               "atts": {
                 "number": "10"
               }
-            }, {
-              "type": "wrapper",
-              "subtype": "usfm:wj",
-              "content": ["Or, afin que vous sachiez que le Fils de l’homme a sur la terre le pouvoir de pardonner les péchés:"]
             },
-            " ", {
+            {
+              "type": "wrapper",
+              "subtype": "usfm:span",
+              "content": [
+                "Or, afin que vous sachiez que le Fils de l’homme a sur la terre le pouvoir de pardonner les péchés:"
+              ]
+            },
+            " ",
+            {
               "type": "mark",
               "subtype": "verses",
               "atts": {
                 "number": "11"
               }
-            }, {
-              "type": "wrapper",
-              "subtype": "usfm:wj",
-              "content": ["Je te l’ordonne,"]
             },
-            " dit-il au paralytique, ", {
+            {
               "type": "wrapper",
-              "subtype": "usfm:wj",
-              "content": ["lève-toi, prends ton lit, et va dans ta maison."]
+              "subtype": "usfm:span",
+              "content": [
+                "Je te l’ordonne,"
+              ]
             },
-            " ", {
+            " dit-il au paralytique, ",
+            {
+              "type": "wrapper",
+              "subtype": "usfm:span",
+              "content": [
+                "lève-toi, prends ton lit, et va dans ta maison."
+              ]
+            },
+            " ",
+            {
               "type": "mark",
               "subtype": "verses",
               "atts": {
@@ -871,23 +983,21 @@
             },
             "Et, à l’instant, il se leva, prit son lit, et sortit en présence de tout le monde, de sorte qu’ils étaient tous dans l’étonnement et glorifiaient Dieu, disant: Nous n’avons jamais rien vu de pareil."
           ]
-        }, {
+        },
+        {
           "type": "graft",
           "subtype": "heading",
           "target": "ZDQyZWM2MzQt"
-        }, {
+        },
+        {
           "type": "graft",
           "subtype": "heading",
           "target": "MWRmMTk2NzUt"
-        }, {
+        },
+        {
           "type": "paragraph",
           "subtype": "usfm:p",
           "content": [
-            {
-              "type": "wrapper",
-              "subtype": "meta_content",
-              "meta_content": ["<== Long verse (35 words)"]
-            },
             {
               "type": "mark",
               "subtype": "verses",
@@ -900,25 +1010,31 @@
               "subtype": "xref",
               "target": "NjgwNjgzOWEt"
             },
-            "Jésus sortit de nouveau du côté de la mer. Toute la foule venait à lui, et il les enseignait. ", {
+            "Jésus sortit de nouveau du côté de la mer. Toute la foule venait à lui, et il les enseignait. ",
+            {
               "type": "mark",
               "subtype": "verses",
               "atts": {
                 "number": "14"
               }
             },
-            "En passant, il vit Lévi, fils d’Alphée, assis au bureau des péages. Il lui dit: ", {
+            "En passant, il vit Lévi, fils d’Alphée, assis au bureau des péages. Il lui dit: ",
+            {
               "type": "wrapper",
-              "subtype": "usfm:wj",
-              "content": ["Suis-moi."]
+              "subtype": "usfm:span",
+              "content": [
+                "Suis-moi."
+              ]
             },
             " Lévi se leva, et le suivit."
           ]
-        }, {
+        },
+        {
           "type": "graft",
           "subtype": "heading",
           "target": "MWEwZWY0ZTgt"
-        }, {
+        },
+        {
           "type": "paragraph",
           "subtype": "usfm:p",
           "content": [
@@ -931,59 +1047,56 @@
             },
             "Comme Jésus était à table dans la maison de Lévi, beaucoup de publicains et de gens de mauvaise vie se mirent aussi à table avec lui et avec ses disciples; car ils étaient nombreux, et l’avaient suivi. ",
             {
-              "type": "wrapper",
-              "subtype": "meta_content",
-              "meta_content": ["<== Long verse (38 words)"]
-            },
-            {
               "type": "mark",
               "subtype": "verses",
               "atts": {
                 "number": "16"
               }
             },
-            "Les scribes et les pharisiens, le voyant manger avec les publicains et les gens de mauvaise vie, dirent à ses disciples: Pourquoi mange-t-il et boit-il avec les publicains et les gens de mauvaise vie? ", {
-              "type": "wrapper",
-              "subtype": "meta_content",
-              "meta_content": ["<== Long verse (35 words)"]
-            }, {
+            "Les scribes et les pharisiens, le voyant manger avec les publicains et les gens de mauvaise vie, dirent à ses disciples: Pourquoi mange-t-il et boit-il avec les publicains et les gens de mauvaise vie? ",
+            {
               "type": "mark",
               "subtype": "verses",
               "atts": {
                 "number": "17"
               }
             },
-            "Ce que Jésus ayant entendu, il leur dit: ", {
+            "Ce que Jésus ayant entendu, il leur dit: ",
+            {
               "type": "wrapper",
-              "subtype": "usfm:wj",
-              "content": ["Ce ne sont pas ceux qui se portent bien qui ont besoin de médecin, mais les malades."]
-            }, {
+              "subtype": "usfm:span",
+              "content": [
+                "Ce ne sont pas ceux qui se portent bien qui ont besoin de médecin, mais les malades."
+              ]
+            },
+            {
               "type": "graft",
               "subtype": "xref",
               "target": "OWJhMjNkYjIt"
-            }, {
+            },
+            {
               "type": "wrapper",
-              "subtype": "usfm:wj",
-              "content": ["Je ne suis pas venu appeler des justes, mais des pécheurs."]
+              "subtype": "usfm:span",
+              "content": [
+                "Je ne suis pas venu appeler des justes, mais des pécheurs."
+              ]
             }
           ]
-        }, {
+        },
+        {
           "type": "graft",
           "subtype": "heading",
           "target": "M2UwYmY4ODQt"
-        }, {
+        },
+        {
           "type": "graft",
           "subtype": "heading",
           "target": "NjI5M2VjMDAt"
-        }, {
+        },
+        {
           "type": "paragraph",
           "subtype": "usfm:p",
           "content": [
-            {
-              "type": "wrapper",
-              "subtype": "meta_content",
-              "meta_content": ["<== Long verse (37 words)"]
-            },
             {
               "type": "mark",
               "subtype": "verses",
@@ -996,28 +1109,30 @@
               "subtype": "xref",
               "target": "ZGUyNmFhYjAt"
             },
-            "Les disciples de Jean et les pharisiens jeûnaient. Ils vinrent dire à Jésus: Pourquoi les disciples de Jean et ceux des pharisiens jeûnent-ils, tandis que tes disciples ne jeûnent point? ", {
-              "type": "wrapper",
-              "subtype": "meta_content",
-              "meta_content": ["<== Long verse (31 words)"]
-            }, {
+            "Les disciples de Jean et les pharisiens jeûnaient. Ils vinrent dire à Jésus: Pourquoi les disciples de Jean et ceux des pharisiens jeûnent-ils, tandis que tes disciples ne jeûnent point? ",
+            {
               "type": "mark",
               "subtype": "verses",
               "atts": {
                 "number": "19"
               }
             },
-            "Jésus leur répondit: ", {
+            "Jésus leur répondit: ",
+            {
               "type": "graft",
               "subtype": "xref",
               "target": "NDQ1MGJmYmQt"
-            }, {
+            },
+            {
               "type": "wrapper",
-              "subtype": "usfm:wj",
-              "content": ["Les amis de l’époux peuvent-ils jeûner pendant que l’époux est avec eux? Aussi longtemps qu’ils ont avec eux l’époux, ils ne peuvent jeûner."]
+              "subtype": "usfm:span",
+              "content": [
+                "Les amis de l’époux peuvent-ils jeûner pendant que l’époux est avec eux? Aussi longtemps qu’ils ont avec eux l’époux, ils ne peuvent jeûner."
+              ]
             }
           ]
-        }, {
+        },
+        {
           "type": "paragraph",
           "subtype": "usfm:p",
           "content": [
@@ -1030,8 +1145,10 @@
             },
             {
               "type": "wrapper",
-              "subtype": "usfm:wj",
-              "content": ["Les jours viendront où l’époux leur sera enlevé, et alors ils jeûneront en ce jour-là."]
+              "subtype": "usfm:span",
+              "content": [
+                "Les jours viendront où l’époux leur sera enlevé, et alors ils jeûneront en ce jour-là."
+              ]
             },
             " ",
             {
@@ -1040,48 +1157,50 @@
               "atts": {
                 "number": "21"
               }
-            }, {
-              "type": "wrapper",
-              "subtype": "usfm:wj",
-              "content": ["Personne ne coud une pièce de drap neuf à un vieil habit; autrement, la pièce de drap neuf emporterait une partie du vieux, et la déchirure serait pire."]
             },
-            " ", {
+            {
               "type": "wrapper",
-              "subtype": "meta_content",
-              "meta_content": ["<== Long verse (30 words)"]
-            }, {
+              "subtype": "usfm:span",
+              "content": [
+                "Personne ne coud une pièce de drap neuf à un vieil habit; autrement, la pièce de drap neuf emporterait une partie du vieux, et la déchirure serait pire."
+              ]
+            },
+            " ",
+            {
               "type": "mark",
               "subtype": "verses",
               "atts": {
                 "number": "22"
               }
-            }, {
+            },
+            {
               "type": "graft",
               "subtype": "xref",
               "target": "MGU4ZGMxMGIt"
-            }, {
+            },
+            {
               "type": "wrapper",
-              "subtype": "usfm:wj",
-              "content": ["Et personne ne met du vin nouveau dans de vieilles outres; autrement, le vin fait rompre les outres, et le vin et les outres sont perdus; mais il faut mettre le vin nouveau dans des outres neuves."]
+              "subtype": "usfm:span",
+              "content": [
+                "Et personne ne met du vin nouveau dans de vieilles outres; autrement, le vin fait rompre les outres, et le vin et les outres sont perdus; mais il faut mettre le vin nouveau dans des outres neuves."
+              ]
             }
           ]
-        }, {
+        },
+        {
           "type": "graft",
           "subtype": "heading",
           "target": "MjE5ZjhiMDIt"
-        }, {
+        },
+        {
           "type": "graft",
           "subtype": "heading",
           "target": "ZGQ0MTNhMzMt"
-        }, {
+        },
+        {
           "type": "paragraph",
           "subtype": "usfm:p",
           "content": [
-            {
-              "type": "wrapper",
-              "subtype": "meta_content",
-              "meta_content": ["<== Long verse (37 words)"]
-            },
             {
               "type": "mark",
               "subtype": "verses",
@@ -1094,40 +1213,51 @@
               "subtype": "xref",
               "target": "Yzc1ODZlOGQt"
             },
-            "Il arriva, un jour de sabbat, que Jésus traversa des champs de blé. Ses disciples, chemin faisant, se mirent à arracher des épis. ", {
+            "Il arriva, un jour de sabbat, que Jésus traversa des champs de blé. Ses disciples, chemin faisant, se mirent à arracher des épis. ",
+            {
               "type": "mark",
               "subtype": "verses",
               "atts": {
                 "number": "24"
               }
             },
-            "Les pharisiens lui dirent: Voici, pourquoi font-ils ", {
+            "Les pharisiens lui dirent: Voici, pourquoi font-ils ",
+            {
               "type": "graft",
               "subtype": "xref",
               "target": "NjgyYzhiZjAt"
             },
-            "ce qui n’est pas permis pendant le sabbat? ", {
+            "ce qui n’est pas permis pendant le sabbat? ",
+            {
               "type": "mark",
               "subtype": "verses",
               "atts": {
                 "number": "25"
               }
             },
-            "Jésus leur répondit: ", {
+            "Jésus leur répondit: ",
+            {
               "type": "wrapper",
-              "subtype": "usfm:wj",
-              "content": ["N’avez-vous jamais lu ce que fit"]
-            }, {
+              "subtype": "usfm:span",
+              "content": [
+                "N’avez-vous jamais lu ce que fit"
+              ]
+            },
+            {
               "type": "graft",
               "subtype": "xref",
               "target": "NjU1ZGY5ZGEt"
-            }, {
+            },
+            {
               "type": "wrapper",
-              "subtype": "usfm:wj",
-              "content": ["David, lorsqu’il fut dans la nécessité et qu’il eut faim, lui et ceux qui étaient avec lui;"]
+              "subtype": "usfm:span",
+              "content": [
+                "David, lorsqu’il fut dans la nécessité et qu’il eut faim, lui et ceux qui étaient avec lui;"
+              ]
             }
           ]
-        }, {
+        },
+        {
           "type": "paragraph",
           "subtype": "usfm:p",
           "content": [
@@ -1140,8 +1270,10 @@
             },
             {
               "type": "wrapper",
-              "subtype": "usfm:wj",
-              "content": ["comment il entra dans la maison de Dieu, du temps du souverain sacrificateur Abiathar, et mangea les pains de proposition, qu’il n’est permis"]
+              "subtype": "usfm:span",
+              "content": [
+                "comment il entra dans la maison de Dieu, du temps du souverain sacrificateur Abiathar, et mangea les pains de proposition, qu’il n’est permis"
+              ]
             },
             {
               "type": "graft",
@@ -1150,27 +1282,30 @@
             },
             {
               "type": "wrapper",
-              "subtype": "usfm:wj",
-              "content": ["qu’aux sacrificateurs de manger, et en donna même à ceux qui étaient avec lui!"]
+              "subtype": "usfm:span",
+              "content": [
+                "qu’aux sacrificateurs de manger, et en donna même à ceux qui étaient avec lui!"
+              ]
             },
-            " ", {
-              "type": "wrapper",
-              "subtype": "meta_content",
-              "meta_content": ["<== Long verse (39 words)"]
-            }, {
+            " ",
+            {
               "type": "mark",
               "subtype": "verses",
               "atts": {
                 "number": "27"
               }
             },
-            "Puis il leur dit: ", {
+            "Puis il leur dit: ",
+            {
               "type": "wrapper",
-              "subtype": "usfm:wj",
-              "content": ["Le sabbat a été fait pour l’homme, et non l’homme pour le sabbat,"]
+              "subtype": "usfm:span",
+              "content": [
+                "Le sabbat a été fait pour l’homme, et non l’homme pour le sabbat,"
+              ]
             }
           ]
-        }, {
+        },
+        {
           "type": "paragraph",
           "subtype": "usfm:p",
           "content": [
@@ -1180,25 +1315,32 @@
               "atts": {
                 "number": "28"
               }
-            }, {
+            },
+            {
               "type": "graft",
               "subtype": "xref",
               "target": "NDZjMDE0ZTIt"
-            }, {
+            },
+            {
               "type": "wrapper",
-              "subtype": "usfm:wj",
-              "content": ["de sorte que le Fils de l’homme est maître même du sabbat."]
+              "subtype": "usfm:span",
+              "content": [
+                "de sorte que le Fils de l’homme est maître même du sabbat."
+              ]
             }
           ]
-        }, {
+        },
+        {
           "type": "graft",
           "subtype": "heading",
           "target": "NWM1OGM3MDkt"
-        }, {
+        },
+        {
           "type": "graft",
           "subtype": "heading",
           "target": "ZWZmMTA4MGIt"
-        }, {
+        },
+        {
           "type": "paragraph",
           "subtype": "usfm:p",
           "content": [
@@ -1221,80 +1363,90 @@
               "subtype": "xref",
               "target": "MDNiNzM3OTgt"
             },
-            "Jésus entra de nouveau dans la synagogue. Il s’y trouvait un homme qui avait la main sèche. ", {
+            "Jésus entra de nouveau dans la synagogue. Il s’y trouvait un homme qui avait la main sèche. ",
+            {
               "type": "mark",
               "subtype": "verses",
               "atts": {
                 "number": "2"
               }
             },
-            "Ils observaient Jésus, pour voir s’il le guérirait le jour du sabbat: c’était afin de pouvoir l’accuser. ", {
+            "Ils observaient Jésus, pour voir s’il le guérirait le jour du sabbat: c’était afin de pouvoir l’accuser. ",
+            {
               "type": "mark",
               "subtype": "verses",
               "atts": {
                 "number": "3"
               }
             },
-            "Et Jésus dit à l’homme qui avait la main sèche: ", {
+            "Et Jésus dit à l’homme qui avait la main sèche: ",
+            {
               "type": "wrapper",
-              "subtype": "usfm:wj",
-              "content": ["Lève-toi, là au milieu."]
+              "subtype": "usfm:span",
+              "content": [
+                "Lève-toi, là au milieu."
+              ]
             },
-            " ", {
+            " ",
+            {
               "type": "mark",
               "subtype": "verses",
               "atts": {
                 "number": "4"
               }
             },
-            "Puis il leur dit: ", {
+            "Puis il leur dit: ",
+            {
               "type": "wrapper",
-              "subtype": "usfm:wj",
-              "content": ["Est-il permis, le jour du sabbat, de faire du bien ou de faire du mal, de sauver une personne ou de la tuer?"]
+              "subtype": "usfm:span",
+              "content": [
+                "Est-il permis, le jour du sabbat, de faire du bien ou de faire du mal, de sauver une personne ou de la tuer?"
+              ]
             },
-            " Mais ils gardèrent le silence. ", {
-              "type": "wrapper",
-              "subtype": "meta_content",
-              "meta_content": ["<== Long verse (35 words)"]
-            }, {
+            " Mais ils gardèrent le silence. ",
+            {
               "type": "mark",
               "subtype": "verses",
               "atts": {
                 "number": "5"
               }
             },
-            "Alors, promenant ses regards sur eux avec indignation, et en même temps affligé de l’endurcissement de leur cœur, il dit à l’homme: ", {
+            "Alors, promenant ses regards sur eux avec indignation, et en même temps affligé de l’endurcissement de leur cœur, il dit à l’homme: ",
+            {
               "type": "wrapper",
-              "subtype": "usfm:wj",
-              "content": ["Étends ta main."]
+              "subtype": "usfm:span",
+              "content": [
+                "Étends ta main."
+              ]
             },
-            " Il l’étendit, ", {
+            " Il l’étendit, ",
+            {
               "type": "graft",
               "subtype": "xref",
               "target": "ODIwNzA4ZDct"
             },
-            "et sa main fut guérie. ", {
-              "type": "wrapper",
-              "subtype": "meta_content",
-              "meta_content": ["<== Long verse (36 words)"]
-            }, {
+            "et sa main fut guérie. ",
+            {
               "type": "mark",
               "subtype": "verses",
               "atts": {
                 "number": "6"
               }
-            }, {
+            },
+            {
               "type": "graft",
               "subtype": "xref",
               "target": "NTkzZWIwZjQt"
             },
             "Les pharisiens sortirent, et aussitôt ils se consultèrent avec les hérodiens sur les moyens de le faire périr."
           ]
-        }, {
+        },
+        {
           "type": "graft",
           "subtype": "heading",
           "target": "MGM3OTllMTct"
-        }, {
+        },
+        {
           "type": "paragraph",
           "subtype": "usfm:p",
           "content": [
@@ -1311,39 +1463,40 @@
               "subtype": "xref",
               "target": "NzFlNTU1MmQt"
             },
-            "Une grande multitude le suivit de la Galilée; ", {
+            "Une grande multitude le suivit de la Galilée; ",
+            {
               "type": "mark",
               "subtype": "verses",
               "atts": {
                 "number": "8"
               }
             },
-            "et de la Judée, et de Jérusalem, et de l’Idumée, et d’au-delà du Jourdain, et des environs de Tyr et de Sidon, une grande multitude, apprenant tout ce qu’il faisait, vint à lui. ", {
-              "type": "wrapper",
-              "subtype": "meta_content",
-              "meta_content": ["<== Long verse (34 words)"]
-            }, {
+            "et de la Judée, et de Jérusalem, et de l’Idumée, et d’au-delà du Jourdain, et des environs de Tyr et de Sidon, une grande multitude, apprenant tout ce qu’il faisait, vint à lui. ",
+            {
               "type": "mark",
               "subtype": "verses",
               "atts": {
                 "number": "9"
               }
             },
-            "Il chargea ses disciples de tenir toujours à sa disposition une petite barque, afin de ne pas être pressé par la foule. ", {
+            "Il chargea ses disciples de tenir toujours à sa disposition une petite barque, afin de ne pas être pressé par la foule. ",
+            {
               "type": "mark",
               "subtype": "verses",
               "atts": {
                 "number": "10"
               }
             },
-            "Car, comme il guérissait beaucoup de gens, tous ceux qui avaient des maladies se jetaient sur lui pour le toucher. ", {
+            "Car, comme il guérissait beaucoup de gens, tous ceux qui avaient des maladies se jetaient sur lui pour le toucher. ",
+            {
               "type": "mark",
               "subtype": "verses",
               "atts": {
                 "number": "11"
               }
             },
-            "Les esprits impurs, quand ils le voyaient, se prosternaient devant lui, et s’écriaient: Tu es le Fils de Dieu. ", {
+            "Les esprits impurs, quand ils le voyaient, se prosternaient devant lui, et s’écriaient: Tu es le Fils de Dieu. ",
+            {
               "type": "mark",
               "subtype": "verses",
               "atts": {
@@ -1352,15 +1505,18 @@
             },
             "Mais il leur recommandait très sévèrement de ne pas le faire connaître."
           ]
-        }, {
+        },
+        {
           "type": "graft",
           "subtype": "heading",
           "target": "N2Q1YWRjYTYt"
-        }, {
+        },
+        {
           "type": "graft",
           "subtype": "heading",
           "target": "MDYzN2EwZjkt"
-        }, {
+        },
+        {
           "type": "paragraph",
           "subtype": "usfm:p",
           "content": [
@@ -1384,35 +1540,40 @@
                 "number": "14"
               }
             },
-            "Il en établit douze, pour les avoir avec lui, ", {
+            "Il en établit douze, pour les avoir avec lui, ",
+            {
               "type": "mark",
               "subtype": "verses",
               "atts": {
                 "number": "15"
               }
             },
-            "et pour les envoyer prêcher avec le pouvoir de chasser les démons. ", {
+            "et pour les envoyer prêcher avec le pouvoir de chasser les démons. ",
+            {
               "type": "mark",
               "subtype": "verses",
               "atts": {
                 "number": "16"
               }
             },
-            "Voici les douze qu’il établit: Simon, qu’il nomma Pierre; ", {
+            "Voici les douze qu’il établit: Simon, qu’il nomma Pierre; ",
+            {
               "type": "mark",
               "subtype": "verses",
               "atts": {
                 "number": "17"
               }
             },
-            "Jacques, fils de Zébédée, et Jean, frère de Jacques, auxquels il donna le nom de Boanergès, qui signifie fils du tonnerre; ", {
+            "Jacques, fils de Zébédée, et Jean, frère de Jacques, auxquels il donna le nom de Boanergès, qui signifie fils du tonnerre; ",
+            {
               "type": "mark",
               "subtype": "verses",
               "atts": {
                 "number": "18"
               }
             },
-            "André; Philippe; Barthélemy; Matthieu; Thomas; Jacques, fils d’Alphée; Thaddée; Simon le Cananite; ", {
+            "André; Philippe; Barthélemy; Matthieu; Thomas; Jacques, fils d’Alphée; Thaddée; Simon le Cananite; ",
+            {
               "type": "mark",
               "subtype": "verses",
               "atts": {
@@ -1421,15 +1582,18 @@
             },
             "et Judas Iscariot, celui qui livra Jésus."
           ]
-        }, {
+        },
+        {
           "type": "graft",
           "subtype": "heading",
           "target": "YTk3NzIxNmEt"
-        }, {
+        },
+        {
           "type": "graft",
           "subtype": "heading",
           "target": "ZTdkNmEwYjUt"
-        }, {
+        },
+        {
           "type": "paragraph",
           "subtype": "usfm:p",
           "content": [
@@ -1446,44 +1610,53 @@
               "subtype": "xref",
               "target": "NjAwY2U2YjIt"
             },
-            "qu’ils ne pouvaient pas même prendre leur repas. ", {
+            "qu’ils ne pouvaient pas même prendre leur repas. ",
+            {
               "type": "mark",
               "subtype": "verses",
               "atts": {
                 "number": "21"
               }
             },
-            "Les parents de Jésus, ayant appris ce qui se passait, vinrent pour se saisir de lui; car ils disaient: Il est hors de sens. ", {
+            "Les parents de Jésus, ayant appris ce qui se passait, vinrent pour se saisir de lui; car ils disaient: Il est hors de sens. ",
+            {
               "type": "mark",
               "subtype": "verses",
               "atts": {
                 "number": "22"
               }
             },
-            "Et les scribes, qui étaient descendus de Jérusalem, dirent: ", {
+            "Et les scribes, qui étaient descendus de Jérusalem, dirent: ",
+            {
               "type": "graft",
               "subtype": "xref",
               "target": "ZjBjNjRjZjQt"
             },
-            "Il est possédé de Béelzébul; c’est par le prince des démons qu’il chasse les démons. ", {
+            "Il est possédé de Béelzébul; c’est par le prince des démons qu’il chasse les démons. ",
+            {
               "type": "mark",
               "subtype": "verses",
               "atts": {
                 "number": "23"
               }
             },
-            "Jésus les appela, et ", {
+            "Jésus les appela, et ",
+            {
               "type": "graft",
               "subtype": "xref",
               "target": "ZGRlMDUwN2Et"
             },
-            "leur dit sous forme de paraboles: ", {
+            "leur dit sous forme de paraboles: ",
+            {
               "type": "wrapper",
-              "subtype": "usfm:wj",
-              "content": ["Comment Satan peut-il chasser Satan?"]
+              "subtype": "usfm:span",
+              "content": [
+                "Comment Satan peut-il chasser Satan?"
+              ]
             }
           ]
-        }, {
+        },
+        {
           "type": "paragraph",
           "subtype": "usfm:p",
           "content": [
@@ -1496,8 +1669,10 @@
             },
             {
               "type": "wrapper",
-              "subtype": "usfm:wj",
-              "content": ["Si un royaume est divisé contre lui-même, ce royaume ne peut subsister;"]
+              "subtype": "usfm:span",
+              "content": [
+                "Si un royaume est divisé contre lui-même, ce royaume ne peut subsister;"
+              ]
             },
             " ",
             {
@@ -1506,80 +1681,110 @@
               "atts": {
                 "number": "25"
               }
-            }, {
-              "type": "wrapper",
-              "subtype": "usfm:wj",
-              "content": ["et si une maison est divisée contre elle-même, cette maison ne peut subsister."]
             },
-            " ", {
+            {
+              "type": "wrapper",
+              "subtype": "usfm:span",
+              "content": [
+                "et si une maison est divisée contre elle-même, cette maison ne peut subsister."
+              ]
+            },
+            " ",
+            {
               "type": "mark",
               "subtype": "verses",
               "atts": {
                 "number": "26"
               }
-            }, {
-              "type": "wrapper",
-              "subtype": "usfm:wj",
-              "content": ["Si donc Satan se révolte contre lui-même, il est divisé, et il ne peut subsister, mais c’en est fait de lui."]
             },
-            " ", {
+            {
+              "type": "wrapper",
+              "subtype": "usfm:span",
+              "content": [
+                "Si donc Satan se révolte contre lui-même, il est divisé, et il ne peut subsister, mais c’en est fait de lui."
+              ]
+            },
+            " ",
+            {
               "type": "mark",
               "subtype": "verses",
               "atts": {
                 "number": "27"
               }
-            }, {
+            },
+            {
               "type": "graft",
               "subtype": "xref",
               "target": "M2YzMTNkYmIt"
-            }, {
+            },
+            {
               "type": "wrapper",
-              "subtype": "usfm:wj",
-              "content": ["Personne ne peut entrer dans la maison d’un homme fort et piller ses biens,"]
-            }, {
+              "subtype": "usfm:span",
+              "content": [
+                "Personne ne peut entrer dans la maison d’un homme fort et piller ses biens,"
+              ]
+            },
+            {
               "type": "graft",
               "subtype": "xref",
               "target": "NWM3ZWYzYjIt"
-            }, {
-              "type": "wrapper",
-              "subtype": "usfm:wj",
-              "content": ["sans avoir auparavant lié cet homme fort; alors il pillera sa maison."]
             },
-            " ", {
+            {
+              "type": "wrapper",
+              "subtype": "usfm:span",
+              "content": [
+                "sans avoir auparavant lié cet homme fort; alors il pillera sa maison."
+              ]
+            },
+            " ",
+            {
               "type": "mark",
               "subtype": "verses",
               "atts": {
                 "number": "28"
               }
-            }, {
+            },
+            {
               "type": "wrapper",
-              "subtype": "usfm:wj",
-              "content": ["Je vous le dis en vérité,"]
-            }, {
+              "subtype": "usfm:span",
+              "content": [
+                "Je vous le dis en vérité,"
+              ]
+            },
+            {
               "type": "graft",
               "subtype": "xref",
               "target": "YjkwYjk3Yjct"
-            }, {
-              "type": "wrapper",
-              "subtype": "usfm:wj",
-              "content": ["tous les péchés seront pardonnés aux fils des hommes, et les blasphèmes qu’ils auront proférés;"]
             },
-            " ", {
+            {
+              "type": "wrapper",
+              "subtype": "usfm:span",
+              "content": [
+                "tous les péchés seront pardonnés aux fils des hommes, et les blasphèmes qu’ils auront proférés;"
+              ]
+            },
+            " ",
+            {
               "type": "mark",
               "subtype": "verses",
               "atts": {
                 "number": "29"
               }
-            }, {
+            },
+            {
               "type": "graft",
               "subtype": "xref",
               "target": "ZWNlZjM0YTAt"
-            }, {
-              "type": "wrapper",
-              "subtype": "usfm:wj",
-              "content": ["mais quiconque blasphémera contre le Saint-Esprit n’obtiendra jamais de pardon: il est coupable d’un péché éternel."]
             },
-            " ", {
+            {
+              "type": "wrapper",
+              "subtype": "usfm:span",
+              "content": [
+                "mais quiconque blasphémera contre le Saint-Esprit n’obtiendra jamais de pardon: il est coupable d’un péché éternel."
+              ]
+            },
+            " ",
+            {
               "type": "mark",
               "subtype": "verses",
               "atts": {
@@ -1588,15 +1793,18 @@
             },
             "Jésus parla ainsi parce qu’ils disaient: Il est possédé d’un esprit impur."
           ]
-        }, {
+        },
+        {
           "type": "graft",
           "subtype": "heading",
           "target": "ZGQ2MTI5NWUt"
-        }, {
+        },
+        {
           "type": "graft",
           "subtype": "heading",
           "target": "ZjU4MTI3ZWYt"
-        }, {
+        },
+        {
           "type": "paragraph",
           "subtype": "usfm:p",
           "content": [
@@ -1620,37 +1828,49 @@
                 "number": "32"
               }
             },
-            "La foule était assise autour de lui, et on lui dit: Voici, ta mère et tes frères sont dehors et te demandent. ", {
+            "La foule était assise autour de lui, et on lui dit: Voici, ta mère et tes frères sont dehors et te demandent. ",
+            {
               "type": "mark",
               "subtype": "verses",
               "atts": {
                 "number": "33"
               }
             },
-            "Et il répondit: ", {
+            "Et il répondit: ",
+            {
               "type": "wrapper",
-              "subtype": "usfm:wj",
-              "content": ["Qui est ma mère, et qui sont mes frères?"]
+              "subtype": "usfm:span",
+              "content": [
+                "Qui est ma mère, et qui sont mes frères?"
+              ]
             },
-            " ", {
+            " ",
+            {
               "type": "mark",
               "subtype": "verses",
               "atts": {
                 "number": "34"
               }
             },
-            "Puis, jetant les regards sur ceux qui étaient assis tout autour de lui: ", {
+            "Puis, jetant les regards sur ceux qui étaient assis tout autour de lui: ",
+            {
               "type": "wrapper",
-              "subtype": "usfm:wj",
-              "content": ["Voici,"]
+              "subtype": "usfm:span",
+              "content": [
+                "Voici,"
+              ]
             },
-            " dit-il, ", {
+            " dit-il, ",
+            {
               "type": "wrapper",
-              "subtype": "usfm:wj",
-              "content": ["ma mère et mes frères."]
+              "subtype": "usfm:span",
+              "content": [
+                "ma mère et mes frères."
+              ]
             }
           ]
-        }, {
+        },
+        {
           "type": "paragraph",
           "subtype": "usfm:p",
           "content": [
@@ -1660,25 +1880,32 @@
               "atts": {
                 "number": "35"
               }
-            }, {
+            },
+            {
               "type": "graft",
               "subtype": "xref",
               "target": "ZDU4ZmU0Mzct"
-            }, {
+            },
+            {
               "type": "wrapper",
-              "subtype": "usfm:wj",
-              "content": ["Car, quiconque fait la volonté de Dieu, celui-là est mon frère, ma sœur, et ma mère."]
+              "subtype": "usfm:span",
+              "content": [
+                "Car, quiconque fait la volonté de Dieu, celui-là est mon frère, ma sœur, et ma mère."
+              ]
             }
           ]
-        }, {
+        },
+        {
           "type": "graft",
           "subtype": "heading",
           "target": "MmQyNWU0OTMt"
-        }, {
+        },
+        {
           "type": "graft",
           "subtype": "heading",
           "target": "OWM2ZTYwYTEt"
-        }, {
+        },
+        {
           "type": "paragraph",
           "subtype": "usfm:p",
           "content": [
@@ -1701,11 +1928,8 @@
               "subtype": "xref",
               "target": "NDJhNjRhZGYt"
             },
-            "Jésus se mit de nouveau à enseigner au bord de la mer. Une grande foule s’étant assemblée auprès de lui, il monta et s’assit dans une barque, sur la mer. Toute la foule était à terre sur le rivage. ", {
-              "type": "wrapper",
-              "subtype": "meta_content",
-              "meta_content": ["<== Long verse (40 words)"]
-            }, {
+            "Jésus se mit de nouveau à enseigner au bord de la mer. Une grande foule s’étant assemblée auprès de lui, il monta et s’assit dans une barque, sur la mer. Toute la foule était à terre sur le rivage. ",
+            {
               "type": "mark",
               "subtype": "verses",
               "atts": {
@@ -1714,7 +1938,8 @@
             },
             "Il leur enseigna beaucoup de choses en paraboles, et il leur dit dans son enseignement:"
           ]
-        }, {
+        },
+        {
           "type": "paragraph",
           "subtype": "usfm:p",
           "content": [
@@ -1727,8 +1952,10 @@
             },
             {
               "type": "wrapper",
-              "subtype": "usfm:wj",
-              "content": ["Écoutez. Un semeur sortit pour semer."]
+              "subtype": "usfm:span",
+              "content": [
+                "Écoutez. Un semeur sortit pour semer."
+              ]
             },
             " ",
             {
@@ -1737,104 +1964,139 @@
               "atts": {
                 "number": "4"
               }
-            }, {
-              "type": "wrapper",
-              "subtype": "usfm:wj",
-              "content": ["Comme il semait, une partie de la semence tomba le long du chemin: les oiseaux vinrent, et la mangèrent."]
             },
-            " ", {
+            {
+              "type": "wrapper",
+              "subtype": "usfm:span",
+              "content": [
+                "Comme il semait, une partie de la semence tomba le long du chemin: les oiseaux vinrent, et la mangèrent."
+              ]
+            },
+            " ",
+            {
               "type": "mark",
               "subtype": "verses",
               "atts": {
                 "number": "5"
               }
-            }, {
-              "type": "wrapper",
-              "subtype": "usfm:wj",
-              "content": ["Une autre partie tomba dans un endroit pierreux, où elle n’avait pas beaucoup de terre; elle leva aussitôt, parce qu’elle ne trouva pas un sol profond;"]
             },
-            " ", {
+            {
+              "type": "wrapper",
+              "subtype": "usfm:span",
+              "content": [
+                "Une autre partie tomba dans un endroit pierreux, où elle n’avait pas beaucoup de terre; elle leva aussitôt, parce qu’elle ne trouva pas un sol profond;"
+              ]
+            },
+            " ",
+            {
               "type": "mark",
               "subtype": "verses",
               "atts": {
                 "number": "6"
               }
-            }, {
-              "type": "wrapper",
-              "subtype": "usfm:wj",
-              "content": ["mais, quand le soleil parut, elle fut brûlée et sécha, faute de racines."]
             },
-            " ", {
+            {
+              "type": "wrapper",
+              "subtype": "usfm:span",
+              "content": [
+                "mais, quand le soleil parut, elle fut brûlée et sécha, faute de racines."
+              ]
+            },
+            " ",
+            {
               "type": "mark",
               "subtype": "verses",
               "atts": {
                 "number": "7"
               }
-            }, {
-              "type": "wrapper",
-              "subtype": "usfm:wj",
-              "content": ["Une autre partie tomba parmi les épines: les épines montèrent, et l’étouffèrent, et elle ne donna point de fruit."]
             },
-            " ", {
+            {
+              "type": "wrapper",
+              "subtype": "usfm:span",
+              "content": [
+                "Une autre partie tomba parmi les épines: les épines montèrent, et l’étouffèrent, et elle ne donna point de fruit."
+              ]
+            },
+            " ",
+            {
               "type": "mark",
               "subtype": "verses",
               "atts": {
                 "number": "8"
               }
-            }, {
-              "type": "wrapper",
-              "subtype": "usfm:wj",
-              "content": ["Une autre partie tomba dans la bonne terre: elle donna du fruit qui montait et croissait, et elle rapporta trente, soixante, et cent pour un."]
             },
-            " ", {
+            {
+              "type": "wrapper",
+              "subtype": "usfm:span",
+              "content": [
+                "Une autre partie tomba dans la bonne terre: elle donna du fruit qui montait et croissait, et elle rapporta trente, soixante, et cent pour un."
+              ]
+            },
+            " ",
+            {
               "type": "mark",
               "subtype": "verses",
               "atts": {
                 "number": "9"
               }
             },
-            "Puis il dit: ", {
+            "Puis il dit: ",
+            {
               "type": "wrapper",
-              "subtype": "usfm:wj",
-              "content": ["Que celui qui a des oreilles pour entendre entende."]
+              "subtype": "usfm:span",
+              "content": [
+                "Que celui qui a des oreilles pour entendre entende."
+              ]
             },
-            " ", {
+            " ",
+            {
               "type": "mark",
               "subtype": "verses",
               "atts": {
                 "number": "10"
               }
-            }, {
+            },
+            {
               "type": "graft",
               "subtype": "xref",
               "target": "NmM3ZWQxNzAt"
             },
-            "Lorsqu’il fut en particulier, ceux qui l’entouraient avec les douze l’interrogèrent sur les paraboles. ", {
+            "Lorsqu’il fut en particulier, ceux qui l’entouraient avec les douze l’interrogèrent sur les paraboles. ",
+            {
               "type": "mark",
               "subtype": "verses",
               "atts": {
                 "number": "11"
               }
             },
-            "Il leur dit: ", {
+            "Il leur dit: ",
+            {
               "type": "graft",
               "subtype": "xref",
               "target": "MzI1YmRmZDkt"
-            }, {
+            },
+            {
               "type": "wrapper",
-              "subtype": "usfm:wj",
-              "content": ["C’est à vous qu’a été donné le mystère du royaume de Dieu;"]
-            }, {
+              "subtype": "usfm:span",
+              "content": [
+                "C’est à vous qu’a été donné le mystère du royaume de Dieu;"
+              ]
+            },
+            {
               "type": "graft",
               "subtype": "xref",
               "target": "MjI1NWFkNzQt"
-            }, {
+            },
+            {
               "type": "wrapper",
-              "subtype": "usfm:wj",
-              "content": ["mais pour ceux qui sont dehors tout se passe en paraboles,"]
+              "subtype": "usfm:span",
+              "content": [
+                "mais pour ceux qui sont dehors tout se passe en paraboles,"
+              ]
             }
           ]
-        }, {
+        },
+        {
           "type": "paragraph",
           "subtype": "usfm:p",
           "content": [
@@ -1852,27 +2114,30 @@
             },
             {
               "type": "wrapper",
-              "subtype": "usfm:wj",
-              "content": ["afin qu’en voyant ils voient et n’aperçoivent point, et qu’en entendant ils entendent et ne comprennent point, de peur qu’ils ne se convertissent, et que les péchés ne leur soient pardonnés."]
+              "subtype": "usfm:span",
+              "content": [
+                "afin qu’en voyant ils voient et n’aperçoivent point, et qu’en entendant ils entendent et ne comprennent point, de peur qu’ils ne se convertissent, et que les péchés ne leur soient pardonnés."
+              ]
             },
-            " ", {
-              "type": "wrapper",
-              "subtype": "meta_content",
-              "meta_content": ["<== Long verse (33 words)"]
-            }, {
+            " ",
+            {
               "type": "mark",
               "subtype": "verses",
               "atts": {
                 "number": "13"
               }
             },
-            "Il leur dit encore: ", {
+            "Il leur dit encore: ",
+            {
               "type": "wrapper",
-              "subtype": "usfm:wj",
-              "content": ["Vous ne comprenez pas cette parabole? Comment donc comprendrez-vous toutes les paraboles?"]
+              "subtype": "usfm:span",
+              "content": [
+                "Vous ne comprenez pas cette parabole? Comment donc comprendrez-vous toutes les paraboles?"
+              ]
             }
           ]
-        }, {
+        },
+        {
           "type": "paragraph",
           "subtype": "usfm:p",
           "content": [
@@ -1890,93 +2155,114 @@
             },
             {
               "type": "wrapper",
-              "subtype": "usfm:wj",
-              "content": ["Le semeur sème la parole."]
+              "subtype": "usfm:span",
+              "content": [
+                "Le semeur sème la parole."
+              ]
             },
-            " ", {
+            " ",
+            {
               "type": "mark",
               "subtype": "verses",
               "atts": {
                 "number": "15"
               }
-            }, {
-              "type": "wrapper",
-              "subtype": "usfm:wj",
-              "content": ["Les uns sont le long du chemin, où la parole est semée; quand ils l’ont entendue, aussitôt Satan vient et enlève la parole qui a été semée en eux."]
             },
-            " ", {
+            {
               "type": "wrapper",
-              "subtype": "meta_content",
-              "meta_content": ["<== Long verse (31 words)"]
-            }, {
+              "subtype": "usfm:span",
+              "content": [
+                "Les uns sont le long du chemin, où la parole est semée; quand ils l’ont entendue, aussitôt Satan vient et enlève la parole qui a été semée en eux."
+              ]
+            },
+            " ",
+            {
               "type": "mark",
               "subtype": "verses",
               "atts": {
                 "number": "16"
               }
-            }, {
-              "type": "wrapper",
-              "subtype": "usfm:wj",
-              "content": ["Les autres, pareillement, reçoivent la semence dans les endroits pierreux; quand ils entendent la parole, ils la reçoivent d’abord avec joie;"]
             },
-            " ", {
+            {
+              "type": "wrapper",
+              "subtype": "usfm:span",
+              "content": [
+                "Les autres, pareillement, reçoivent la semence dans les endroits pierreux; quand ils entendent la parole, ils la reçoivent d’abord avec joie;"
+              ]
+            },
+            " ",
+            {
               "type": "mark",
               "subtype": "verses",
               "atts": {
                 "number": "17"
               }
-            }, {
-              "type": "wrapper",
-              "subtype": "usfm:wj",
-              "content": ["mais ils n’ont pas de racine en eux-mêmes, ils manquent de persistance, et, dès que survient une tribulation ou une persécution à cause de la parole, ils y trouvent une occasion de chute."]
             },
-            " ", {
+            {
               "type": "wrapper",
-              "subtype": "meta_content",
-              "meta_content": ["<== Long verse (35 words)"]
-            }, {
+              "subtype": "usfm:span",
+              "content": [
+                "mais ils n’ont pas de racine en eux-mêmes, ils manquent de persistance, et, dès que survient une tribulation ou une persécution à cause de la parole, ils y trouvent une occasion de chute."
+              ]
+            },
+            " ",
+            {
               "type": "mark",
               "subtype": "verses",
               "atts": {
                 "number": "18"
               }
-            }, {
-              "type": "wrapper",
-              "subtype": "usfm:wj",
-              "content": ["D’autres reçoivent la semence parmi les épines; ce sont ceux qui entendent la parole,"]
             },
-            " ", {
+            {
+              "type": "wrapper",
+              "subtype": "usfm:span",
+              "content": [
+                "D’autres reçoivent la semence parmi les épines; ce sont ceux qui entendent la parole,"
+              ]
+            },
+            " ",
+            {
               "type": "mark",
               "subtype": "verses",
               "atts": {
                 "number": "19"
               }
-            }, {
+            },
+            {
               "type": "graft",
               "subtype": "xref",
               "target": "NTE2OGJhOTMt"
-            }, {
-              "type": "wrapper",
-              "subtype": "usfm:wj",
-              "content": ["mais en qui les soucis du siècle, la séduction des richesses et l’invasion des autres convoitises, étouffent la parole, et la rendent infructueuse."]
             },
-            " ", {
+            {
+              "type": "wrapper",
+              "subtype": "usfm:span",
+              "content": [
+                "mais en qui les soucis du siècle, la séduction des richesses et l’invasion des autres convoitises, étouffent la parole, et la rendent infructueuse."
+              ]
+            },
+            " ",
+            {
               "type": "mark",
               "subtype": "verses",
               "atts": {
                 "number": "20"
               }
-            }, {
+            },
+            {
               "type": "wrapper",
-              "subtype": "usfm:wj",
-              "content": ["D’autres reçoivent la semence dans la bonne terre; ce sont ceux qui entendent la parole, la reçoivent, et portent du fruit, trente, soixante, et cent pour un."]
+              "subtype": "usfm:span",
+              "content": [
+                "D’autres reçoivent la semence dans la bonne terre; ce sont ceux qui entendent la parole, la reçoivent, et portent du fruit, trente, soixante, et cent pour un."
+              ]
             }
           ]
-        }, {
+        },
+        {
           "type": "graft",
           "subtype": "heading",
           "target": "MjFlMjE0Nzct"
-        }, {
+        },
+        {
           "type": "paragraph",
           "subtype": "usfm:p",
           "content": [
@@ -1986,18 +2272,23 @@
               "atts": {
                 "number": "21"
               }
-            }, {
+            },
+            {
               "type": "graft",
               "subtype": "xref",
               "target": "NWJjYzAwZDgt"
             },
-            "Il leur dit encore: ", {
+            "Il leur dit encore: ",
+            {
               "type": "wrapper",
-              "subtype": "usfm:wj",
-              "content": ["Apporte-t-on la lampe pour la mettre sous le boisseau, ou sous le lit? N’est-ce pas pour la mettre sur le chandelier?"]
+              "subtype": "usfm:span",
+              "content": [
+                "Apporte-t-on la lampe pour la mettre sous le boisseau, ou sous le lit? N’est-ce pas pour la mettre sur le chandelier?"
+              ]
             }
           ]
-        }, {
+        },
+        {
           "type": "paragraph",
           "subtype": "usfm:p",
           "content": [
@@ -2015,42 +2306,57 @@
             },
             {
               "type": "wrapper",
-              "subtype": "usfm:wj",
-              "content": ["Car il n’est rien de caché qui ne doive être découvert, rien de secret qui ne doive être mis au jour."]
+              "subtype": "usfm:span",
+              "content": [
+                "Car il n’est rien de caché qui ne doive être découvert, rien de secret qui ne doive être mis au jour."
+              ]
             },
-            " ", {
+            " ",
+            {
               "type": "mark",
               "subtype": "verses",
               "atts": {
                 "number": "23"
               }
-            }, {
-              "type": "wrapper",
-              "subtype": "usfm:wj",
-              "content": ["Si quelqu’un a des oreilles pour entendre, qu’il entende."]
             },
-            " ", {
+            {
+              "type": "wrapper",
+              "subtype": "usfm:span",
+              "content": [
+                "Si quelqu’un a des oreilles pour entendre, qu’il entende."
+              ]
+            },
+            " ",
+            {
               "type": "mark",
               "subtype": "verses",
               "atts": {
                 "number": "24"
               }
             },
-            "Il leur dit encore: ", {
+            "Il leur dit encore: ",
+            {
               "type": "wrapper",
-              "subtype": "usfm:wj",
-              "content": ["Prenez garde à ce que vous entendez."]
-            }, {
+              "subtype": "usfm:span",
+              "content": [
+                "Prenez garde à ce que vous entendez."
+              ]
+            },
+            {
               "type": "graft",
               "subtype": "xref",
               "target": "YTM4NDQ2ZTEt"
-            }, {
+            },
+            {
               "type": "wrapper",
-              "subtype": "usfm:wj",
-              "content": ["On vous mesurera avec la mesure dont vous vous serez servis, et on y ajoutera pour vous."]
+              "subtype": "usfm:span",
+              "content": [
+                "On vous mesurera avec la mesure dont vous vous serez servis, et on y ajoutera pour vous."
+              ]
             }
           ]
-        }, {
+        },
+        {
           "type": "paragraph",
           "subtype": "usfm:p",
           "content": [
@@ -2060,21 +2366,27 @@
               "atts": {
                 "number": "25"
               }
-            }, {
+            },
+            {
               "type": "graft",
               "subtype": "xref",
               "target": "OGNhNTgyZGUt"
-            }, {
+            },
+            {
               "type": "wrapper",
-              "subtype": "usfm:wj",
-              "content": ["Car on donnera à celui qui a; mais à celui qui n’a pas on ôtera même ce qu’il a."]
+              "subtype": "usfm:span",
+              "content": [
+                "Car on donnera à celui qui a; mais à celui qui n’a pas on ôtera même ce qu’il a."
+              ]
             }
           ]
-        }, {
+        },
+        {
           "type": "graft",
           "subtype": "heading",
           "target": "MmIyZGY2Nzct"
-        }, {
+        },
+        {
           "type": "paragraph",
           "subtype": "usfm:p",
           "content": [
@@ -2085,13 +2397,17 @@
                 "number": "26"
               }
             },
-            "Il dit encore: ", {
+            "Il dit encore: ",
+            {
               "type": "wrapper",
-              "subtype": "usfm:wj",
-              "content": ["Il en est du royaume de Dieu comme quand un homme jette de la semence en terre;"]
+              "subtype": "usfm:span",
+              "content": [
+                "Il en est du royaume de Dieu comme quand un homme jette de la semence en terre;"
+              ]
             }
           ]
-        }, {
+        },
+        {
           "type": "paragraph",
           "subtype": "usfm:p",
           "content": [
@@ -2104,8 +2420,10 @@
             },
             {
               "type": "wrapper",
-              "subtype": "usfm:wj",
-              "content": ["qu’il dorme ou qu’il veille, nuit et jour, la semence germe et croît sans qu’il sache comment."]
+              "subtype": "usfm:span",
+              "content": [
+                "qu’il dorme ou qu’il veille, nuit et jour, la semence germe et croît sans qu’il sache comment."
+              ]
             },
             " ",
             {
@@ -2114,28 +2432,37 @@
               "atts": {
                 "number": "28"
               }
-            }, {
-              "type": "wrapper",
-              "subtype": "usfm:wj",
-              "content": ["La terre produit d’elle-même, d’abord l’herbe, puis l’épi, puis le grain tout formé dans l’épi;"]
             },
-            " ", {
+            {
+              "type": "wrapper",
+              "subtype": "usfm:span",
+              "content": [
+                "La terre produit d’elle-même, d’abord l’herbe, puis l’épi, puis le grain tout formé dans l’épi;"
+              ]
+            },
+            " ",
+            {
               "type": "mark",
               "subtype": "verses",
               "atts": {
                 "number": "29"
               }
-            }, {
+            },
+            {
               "type": "wrapper",
-              "subtype": "usfm:wj",
-              "content": ["et, dès que le fruit est mûr, on y met la faucille, car la moisson est là."]
+              "subtype": "usfm:span",
+              "content": [
+                "et, dès que le fruit est mûr, on y met la faucille, car la moisson est là."
+              ]
             }
           ]
-        }, {
+        },
+        {
           "type": "graft",
           "subtype": "heading",
           "target": "ZGEyYjY2YTMt"
-        }, {
+        },
+        {
           "type": "paragraph",
           "subtype": "usfm:p",
           "content": [
@@ -2145,18 +2472,23 @@
               "atts": {
                 "number": "30"
               }
-            }, {
+            },
+            {
               "type": "graft",
               "subtype": "xref",
               "target": "OTRlMzhjNjQt"
             },
-            "Il dit encore: ", {
+            "Il dit encore: ",
+            {
               "type": "wrapper",
-              "subtype": "usfm:wj",
-              "content": ["A quoi comparerons-nous le royaume de Dieu, ou par quelle parabole le représenterons-nous?"]
+              "subtype": "usfm:span",
+              "content": [
+                "A quoi comparerons-nous le royaume de Dieu, ou par quelle parabole le représenterons-nous?"
+              ]
             }
           ]
-        }, {
+        },
+        {
           "type": "paragraph",
           "subtype": "usfm:p",
           "content": [
@@ -2169,8 +2501,10 @@
             },
             {
               "type": "wrapper",
-              "subtype": "usfm:wj",
-              "content": ["Il est semblable à un grain de sénevé, qui, lorsqu’on le sème en terre, est la plus petite de toutes les semences qui sont sur la terre;"]
+              "subtype": "usfm:span",
+              "content": [
+                "Il est semblable à un grain de sénevé, qui, lorsqu’on le sème en terre, est la plus petite de toutes les semences qui sont sur la terre;"
+              ]
             },
             " ",
             {
@@ -2179,27 +2513,29 @@
               "atts": {
                 "number": "32"
               }
-            }, {
-              "type": "wrapper",
-              "subtype": "usfm:wj",
-              "content": ["mais, lorsqu’il a été semé, il monte, devient plus grand que tous les légumes, et pousse de grandes branches, en sorte que les oiseaux du ciel peuvent habiter sous son ombre."]
             },
-            " ", {
+            {
               "type": "wrapper",
-              "subtype": "meta_content",
-              "meta_content": ["<== Long verse (33 words)"]
-            }, {
+              "subtype": "usfm:span",
+              "content": [
+                "mais, lorsqu’il a été semé, il monte, devient plus grand que tous les légumes, et pousse de grandes branches, en sorte que les oiseaux du ciel peuvent habiter sous son ombre."
+              ]
+            },
+            " ",
+            {
               "type": "mark",
               "subtype": "verses",
               "atts": {
                 "number": "33"
               }
-            }, {
+            },
+            {
               "type": "graft",
               "subtype": "xref",
               "target": "ZjFmZTI4YzMt"
             },
-            "C’est par beaucoup de paraboles de ce genre qu’il leur annonçait la parole, selon qu’ils étaient capables de l’entendre. ", {
+            "C’est par beaucoup de paraboles de ce genre qu’il leur annonçait la parole, selon qu’ils étaient capables de l’entendre. ",
+            {
               "type": "mark",
               "subtype": "verses",
               "atts": {
@@ -2208,15 +2544,18 @@
             },
             "Il ne leur parlait point sans parabole; mais, en particulier, il expliquait tout à ses disciples."
           ]
-        }, {
+        },
+        {
           "type": "graft",
           "subtype": "heading",
           "target": "OThiMTFkYWYt"
-        }, {
+        },
+        {
           "type": "graft",
           "subtype": "heading",
           "target": "OTU3MWNjYjkt"
-        }, {
+        },
+        {
           "type": "paragraph",
           "subtype": "usfm:p",
           "content": [
@@ -2235,60 +2574,75 @@
             "Ce même jour, sur le soir, Jésus leur dit: ",
             {
               "type": "wrapper",
-              "subtype": "usfm:wj",
-              "content": ["Passons à l’autre bord."]
+              "subtype": "usfm:span",
+              "content": [
+                "Passons à l’autre bord."
+              ]
             },
-            " ", {
+            " ",
+            {
               "type": "mark",
               "subtype": "verses",
               "atts": {
                 "number": "36"
               }
             },
-            "Après avoir renvoyé la foule, ils l’emmenèrent dans la barque où il se trouvait; il y avait aussi d’autres barques avec lui. ", {
+            "Après avoir renvoyé la foule, ils l’emmenèrent dans la barque où il se trouvait; il y avait aussi d’autres barques avec lui. ",
+            {
               "type": "mark",
               "subtype": "verses",
               "atts": {
                 "number": "37"
               }
             },
-            "Il s’éleva un grand tourbillon, et les flots se jetaient dans la barque, au point qu’elle se remplissait déjà. ", {
+            "Il s’éleva un grand tourbillon, et les flots se jetaient dans la barque, au point qu’elle se remplissait déjà. ",
+            {
               "type": "mark",
               "subtype": "verses",
               "atts": {
                 "number": "38"
               }
             },
-            "Et lui, il dormait à la poupe sur le coussin. Ils le réveillèrent, et lui dirent: Maître, ne t’inquiètes-tu pas de ce que nous périssons? ", {
+            "Et lui, il dormait à la poupe sur le coussin. Ils le réveillèrent, et lui dirent: Maître, ne t’inquiètes-tu pas de ce que nous périssons? ",
+            {
               "type": "mark",
               "subtype": "verses",
               "atts": {
                 "number": "39"
               }
             },
-            "S’étant réveillé, il ", {
+            "S’étant réveillé, il ",
+            {
               "type": "graft",
               "subtype": "xref",
               "target": "MjMyYjhhMGQt"
             },
-            "menaça le vent, et dit à la mer: ", {
+            "menaça le vent, et dit à la mer: ",
+            {
               "type": "wrapper",
-              "subtype": "usfm:wj",
-              "content": ["Silence! Tais-toi!"]
+              "subtype": "usfm:span",
+              "content": [
+                "Silence! Tais-toi!"
+              ]
             },
-            " Et le vent cessa, et il y eut un grand calme. ", {
+            " Et le vent cessa, et il y eut un grand calme. ",
+            {
               "type": "mark",
               "subtype": "verses",
               "atts": {
                 "number": "40"
               }
             },
-            "Puis il leur dit: ", {
+            "Puis il leur dit: ",
+            {
               "type": "wrapper",
-              "subtype": "usfm:wj",
-              "content": ["Pourquoi avez-vous ainsi peur? Comment n’avez-vous point de foi?"]
+              "subtype": "usfm:span",
+              "content": [
+                "Pourquoi avez-vous ainsi peur? Comment n’avez-vous point de foi?"
+              ]
             },
-            " ", {
+            " ",
+            {
               "type": "mark",
               "subtype": "verses",
               "atts": {
@@ -2297,15 +2651,18 @@
             },
             "Ils furent saisis d’une grande frayeur, et ils se dirent les uns aux autres: Quel est donc celui-ci, à qui obéissent même le vent et la mer?"
           ]
-        }, {
+        },
+        {
           "type": "graft",
           "subtype": "heading",
           "target": "ZGUwYTU1MjIt"
-        }, {
+        },
+        {
           "type": "graft",
           "subtype": "heading",
           "target": "OWNhNTQ5ZDEt"
-        }, {
+        },
+        {
           "type": "paragraph",
           "subtype": "usfm:p",
           "content": [
@@ -2328,172 +2685,186 @@
               "subtype": "xref",
               "target": "MWYyNDM3YTAt"
             },
-            "Ils arrivèrent à l’autre bord de la mer, dans le pays des Gadaréniens. ", {
+            "Ils arrivèrent à l’autre bord de la mer, dans le pays des Gadaréniens. ",
+            {
               "type": "mark",
               "subtype": "verses",
               "atts": {
                 "number": "2"
               }
             },
-            "Aussitôt que Jésus fut hors de la barque, il vint au-devant de lui un homme, sortant des sépulcres, et possédé d’un esprit impur. ", {
+            "Aussitôt que Jésus fut hors de la barque, il vint au-devant de lui un homme, sortant des sépulcres, et possédé d’un esprit impur. ",
+            {
               "type": "mark",
               "subtype": "verses",
               "atts": {
                 "number": "3"
               }
             },
-            "Cet homme avait sa demeure dans les sépulcres, et personne ne pouvait plus le lier, même avec une chaîne. ", {
+            "Cet homme avait sa demeure dans les sépulcres, et personne ne pouvait plus le lier, même avec une chaîne. ",
+            {
               "type": "mark",
               "subtype": "verses",
               "atts": {
                 "number": "4"
               }
             },
-            "Car souvent il avait eu les fers aux pieds et avait été lié de chaînes, mais il avait rompu les chaînes et brisé les fers, et personne n’avait la force de le dompter. ", {
-              "type": "wrapper",
-              "subtype": "meta_content",
-              "meta_content": ["<== Long verse (34 words)"]
-            }, {
+            "Car souvent il avait eu les fers aux pieds et avait été lié de chaînes, mais il avait rompu les chaînes et brisé les fers, et personne n’avait la force de le dompter. ",
+            {
               "type": "mark",
               "subtype": "verses",
               "atts": {
                 "number": "5"
               }
             },
-            "Il était sans cesse, nuit et jour, dans les sépulcres et sur les montagnes, criant, et se meurtrissant avec des pierres. ", {
+            "Il était sans cesse, nuit et jour, dans les sépulcres et sur les montagnes, criant, et se meurtrissant avec des pierres. ",
+            {
               "type": "mark",
               "subtype": "verses",
               "atts": {
                 "number": "6"
               }
             },
-            "Ayant vu Jésus de loin, il accourut, se prosterna devant lui, ", {
+            "Ayant vu Jésus de loin, il accourut, se prosterna devant lui, ",
+            {
               "type": "mark",
               "subtype": "verses",
               "atts": {
                 "number": "7"
               }
             },
-            "et s’écria d’une voix forte: Qu’y a-t-il entre moi et toi, Jésus, Fils du Dieu Très-Haut? Je t’en conjure au nom de Dieu, ne me tourmente pas. ", {
+            "et s’écria d’une voix forte: Qu’y a-t-il entre moi et toi, Jésus, Fils du Dieu Très-Haut? Je t’en conjure au nom de Dieu, ne me tourmente pas. ",
+            {
               "type": "mark",
               "subtype": "verses",
               "atts": {
                 "number": "8"
               }
             },
-            "Car Jésus lui disait: ", {
+            "Car Jésus lui disait: ",
+            {
               "type": "wrapper",
-              "subtype": "usfm:wj",
-              "content": ["Sors de cet homme, esprit impur!"]
+              "subtype": "usfm:span",
+              "content": [
+                "Sors de cet homme, esprit impur!"
+              ]
             },
-            " ", {
+            " ",
+            {
               "type": "mark",
               "subtype": "verses",
               "atts": {
                 "number": "9"
               }
             },
-            "Et, il lui demanda: ", {
+            "Et, il lui demanda: ",
+            {
               "type": "wrapper",
-              "subtype": "usfm:wj",
-              "content": ["Quel est ton nom?"]
+              "subtype": "usfm:span",
+              "content": [
+                "Quel est ton nom?"
+              ]
             },
-            " Légion est mon nom, lui répondit-il, car nous sommes plusieurs. ", {
+            " Légion est mon nom, lui répondit-il, car nous sommes plusieurs. ",
+            {
               "type": "mark",
               "subtype": "verses",
               "atts": {
                 "number": "10"
               }
             },
-            "Et il le priait instamment de ne pas les envoyer hors du pays. ", {
+            "Et il le priait instamment de ne pas les envoyer hors du pays. ",
+            {
               "type": "mark",
               "subtype": "verses",
               "atts": {
                 "number": "11"
               }
             },
-            "Il y avait là, vers la montagne, un grand troupeau de pourceaux qui paissaient. ", {
+            "Il y avait là, vers la montagne, un grand troupeau de pourceaux qui paissaient. ",
+            {
               "type": "mark",
               "subtype": "verses",
               "atts": {
                 "number": "12"
               }
             },
-            "Et les démons le prièrent, disant: Envoie-nous dans ces pourceaux, afin que nous entrions en eux. ", {
+            "Et les démons le prièrent, disant: Envoie-nous dans ces pourceaux, afin que nous entrions en eux. ",
+            {
               "type": "mark",
               "subtype": "verses",
               "atts": {
                 "number": "13"
               }
             },
-            "Il le leur permit. Et les esprits impurs sortirent, entrèrent dans les pourceaux, et le troupeau se précipita des pentes escarpées dans la mer: il y en avait environ deux mille, et ils se noyèrent dans la mer. ", {
-              "type": "wrapper",
-              "subtype": "meta_content",
-              "meta_content": ["<== Long verse (39 words)"]
-            }, {
+            "Il le leur permit. Et les esprits impurs sortirent, entrèrent dans les pourceaux, et le troupeau se précipita des pentes escarpées dans la mer: il y en avait environ deux mille, et ils se noyèrent dans la mer. ",
+            {
               "type": "mark",
               "subtype": "verses",
               "atts": {
                 "number": "14"
               }
             },
-            "Ceux qui les faisaient paître s’enfuirent, et répandirent la nouvelle dans la ville et dans les campagnes. Les gens allèrent voir ce qui était arrivé. ", {
+            "Ceux qui les faisaient paître s’enfuirent, et répandirent la nouvelle dans la ville et dans les campagnes. Les gens allèrent voir ce qui était arrivé. ",
+            {
               "type": "mark",
               "subtype": "verses",
               "atts": {
                 "number": "15"
               }
             },
-            "Ils vinrent auprès de Jésus, et ils virent le démoniaque, celui qui avait eu la légion, assis, vêtu, et dans son bon sens; et ils furent saisis de frayeur. ", {
-              "type": "wrapper",
-              "subtype": "meta_content",
-              "meta_content": ["<== Long verse (30 words)"]
-            }, {
+            "Ils vinrent auprès de Jésus, et ils virent le démoniaque, celui qui avait eu la légion, assis, vêtu, et dans son bon sens; et ils furent saisis de frayeur. ",
+            {
               "type": "mark",
               "subtype": "verses",
               "atts": {
                 "number": "16"
               }
             },
-            "Ceux qui avaient vu ce qui s’était passé leur racontèrent ce qui était arrivé au démoniaque et aux pourceaux. ", {
+            "Ceux qui avaient vu ce qui s’était passé leur racontèrent ce qui était arrivé au démoniaque et aux pourceaux. ",
+            {
               "type": "mark",
               "subtype": "verses",
               "atts": {
                 "number": "17"
               }
-            }, {
+            },
+            {
               "type": "graft",
               "subtype": "xref",
               "target": "ZDM4MzQ1ZmYt"
             },
-            "Alors ils se mirent à supplier Jésus de quitter leur territoire. ", {
+            "Alors ils se mirent à supplier Jésus de quitter leur territoire. ",
+            {
               "type": "mark",
               "subtype": "verses",
               "atts": {
                 "number": "18"
               }
-            }, {
+            },
+            {
               "type": "graft",
               "subtype": "xref",
               "target": "ZDg2YmJjZDkt"
             },
-            "Comme il montait dans la barque, celui qui avait été démoniaque lui demanda la permission de rester avec lui. ", {
+            "Comme il montait dans la barque, celui qui avait été démoniaque lui demanda la permission de rester avec lui. ",
+            {
               "type": "mark",
               "subtype": "verses",
               "atts": {
                 "number": "19"
               }
             },
-            "Jésus ne le lui permit pas, mais il lui dit: ", {
+            "Jésus ne le lui permit pas, mais il lui dit: ",
+            {
               "type": "wrapper",
-              "subtype": "usfm:wj",
-              "content": ["Va dans ta maison, vers les tiens, et raconte-leur tout ce que le Seigneur t’a fait, et comment il a eu pitié de toi."]
+              "subtype": "usfm:span",
+              "content": [
+                "Va dans ta maison, vers les tiens, et raconte-leur tout ce que le Seigneur t’a fait, et comment il a eu pitié de toi."
+              ]
             },
-            " ", {
-              "type": "wrapper",
-              "subtype": "meta_content",
-              "meta_content": ["<== Long verse (37 words)"]
-            }, {
+            " ",
+            {
               "type": "mark",
               "subtype": "verses",
               "atts": {
@@ -2502,15 +2873,18 @@
             },
             "Il s’en alla, et se mit à publier dans la Décapole tout ce que Jésus avait fait pour lui. Et tous furent dans l’étonnement."
           ]
-        }, {
+        },
+        {
           "type": "graft",
           "subtype": "heading",
           "target": "ZWU0MWZlZjQt"
-        }, {
+        },
+        {
           "type": "graft",
           "subtype": "heading",
           "target": "ZWU2YmMyYmUt"
-        }, {
+        },
+        {
           "type": "paragraph",
           "subtype": "usfm:p",
           "content": [
@@ -2533,205 +2907,241 @@
               "atts": {
                 "number": "22"
               }
-            }, {
+            },
+            {
               "type": "graft",
               "subtype": "xref",
               "target": "ZThkODYxMGUt"
             },
-            "Alors vint un des chefs de la synagogue, nommé Jaïrus, qui, l’ayant aperçu, se jeta à ses pieds, ", {
+            "Alors vint un des chefs de la synagogue, nommé Jaïrus, qui, l’ayant aperçu, se jeta à ses pieds, ",
+            {
               "type": "mark",
               "subtype": "verses",
               "atts": {
                 "number": "23"
               }
             },
-            "et lui adressa cette instante prière: Ma petite fille est à l’extrémité, viens, impose-lui les mains, afin qu’elle soit sauvée et qu’elle vive. ", {
+            "et lui adressa cette instante prière: Ma petite fille est à l’extrémité, viens, impose-lui les mains, afin qu’elle soit sauvée et qu’elle vive. ",
+            {
               "type": "mark",
               "subtype": "verses",
               "atts": {
                 "number": "24"
               }
             },
-            "Jésus s’en alla avec lui. Et une grande foule le suivait et le pressait. ", {
+            "Jésus s’en alla avec lui. Et une grande foule le suivait et le pressait. ",
+            {
               "type": "mark",
               "subtype": "verses",
               "atts": {
                 "number": "25"
               }
-            }, {
+            },
+            {
               "type": "graft",
               "subtype": "xref",
               "target": "MzM5NTM0NmQt"
             },
-            "Or, il y avait une femme atteinte d’une perte de sang depuis douze ans. ", {
+            "Or, il y avait une femme atteinte d’une perte de sang depuis douze ans. ",
+            {
               "type": "mark",
               "subtype": "verses",
               "atts": {
                 "number": "26"
               }
             },
-            "Elle avait beaucoup souffert entre les mains de plusieurs médecins, elle avait dépensé tout ce qu’elle possédait, et elle n’avait éprouvé aucun soulagement, mais était allée plutôt en empirant. ", {
-              "type": "wrapper",
-              "subtype": "meta_content",
-              "meta_content": ["<== Long verse (30 words)"]
-            }, {
+            "Elle avait beaucoup souffert entre les mains de plusieurs médecins, elle avait dépensé tout ce qu’elle possédait, et elle n’avait éprouvé aucun soulagement, mais était allée plutôt en empirant. ",
+            {
               "type": "mark",
               "subtype": "verses",
               "atts": {
                 "number": "27"
               }
             },
-            "Ayant entendu parler de Jésus, elle vint dans la foule par derrière, et toucha son vêtement. ", {
+            "Ayant entendu parler de Jésus, elle vint dans la foule par derrière, et toucha son vêtement. ",
+            {
               "type": "mark",
               "subtype": "verses",
               "atts": {
                 "number": "28"
               }
             },
-            "Car elle disait: Si je puis seulement toucher ses vêtements, je serai guérie. ", {
+            "Car elle disait: Si je puis seulement toucher ses vêtements, je serai guérie. ",
+            {
               "type": "mark",
               "subtype": "verses",
               "atts": {
                 "number": "29"
               }
             },
-            "Au même instant la perte de sang s’arrêta, et elle sentit dans son corps qu’elle était guérie de son mal. ", {
+            "Au même instant la perte de sang s’arrêta, et elle sentit dans son corps qu’elle était guérie de son mal. ",
+            {
               "type": "mark",
               "subtype": "verses",
               "atts": {
                 "number": "30"
               }
             },
-            "Jésus connut aussitôt en lui-même qu’une force était sortie de lui; et, se retournant au milieu de la foule, il dit: ", {
+            "Jésus connut aussitôt en lui-même qu’une force était sortie de lui; et, se retournant au milieu de la foule, il dit: ",
+            {
               "type": "wrapper",
-              "subtype": "usfm:wj",
-              "content": ["Qui a touché mes vêtements?"]
+              "subtype": "usfm:span",
+              "content": [
+                "Qui a touché mes vêtements?"
+              ]
             },
-            " ", {
+            " ",
+            {
               "type": "mark",
               "subtype": "verses",
               "atts": {
                 "number": "31"
               }
             },
-            "Ses disciples lui dirent: Tu vois la foule qui te presse, et tu dis: Qui m’a touché? ", {
+            "Ses disciples lui dirent: Tu vois la foule qui te presse, et tu dis: Qui m’a touché? ",
+            {
               "type": "mark",
               "subtype": "verses",
               "atts": {
                 "number": "32"
               }
             },
-            "Et il regardait autour de lui, pour voir celle qui avait fait cela. ", {
+            "Et il regardait autour de lui, pour voir celle qui avait fait cela. ",
+            {
               "type": "mark",
               "subtype": "verses",
               "atts": {
                 "number": "33"
               }
             },
-            "La femme, effrayée et tremblante, sachant ce qui s’était passé en elle, vint se jeter à ses pieds, et lui dit toute la vérité. ", {
+            "La femme, effrayée et tremblante, sachant ce qui s’était passé en elle, vint se jeter à ses pieds, et lui dit toute la vérité. ",
+            {
               "type": "mark",
               "subtype": "verses",
               "atts": {
                 "number": "34"
               }
-            }, {
+            },
+            {
               "type": "graft",
               "subtype": "xref",
               "target": "MTA4NmNkNWUt"
             },
-            "Mais Jésus lui dit: ", {
+            "Mais Jésus lui dit: ",
+            {
               "type": "wrapper",
-              "subtype": "usfm:wj",
-              "content": ["Ma fille, ta foi t’a sauvée; va en paix, et sois guérie de ton mal."]
+              "subtype": "usfm:span",
+              "content": [
+                "Ma fille, ta foi t’a sauvée; va en paix, et sois guérie de ton mal."
+              ]
             },
-            " ", {
+            " ",
+            {
               "type": "mark",
               "subtype": "verses",
               "atts": {
                 "number": "35"
               }
-            }, {
+            },
+            {
               "type": "graft",
               "subtype": "xref",
               "target": "MGU2ZjZhYjAt"
             },
-            "Comme il parlait encore, survinrent de chez le chef de la synagogue des gens qui dirent: Ta fille est morte; pourquoi importuner davantage le maître? ", {
+            "Comme il parlait encore, survinrent de chez le chef de la synagogue des gens qui dirent: Ta fille est morte; pourquoi importuner davantage le maître? ",
+            {
               "type": "mark",
               "subtype": "verses",
               "atts": {
                 "number": "36"
               }
             },
-            "Mais Jésus, sans tenir compte de ces paroles, dit au chef de la synagogue: ", {
+            "Mais Jésus, sans tenir compte de ces paroles, dit au chef de la synagogue: ",
+            {
               "type": "wrapper",
-              "subtype": "usfm:wj",
-              "content": ["Ne crains pas, crois seulement."]
+              "subtype": "usfm:span",
+              "content": [
+                "Ne crains pas, crois seulement."
+              ]
             },
-            " ", {
+            " ",
+            {
               "type": "mark",
               "subtype": "verses",
               "atts": {
                 "number": "37"
               }
             },
-            "Et il ne permit à personne de l’accompagner, si ce n’est à Pierre, à Jacques, et à Jean, frère de Jacques. ", {
+            "Et il ne permit à personne de l’accompagner, si ce n’est à Pierre, à Jacques, et à Jean, frère de Jacques. ",
+            {
               "type": "mark",
               "subtype": "verses",
               "atts": {
                 "number": "38"
               }
             },
-            "Ils arrivèrent à la maison du chef de la synagogue, où Jésus vit une foule bruyante et des gens qui pleuraient et poussaient de grands cris. ", {
+            "Ils arrivèrent à la maison du chef de la synagogue, où Jésus vit une foule bruyante et des gens qui pleuraient et poussaient de grands cris. ",
+            {
               "type": "mark",
               "subtype": "verses",
               "atts": {
                 "number": "39"
               }
             },
-            "Il entra, et leur dit: ", {
+            "Il entra, et leur dit: ",
+            {
               "type": "wrapper",
-              "subtype": "usfm:wj",
-              "content": ["Pourquoi faites-vous du bruit, et pourquoi pleurez-vous?"]
-            }, {
+              "subtype": "usfm:span",
+              "content": [
+                "Pourquoi faites-vous du bruit, et pourquoi pleurez-vous?"
+              ]
+            },
+            {
               "type": "graft",
               "subtype": "xref",
               "target": "YmIyOWY0NGMt"
-            }, {
-              "type": "wrapper",
-              "subtype": "usfm:wj",
-              "content": ["L’enfant n’est pas morte, mais elle dort."]
             },
-            " ", {
+            {
+              "type": "wrapper",
+              "subtype": "usfm:span",
+              "content": [
+                "L’enfant n’est pas morte, mais elle dort."
+              ]
+            },
+            " ",
+            {
               "type": "mark",
               "subtype": "verses",
               "atts": {
                 "number": "40"
               }
             },
-            "Et ils se moquaient de lui. Alors, ayant fait sortir tout le monde, il prit avec lui le père et la mère de l’enfant, et ceux qui l’avaient accompagné, et il entra là où était l’enfant. ", {
-              "type": "wrapper",
-              "subtype": "meta_content",
-              "meta_content": ["<== Long verse (37 words)"]
-            }, {
+            "Et ils se moquaient de lui. Alors, ayant fait sortir tout le monde, il prit avec lui le père et la mère de l’enfant, et ceux qui l’avaient accompagné, et il entra là où était l’enfant. ",
+            {
               "type": "mark",
               "subtype": "verses",
               "atts": {
                 "number": "41"
               }
             },
-            "Il la saisit par la main, et lui dit: ", {
+            "Il la saisit par la main, et lui dit: ",
+            {
               "type": "wrapper",
-              "subtype": "usfm:wj",
-              "content": ["Talitha koumi,"]
+              "subtype": "usfm:span",
+              "content": [
+                "Talitha koumi,"
+              ]
             },
-            " ce qui signifie: Jeune fille, lève-toi, je te le dis. ", {
+            " ce qui signifie: Jeune fille, lève-toi, je te le dis. ",
+            {
               "type": "mark",
               "subtype": "verses",
               "atts": {
                 "number": "42"
               }
             },
-            "Aussitôt la jeune fille se leva, et se mit à marcher; car elle avait douze ans. Et ils furent dans un grand étonnement. ", {
+            "Aussitôt la jeune fille se leva, et se mit à marcher; car elle avait douze ans. Et ils furent dans un grand étonnement. ",
+            {
               "type": "mark",
               "subtype": "verses",
               "atts": {
@@ -2740,15 +3150,18 @@
             },
             "Jésus leur adressa de fortes recommandations, pour que personne ne sût la chose; et il dit qu’on donnât à manger à la jeune fille."
           ]
-        }, {
+        },
+        {
           "type": "graft",
           "subtype": "heading",
           "target": "N2UzYWZlZmUt"
-        }, {
+        },
+        {
           "type": "graft",
           "subtype": "heading",
           "target": "ZDIwYjMyYzMt"
-        }, {
+        },
+        {
           "type": "paragraph",
           "subtype": "usfm:p",
           "content": [
@@ -2771,60 +3184,63 @@
               "subtype": "xref",
               "target": "ZmVjMTk5MWQt"
             },
-            "Jésus partit de là, et se rendit dans sa patrie. Ses disciples le suivirent. ", {
+            "Jésus partit de là, et se rendit dans sa patrie. Ses disciples le suivirent. ",
+            {
               "type": "mark",
               "subtype": "verses",
               "atts": {
                 "number": "2"
               }
             },
-            "Quand le sabbat fut venu, il se mit à enseigner dans la synagogue. Beaucoup de gens qui l’entendirent étaient étonnés et disaient: D’où lui viennent ces choses? Quelle est cette sagesse qui lui a été donnée, et comment de tels miracles se font-ils par ses mains? ", {
-              "type": "wrapper",
-              "subtype": "meta_content",
-              "meta_content": ["<== Long verse (47 words)"]
-            }, {
+            "Quand le sabbat fut venu, il se mit à enseigner dans la synagogue. Beaucoup de gens qui l’entendirent étaient étonnés et disaient: D’où lui viennent ces choses? Quelle est cette sagesse qui lui a été donnée, et comment de tels miracles se font-ils par ses mains? ",
+            {
               "type": "mark",
               "subtype": "verses",
               "atts": {
                 "number": "3"
               }
-            }, {
+            },
+            {
               "type": "graft",
               "subtype": "xref",
               "target": "YjU0ODA0ZDIt"
             },
-            "N’est-ce pas le charpentier, le fils de Marie, le frère de Jacques, de Joses, de Jude et de Simon? Et ses sœurs ne sont-elles pas ici parmi nous? Et il était pour eux une occasion de chute. ", {
-              "type": "wrapper",
-              "subtype": "meta_content",
-              "meta_content": ["<== Long verse (38 words)"]
-            }, {
+            "N’est-ce pas le charpentier, le fils de Marie, le frère de Jacques, de Joses, de Jude et de Simon? Et ses sœurs ne sont-elles pas ici parmi nous? Et il était pour eux une occasion de chute. ",
+            {
               "type": "mark",
               "subtype": "verses",
               "atts": {
                 "number": "4"
               }
             },
-            "Mais Jésus leur dit: ", {
+            "Mais Jésus leur dit: ",
+            {
               "type": "graft",
               "subtype": "xref",
               "target": "OGZiOGIwODMt"
-            }, {
-              "type": "wrapper",
-              "subtype": "usfm:wj",
-              "content": ["Un prophète n’est méprisé que dans sa patrie, parmi ses parents, et dans sa maison."]
             },
-            " ", {
+            {
+              "type": "wrapper",
+              "subtype": "usfm:span",
+              "content": [
+                "Un prophète n’est méprisé que dans sa patrie, parmi ses parents, et dans sa maison."
+              ]
+            },
+            " ",
+            {
               "type": "mark",
               "subtype": "verses",
               "atts": {
                 "number": "5"
               }
-            }, {
+            },
+            {
               "type": "graft",
               "subtype": "xref",
               "target": "NWU0ZjI3OTct"
             },
-            "Il ne put faire là aucun miracle, si ce n’est qu’il imposa les mains à quelques malades et les guérit. ", {
+            "Il ne put faire là aucun miracle, si ce n’est qu’il imposa les mains à quelques malades et les guérit. ",
+            {
               "type": "mark",
               "subtype": "verses",
               "atts": {
@@ -2833,15 +3249,18 @@
             },
             "Et il s’étonnait de leur incrédulité."
           ]
-        }, {
+        },
+        {
           "type": "graft",
           "subtype": "heading",
           "target": "YTE0N2Q2ZTAt"
-        }, {
+        },
+        {
           "type": "graft",
           "subtype": "heading",
           "target": "YTQ1NjNkNTct"
-        }, {
+        },
+        {
           "type": "paragraph",
           "subtype": "usfm:p",
           "content": [
@@ -2863,38 +3282,46 @@
               "subtype": "xref",
               "target": "ZjcxZDljMWMt"
             },
-            "Alors il appela les douze, et il commença à les envoyer deux à deux, en leur donnant pouvoir sur les esprits impurs. ", {
+            "Alors il appela les douze, et il commença à les envoyer deux à deux, en leur donnant pouvoir sur les esprits impurs. ",
+            {
               "type": "mark",
               "subtype": "verses",
               "atts": {
                 "number": "8"
               }
             },
-            "Il leur prescrivit de ne rien prendre pour le voyage, si ce n’est un bâton; de n’avoir ni pain, ni sac, ni monnaie dans la ceinture; ", {
+            "Il leur prescrivit de ne rien prendre pour le voyage, si ce n’est un bâton; de n’avoir ni pain, ni sac, ni monnaie dans la ceinture; ",
+            {
               "type": "mark",
               "subtype": "verses",
               "atts": {
                 "number": "9"
               }
-            }, {
+            },
+            {
               "type": "graft",
               "subtype": "xref",
               "target": "YzYxNTBiMGMt"
             },
-            "de chausser des sandales, et de ne pas revêtir deux tuniques. ", {
+            "de chausser des sandales, et de ne pas revêtir deux tuniques. ",
+            {
               "type": "mark",
               "subtype": "verses",
               "atts": {
                 "number": "10"
               }
             },
-            "Puis il leur dit: ", {
+            "Puis il leur dit: ",
+            {
               "type": "wrapper",
-              "subtype": "usfm:wj",
-              "content": ["Dans quelque maison que vous entriez, restez-y jusqu’à ce que vous partiez de ce lieu."]
+              "subtype": "usfm:span",
+              "content": [
+                "Dans quelque maison que vous entriez, restez-y jusqu’à ce que vous partiez de ce lieu."
+              ]
             }
           ]
-        }, {
+        },
+        {
           "type": "paragraph",
           "subtype": "usfm:p",
           "content": [
@@ -2912,52 +3339,59 @@
             },
             {
               "type": "wrapper",
-              "subtype": "usfm:wj",
-              "content": ["Et, s’il y a quelque part des gens qui ne vous reçoivent ni ne vous écoutent, retirez-vous de là, et"]
+              "subtype": "usfm:span",
+              "content": [
+                "Et, s’il y a quelque part des gens qui ne vous reçoivent ni ne vous écoutent, retirez-vous de là, et"
+              ]
             },
             {
               "type": "graft",
               "subtype": "xref",
               "target": "MGExZDdkOWIt"
-            }, {
-              "type": "wrapper",
-              "subtype": "usfm:wj",
-              "content": ["secouez la poussière de vos pieds, afin que cela leur serve de témoignage."]
             },
-            " ", {
+            {
               "type": "wrapper",
-              "subtype": "meta_content",
-              "meta_content": ["<== Long verse (35 words)"]
-            }, {
+              "subtype": "usfm:span",
+              "content": [
+                "secouez la poussière de vos pieds, afin que cela leur serve de témoignage."
+              ]
+            },
+            " ",
+            {
               "type": "mark",
               "subtype": "verses",
               "atts": {
                 "number": "12"
               }
             },
-            "Ils partirent, et ils prêchèrent la repentance. ", {
+            "Ils partirent, et ils prêchèrent la repentance. ",
+            {
               "type": "mark",
               "subtype": "verses",
               "atts": {
                 "number": "13"
               }
             },
-            "Ils chassaient beaucoup de démons, ", {
+            "Ils chassaient beaucoup de démons, ",
+            {
               "type": "graft",
               "subtype": "xref",
               "target": "OWZkNGVkNmIt"
             },
             "et ils oignaient d’huile beaucoup de malades et les guérissaient."
           ]
-        }, {
+        },
+        {
           "type": "graft",
           "subtype": "heading",
           "target": "ZGY3MmMyNDIt"
-        }, {
+        },
+        {
           "type": "graft",
           "subtype": "heading",
           "target": "MzU2YWM2ZDAt"
-        }, {
+        },
+        {
           "type": "paragraph",
           "subtype": "usfm:p",
           "content": [
@@ -2975,147 +3409,151 @@
             },
             "Le roi Hérode entendit parler de Jésus, dont le nom était devenu célèbre, et il dit: Jean-Baptiste est ressuscité des morts, et c’est pour cela qu’il se fait par lui des miracles. ",
             {
-              "type": "wrapper",
-              "subtype": "meta_content",
-              "meta_content": ["<== Long verse (33 words)"]
-            }, {
               "type": "mark",
               "subtype": "verses",
               "atts": {
                 "number": "15"
               }
             },
-            "D’autres disaient: C’est Élie. Et d’autres disaient: C’est un prophète comme l’un des prophètes. ", {
+            "D’autres disaient: C’est Élie. Et d’autres disaient: C’est un prophète comme l’un des prophètes. ",
+            {
               "type": "mark",
               "subtype": "verses",
               "atts": {
                 "number": "16"
               }
             },
-            "Mais Hérode, en apprenant cela, disait: Ce Jean que j’ai fait décapiter, c’est lui qui est ressuscité. ", {
+            "Mais Hérode, en apprenant cela, disait: Ce Jean que j’ai fait décapiter, c’est lui qui est ressuscité. ",
+            {
               "type": "mark",
               "subtype": "verses",
               "atts": {
                 "number": "17"
               }
-            }, {
+            },
+            {
               "type": "graft",
               "subtype": "xref",
               "target": "MzJjZDgyODIt"
             },
-            "Car Hérode lui-même avait fait arrêter Jean, et l’avait fait lier en prison, à cause d’Hérodias, femme de Philippe, son frère, parce qu’il l’avait épousée, ", {
+            "Car Hérode lui-même avait fait arrêter Jean, et l’avait fait lier en prison, à cause d’Hérodias, femme de Philippe, son frère, parce qu’il l’avait épousée, ",
+            {
               "type": "mark",
               "subtype": "verses",
               "atts": {
                 "number": "18"
               }
             },
-            "et que Jean lui disait: ", {
+            "et que Jean lui disait: ",
+            {
               "type": "graft",
               "subtype": "xref",
               "target": "ODcxMGEyZWUt"
             },
-            "Il ne t’est pas permis d’avoir la femme de ton frère. ", {
+            "Il ne t’est pas permis d’avoir la femme de ton frère. ",
+            {
               "type": "mark",
               "subtype": "verses",
               "atts": {
                 "number": "19"
               }
             },
-            "Hérodias était irritée contre Jean, et voulait le faire mourir. ", {
+            "Hérodias était irritée contre Jean, et voulait le faire mourir. ",
+            {
               "type": "mark",
               "subtype": "verses",
               "atts": {
                 "number": "20"
               }
             },
-            "Mais elle ne le pouvait; car Hérode craignait Jean, le connaissant pour un homme ", {
+            "Mais elle ne le pouvait; car Hérode craignait Jean, le connaissant pour un homme ",
+            {
               "type": "graft",
               "subtype": "xref",
               "target": "ZTcxMjkyY2It"
             },
-            "juste et saint; il le protégeait, et, après l’avoir entendu, il était souvent perplexe, et l’écoutait avec plaisir. ", {
-              "type": "wrapper",
-              "subtype": "meta_content",
-              "meta_content": ["<== Long verse (34 words)"]
-            }, {
+            "juste et saint; il le protégeait, et, après l’avoir entendu, il était souvent perplexe, et l’écoutait avec plaisir. ",
+            {
               "type": "mark",
               "subtype": "verses",
               "atts": {
                 "number": "21"
               }
             },
-            "Cependant, un jour propice arriva, lorsque Hérode, à ", {
+            "Cependant, un jour propice arriva, lorsque Hérode, à ",
+            {
               "type": "graft",
               "subtype": "xref",
               "target": "YTRiYTkxOTQt"
             },
-            "l’anniversaire de sa naissance, donna un festin à ses grands, aux chefs militaires et aux principaux de la Galilée. ", {
+            "l’anniversaire de sa naissance, donna un festin à ses grands, aux chefs militaires et aux principaux de la Galilée. ",
+            {
               "type": "mark",
               "subtype": "verses",
               "atts": {
                 "number": "22"
               }
             },
-            "La fille d’Hérodias entra dans la salle; elle dansa, et plut à Hérode et à ses convives. Le roi dit à la jeune fille: Demande-moi ce que tu voudras, et je te le donnerai. ", {
-              "type": "wrapper",
-              "subtype": "meta_content",
-              "meta_content": ["<== Long verse (35 words)"]
-            }, {
+            "La fille d’Hérodias entra dans la salle; elle dansa, et plut à Hérode et à ses convives. Le roi dit à la jeune fille: Demande-moi ce que tu voudras, et je te le donnerai. ",
+            {
               "type": "mark",
               "subtype": "verses",
               "atts": {
                 "number": "23"
               }
-            }, {
+            },
+            {
               "type": "graft",
               "subtype": "xref",
               "target": "YTc4MTQzOTMt"
             },
-            "Il ajouta avec serment: Ce que tu me demanderas, je te le donnerai, fût-ce la moitié de mon royaume. ", {
+            "Il ajouta avec serment: Ce que tu me demanderas, je te le donnerai, fût-ce la moitié de mon royaume. ",
+            {
               "type": "mark",
               "subtype": "verses",
               "atts": {
                 "number": "24"
               }
             },
-            "Étant sortie, elle dit à sa mère: Que demanderai-je? Et sa mère répondit: La tête de Jean-Baptiste. ", {
+            "Étant sortie, elle dit à sa mère: Que demanderai-je? Et sa mère répondit: La tête de Jean-Baptiste. ",
+            {
               "type": "mark",
               "subtype": "verses",
               "atts": {
                 "number": "25"
               }
             },
-            "Elle s’empressa de rentrer aussitôt vers le roi, et lui fit cette demande: Je veux que tu me donnes à l’instant, sur un plat, la tête de Jean-Baptiste. ", {
+            "Elle s’empressa de rentrer aussitôt vers le roi, et lui fit cette demande: Je veux que tu me donnes à l’instant, sur un plat, la tête de Jean-Baptiste. ",
+            {
               "type": "mark",
               "subtype": "verses",
               "atts": {
                 "number": "26"
               }
             },
-            "Le roi fut attristé; mais, à cause de ses serments et des convives, il ne voulut pas lui faire un refus. ", {
+            "Le roi fut attristé; mais, à cause de ses serments et des convives, il ne voulut pas lui faire un refus. ",
+            {
               "type": "mark",
               "subtype": "verses",
               "atts": {
                 "number": "27"
               }
-            }, {
+            },
+            {
               "type": "graft",
               "subtype": "xref",
               "target": "YmEyYTNlOGUt"
             },
-            "Il envoya sur-le-champ un garde, avec ordre d’apporter la tête de Jean-Baptiste. ", {
+            "Il envoya sur-le-champ un garde, avec ordre d’apporter la tête de Jean-Baptiste. ",
+            {
               "type": "mark",
               "subtype": "verses",
               "atts": {
                 "number": "28"
               }
             },
-            "Le garde alla décapiter Jean dans la prison, et apporta la tête sur un plat. Il la donna à la jeune fille, et la jeune fille la donna à sa mère. ", {
-              "type": "wrapper",
-              "subtype": "meta_content",
-              "meta_content": ["<== Long verse (32 words)"]
-            }, {
+            "Le garde alla décapiter Jean dans la prison, et apporta la tête sur un plat. Il la donna à la jeune fille, et la jeune fille la donna à sa mère. ",
+            {
               "type": "mark",
               "subtype": "verses",
               "atts": {
@@ -3124,15 +3562,18 @@
             },
             "Les disciples de Jean, ayant appris cela, vinrent prendre son corps, et le mirent dans un sépulcre."
           ]
-        }, {
+        },
+        {
           "type": "graft",
           "subtype": "heading",
           "target": "YTYyMWRkNmYt"
-        }, {
+        },
+        {
           "type": "graft",
           "subtype": "heading",
           "target": "ZTBlNjNlOTUt"
-        }, {
+        },
+        {
           "type": "paragraph",
           "subtype": "usfm:p",
           "content": [
@@ -3156,164 +3597,179 @@
                 "number": "31"
               }
             },
-            "Jésus leur dit: ", {
+            "Jésus leur dit: ",
+            {
               "type": "wrapper",
-              "subtype": "usfm:wj",
-              "content": ["Venez à l’écart dans un lieu désert, et reposez-vous un peu."]
+              "subtype": "usfm:span",
+              "content": [
+                "Venez à l’écart dans un lieu désert, et reposez-vous un peu."
+              ]
             },
-            " Car il y avait beaucoup d’allants et de venants, ", {
+            " Car il y avait beaucoup d’allants et de venants, ",
+            {
               "type": "graft",
               "subtype": "xref",
               "target": "MjZkMTRjOGYt"
             },
-            "et ils n’avaient même pas le temps de manger. ", {
-              "type": "wrapper",
-              "subtype": "meta_content",
-              "meta_content": ["<== Long verse (36 words)"]
-            }, {
+            "et ils n’avaient même pas le temps de manger. ",
+            {
               "type": "mark",
               "subtype": "verses",
               "atts": {
                 "number": "32"
               }
-            }, {
+            },
+            {
               "type": "graft",
               "subtype": "xref",
               "target": "YzZkMmU1ODIt"
             },
-            "Ils partirent donc dans une barque, pour aller à l’écart dans un lieu désert. ", {
+            "Ils partirent donc dans une barque, pour aller à l’écart dans un lieu désert. ",
+            {
               "type": "mark",
               "subtype": "verses",
               "atts": {
                 "number": "33"
               }
             },
-            "Beaucoup de gens les virent s’en aller et les reconnurent, et de toutes les villes on accourut à pied et on les devança au lieu où ils se rendaient. ", {
-              "type": "wrapper",
-              "subtype": "meta_content",
-              "meta_content": ["<== Long verse (30 words)"]
-            }, {
+            "Beaucoup de gens les virent s’en aller et les reconnurent, et de toutes les villes on accourut à pied et on les devança au lieu où ils se rendaient. ",
+            {
               "type": "mark",
               "subtype": "verses",
               "atts": {
                 "number": "34"
               }
             },
-            "Quand il sortit de la barque, ", {
+            "Quand il sortit de la barque, ",
+            {
               "type": "graft",
               "subtype": "xref",
               "target": "NGYyNGExZWEt"
             },
-            "Jésus vit une grande foule, et fut ému de compassion pour eux, ", {
+            "Jésus vit une grande foule, et fut ému de compassion pour eux, ",
+            {
               "type": "graft",
               "subtype": "xref",
               "target": "ZmFiZDViYWQt"
             },
-            "parce qu’ils étaient comme des brebis qui n’ont point de berger; ", {
+            "parce qu’ils étaient comme des brebis qui n’ont point de berger; ",
+            {
               "type": "graft",
               "subtype": "xref",
               "target": "OTU5MGU5MjMt"
             },
-            "et il se mit à leur enseigner beaucoup de choses. ", {
-              "type": "wrapper",
-              "subtype": "meta_content",
-              "meta_content": ["<== Long verse (43 words)"]
-            }, {
+            "et il se mit à leur enseigner beaucoup de choses. ",
+            {
               "type": "mark",
               "subtype": "verses",
               "atts": {
                 "number": "35"
               }
-            }, {
+            },
+            {
               "type": "graft",
               "subtype": "xref",
               "target": "N2NlNzdkNjgt"
             },
-            "Comme l’heure était déjà avancée, ses disciples s’approchèrent de lui, et dirent: Ce lieu est désert, et l’heure est déjà avancée; ", {
+            "Comme l’heure était déjà avancée, ses disciples s’approchèrent de lui, et dirent: Ce lieu est désert, et l’heure est déjà avancée; ",
+            {
               "type": "mark",
               "subtype": "verses",
               "atts": {
                 "number": "36"
               }
             },
-            "renvoie-les, afin qu’ils aillent dans les campagnes et dans les villages des environs, pour s’acheter de quoi manger. ", {
+            "renvoie-les, afin qu’ils aillent dans les campagnes et dans les villages des environs, pour s’acheter de quoi manger. ",
+            {
               "type": "mark",
               "subtype": "verses",
               "atts": {
                 "number": "37"
               }
             },
-            "Jésus leur répondit: ", {
+            "Jésus leur répondit: ",
+            {
               "type": "wrapper",
-              "subtype": "usfm:wj",
-              "content": ["Donnez-leur vous-mêmes à manger."]
+              "subtype": "usfm:span",
+              "content": [
+                "Donnez-leur vous-mêmes à manger."
+              ]
             },
-            " Mais ils lui dirent: Irions-nous acheter des pains pour deux cents deniers, et leur donnerions-nous à manger? ", {
+            " Mais ils lui dirent: Irions-nous acheter des pains pour deux cents deniers, et leur donnerions-nous à manger? ",
+            {
               "type": "mark",
               "subtype": "verses",
               "atts": {
                 "number": "38"
               }
             },
-            "Et il leur dit: ", {
+            "Et il leur dit: ",
+            {
               "type": "wrapper",
-              "subtype": "usfm:wj",
-              "content": ["Combien avez-vous de pains? Allez voir."]
-            }, {
+              "subtype": "usfm:span",
+              "content": [
+                "Combien avez-vous de pains? Allez voir."
+              ]
+            },
+            {
               "type": "graft",
               "subtype": "xref",
               "target": "NjFlOTc4NjMt"
             },
-            "Ils s’en assurèrent, et répondirent: Cinq, et deux poissons. ", {
+            "Ils s’en assurèrent, et répondirent: Cinq, et deux poissons. ",
+            {
               "type": "mark",
               "subtype": "verses",
               "atts": {
                 "number": "39"
               }
             },
-            "Alors il leur commanda de les faire tous asseoir par groupes sur l’herbe verte, ", {
+            "Alors il leur commanda de les faire tous asseoir par groupes sur l’herbe verte, ",
+            {
               "type": "mark",
               "subtype": "verses",
               "atts": {
                 "number": "40"
               }
             },
-            "et ils s’assirent par rangées de cent et de cinquante. ", {
+            "et ils s’assirent par rangées de cent et de cinquante. ",
+            {
               "type": "mark",
               "subtype": "verses",
               "atts": {
                 "number": "41"
               }
             },
-            "Il prit les cinq pains et les deux poissons et, ", {
+            "Il prit les cinq pains et les deux poissons et, ",
+            {
               "type": "graft",
               "subtype": "xref",
               "target": "YTcyMDNhNjYt"
             },
-            "levant les yeux vers le ciel, ", {
+            "levant les yeux vers le ciel, ",
+            {
               "type": "graft",
               "subtype": "xref",
               "target": "ZmY1MzY1ZTEt"
             },
-            "il rendit grâces. Puis, il rompit les pains, et les donna aux disciples, afin qu’ils les distribuassent à la foule. Il partagea aussi les deux poissons entre tous. ", {
-              "type": "wrapper",
-              "subtype": "meta_content",
-              "meta_content": ["<== Long verse (47 words)"]
-            }, {
+            "il rendit grâces. Puis, il rompit les pains, et les donna aux disciples, afin qu’ils les distribuassent à la foule. Il partagea aussi les deux poissons entre tous. ",
+            {
               "type": "mark",
               "subtype": "verses",
               "atts": {
                 "number": "42"
               }
             },
-            "Tous mangèrent et furent rassasiés, ", {
+            "Tous mangèrent et furent rassasiés, ",
+            {
               "type": "mark",
               "subtype": "verses",
               "atts": {
                 "number": "43"
               }
             },
-            "et l’on emporta douze paniers pleins de morceaux de pain et de ce qui restait des poissons. ", {
+            "et l’on emporta douze paniers pleins de morceaux de pain et de ce qui restait des poissons. ",
+            {
               "type": "mark",
               "subtype": "verses",
               "atts": {
@@ -3322,15 +3778,18 @@
             },
             "Ceux qui avaient mangé les pains étaient cinq mille hommes."
           ]
-        }, {
+        },
+        {
           "type": "graft",
           "subtype": "heading",
           "target": "ZjU2NTI0YWYt"
-        }, {
+        },
+        {
           "type": "graft",
           "subtype": "heading",
           "target": "MGUzYWYwMWUt"
-        }, {
+        },
+        {
           "type": "paragraph",
           "subtype": "usfm:p",
           "content": [
@@ -3353,60 +3812,67 @@
               "atts": {
                 "number": "46"
               }
-            }, {
+            },
+            {
               "type": "graft",
               "subtype": "xref",
               "target": "MmViMjI3YmUt"
             },
-            "Quand il l’eut renvoyée, il s’en alla sur la montagne, pour prier. ", {
+            "Quand il l’eut renvoyée, il s’en alla sur la montagne, pour prier. ",
+            {
               "type": "mark",
               "subtype": "verses",
               "atts": {
                 "number": "47"
               }
-            }, {
+            },
+            {
               "type": "graft",
               "subtype": "xref",
               "target": "YzNlMzE1MzIt"
             },
-            "Le soir étant venu, la barque était au milieu de la mer, et Jésus était seul à terre. ", {
+            "Le soir étant venu, la barque était au milieu de la mer, et Jésus était seul à terre. ",
+            {
               "type": "mark",
               "subtype": "verses",
               "atts": {
                 "number": "48"
               }
             },
-            "Il vit qu’ils avaient beaucoup de peine à ramer; car le vent leur était contraire. A la quatrième veille de la nuit environ, il alla vers eux, marchant sur la mer, et il voulait les dépasser. ", {
-              "type": "wrapper",
-              "subtype": "meta_content",
-              "meta_content": ["<== Long verse (37 words)"]
-            }, {
+            "Il vit qu’ils avaient beaucoup de peine à ramer; car le vent leur était contraire. A la quatrième veille de la nuit environ, il alla vers eux, marchant sur la mer, et il voulait les dépasser. ",
+            {
               "type": "mark",
               "subtype": "verses",
               "atts": {
                 "number": "49"
               }
             },
-            "Quand ils le virent marcher sur la mer, ils crurent que c’était un fantôme, et ils poussèrent des cris; ", {
+            "Quand ils le virent marcher sur la mer, ils crurent que c’était un fantôme, et ils poussèrent des cris; ",
+            {
               "type": "mark",
               "subtype": "verses",
               "atts": {
                 "number": "50"
               }
             },
-            "car ils le voyaient tous, et ils étaient troublés. Aussitôt Jésus leur parla, et leur dit: ", {
+            "car ils le voyaient tous, et ils étaient troublés. Aussitôt Jésus leur parla, et leur dit: ",
+            {
               "type": "wrapper",
-              "subtype": "usfm:wj",
-              "content": ["Rassurez-vous, c’est moi, n’ayez pas peur!"]
+              "subtype": "usfm:span",
+              "content": [
+                "Rassurez-vous, c’est moi, n’ayez pas peur!"
+              ]
             },
-            " ", {
+            " ",
+            {
               "type": "mark",
               "subtype": "verses",
               "atts": {
                 "number": "51"
               }
             },
-            "Puis il monta vers eux dans la barque, et le vent cessa. Ils furent en eux-mêmes tout stupéfaits et remplis d’étonnement; ", {
+            "Puis il monta vers eux dans la barque, et le vent cessa. Ils furent en eux-mêmes tout stupéfaits et remplis d’étonnement; ",
+            {
               "type": "mark",
               "subtype": "verses",
               "atts": {
@@ -3415,15 +3881,18 @@
             },
             "car ils n’avaient pas compris le miracle des pains, parce que leur cœur était endurci."
           ]
-        }, {
+        },
+        {
           "type": "graft",
           "subtype": "heading",
           "target": "ODVmN2M1ZWMt"
-        }, {
+        },
+        {
           "type": "graft",
           "subtype": "heading",
           "target": "ZWUyMDQ2YTkt"
-        }, {
+        },
+        {
           "type": "paragraph",
           "subtype": "usfm:p",
           "content": [
@@ -3447,14 +3916,16 @@
                 "number": "54"
               }
             },
-            "Quand ils furent sortis de la barque, les gens, ayant aussitôt reconnu Jésus, ", {
+            "Quand ils furent sortis de la barque, les gens, ayant aussitôt reconnu Jésus, ",
+            {
               "type": "mark",
               "subtype": "verses",
               "atts": {
                 "number": "55"
               }
             },
-            "parcoururent tous les environs, et l’on se mit à apporter les malades sur des lits, partout où l’on apprenait qu’il était. ", {
+            "parcoururent tous les environs, et l’on se mit à apporter les malades sur des lits, partout où l’on apprenait qu’il était. ",
+            {
               "type": "mark",
               "subtype": "verses",
               "atts": {
@@ -3463,15 +3934,18 @@
             },
             "En quelque lieu qu’il arrivât, dans les villages, dans les villes ou dans les campagnes, on mettait les malades sur les places publiques, et on le priait de leur permettre seulement de toucher le bord de son vêtement. Et tous ceux qui le touchaient étaient guéris."
           ]
-        }, {
+        },
+        {
           "type": "graft",
           "subtype": "heading",
           "target": "MzkxMTk4MmQt"
-        }, {
+        },
+        {
           "type": "graft",
           "subtype": "heading",
           "target": "M2RhOTc0YTIt"
-        }, {
+        },
+        {
           "type": "paragraph",
           "subtype": "usfm:p",
           "content": [
@@ -3481,11 +3955,6 @@
               "atts": {
                 "number": "7"
               }
-            },
-            {
-              "type": "wrapper",
-              "subtype": "meta_content",
-              "meta_content": ["<== Long verse (46 words)"]
             },
             {
               "type": "mark",
@@ -3499,52 +3968,57 @@
               "subtype": "xref",
               "target": "ODNiOWRlYzYt"
             },
-            "Les pharisiens et quelques scribes, venus de Jérusalem, s’assemblèrent auprès de Jésus. ", {
+            "Les pharisiens et quelques scribes, venus de Jérusalem, s’assemblèrent auprès de Jésus. ",
+            {
               "type": "mark",
               "subtype": "verses",
               "atts": {
                 "number": "2"
               }
             },
-            "Ils virent quelques-uns de ses disciples prendre leurs repas avec des mains impures, c’est-à-dire, non lavées. ", {
+            "Ils virent quelques-uns de ses disciples prendre leurs repas avec des mains impures, c’est-à-dire, non lavées. ",
+            {
               "type": "mark",
               "subtype": "verses",
               "atts": {
                 "number": "3"
               }
             },
-            "Or, les pharisiens et tous les Juifs ne mangent pas sans s’être lavé soigneusement les mains, conformément à la tradition des anciens; ", {
+            "Or, les pharisiens et tous les Juifs ne mangent pas sans s’être lavé soigneusement les mains, conformément à la tradition des anciens; ",
+            {
               "type": "mark",
               "subtype": "verses",
               "atts": {
                 "number": "4"
               }
             },
-            "et, quand ils reviennent de la place publique, ils ne mangent qu’après s’être purifiés. Ils ont encore beaucoup d’autres observances traditionnelles, comme le lavage des coupes, des cruches et des vases d’airain. ", {
-              "type": "wrapper",
-              "subtype": "meta_content",
-              "meta_content": ["<== Long verse (33 words)"]
-            }, {
+            "et, quand ils reviennent de la place publique, ils ne mangent qu’après s’être purifiés. Ils ont encore beaucoup d’autres observances traditionnelles, comme le lavage des coupes, des cruches et des vases d’airain. ",
+            {
               "type": "mark",
               "subtype": "verses",
               "atts": {
                 "number": "5"
               }
             },
-            "Et les pharisiens et les scribes lui demandèrent: Pourquoi tes disciples ne suivent-ils pas la tradition des anciens, mais prennent-ils leurs repas avec des mains impures? ", {
+            "Et les pharisiens et les scribes lui demandèrent: Pourquoi tes disciples ne suivent-ils pas la tradition des anciens, mais prennent-ils leurs repas avec des mains impures? ",
+            {
               "type": "mark",
               "subtype": "verses",
               "atts": {
                 "number": "6"
               }
             },
-            "Jésus leur répondit: ", {
+            "Jésus leur répondit: ",
+            {
               "type": "wrapper",
-              "subtype": "usfm:wj",
-              "content": ["Hypocrites, Ésaïe a bien prophétisé sur vous, ainsi qu’il est écrit:"]
+              "subtype": "usfm:span",
+              "content": [
+                "Hypocrites, Ésaïe a bien prophétisé sur vous, ainsi qu’il est écrit:"
+              ]
             }
           ]
-        }, {
+        },
+        {
           "type": "paragraph",
           "subtype": "usfm:q",
           "content": [
@@ -3552,23 +4026,30 @@
               "type": "graft",
               "subtype": "xref",
               "target": "MzVkN2E0YzIt"
-            }, {
+            },
+            {
               "type": "wrapper",
-              "subtype": "usfm:wj",
-              "content": ["Ce peuple m’honore des lèvres,"]
+              "subtype": "usfm:span",
+              "content": [
+                "Ce peuple m’honore des lèvres,"
+              ]
             }
           ]
-        }, {
+        },
+        {
           "type": "paragraph",
           "subtype": "usfm:q",
           "content": [
             {
               "type": "wrapper",
-              "subtype": "usfm:wj",
-              "content": ["Mais son cœur est éloigné de moi."]
+              "subtype": "usfm:span",
+              "content": [
+                "Mais son cœur est éloigné de moi."
+              ]
             }
           ]
-        }, {
+        },
+        {
           "type": "paragraph",
           "subtype": "usfm:q",
           "content": [
@@ -3578,27 +4059,35 @@
               "atts": {
                 "number": "7"
               }
-            }, {
+            },
+            {
               "type": "graft",
               "subtype": "xref",
               "target": "ZWJjODFjZDAt"
-            }, {
+            },
+            {
               "type": "wrapper",
-              "subtype": "usfm:wj",
-              "content": ["C’est en vain qu’ils m’honorent,"]
+              "subtype": "usfm:span",
+              "content": [
+                "C’est en vain qu’ils m’honorent,"
+              ]
             }
           ]
-        }, {
+        },
+        {
           "type": "paragraph",
           "subtype": "usfm:q",
           "content": [
             {
               "type": "wrapper",
-              "subtype": "usfm:wj",
-              "content": ["En donnant des préceptes qui sont des commandements d’hommes."]
+              "subtype": "usfm:span",
+              "content": [
+                "En donnant des préceptes qui sont des commandements d’hommes."
+              ]
             }
           ]
-        }, {
+        },
+        {
           "type": "paragraph",
           "subtype": "usfm:m",
           "content": [
@@ -3611,8 +4100,10 @@
             },
             {
               "type": "wrapper",
-              "subtype": "usfm:wj",
-              "content": ["Vous abandonnez le commandement de Dieu, et vous observez la tradition des hommes."]
+              "subtype": "usfm:span",
+              "content": [
+                "Vous abandonnez le commandement de Dieu, et vous observez la tradition des hommes."
+              ]
             },
             " ",
             {
@@ -3622,13 +4113,17 @@
                 "number": "9"
               }
             },
-            "Il leur dit encore: ", {
+            "Il leur dit encore: ",
+            {
               "type": "wrapper",
-              "subtype": "usfm:wj",
-              "content": ["Vous anéantissez fort bien le commandement de Dieu, pour garder votre tradition."]
+              "subtype": "usfm:span",
+              "content": [
+                "Vous anéantissez fort bien le commandement de Dieu, pour garder votre tradition."
+              ]
             }
           ]
-        }, {
+        },
+        {
           "type": "paragraph",
           "subtype": "usfm:p",
           "content": [
@@ -3641,8 +4136,10 @@
             },
             {
               "type": "wrapper",
-              "subtype": "usfm:wj",
-              "content": ["Car Moïse a dit:"]
+              "subtype": "usfm:span",
+              "content": [
+                "Car Moïse a dit:"
+              ]
             },
             {
               "type": "graft",
@@ -3651,60 +4148,81 @@
             },
             {
               "type": "wrapper",
-              "subtype": "usfm:wj",
-              "content": ["Honore ton père et ta mère; et:"]
-            }, {
+              "subtype": "usfm:span",
+              "content": [
+                "Honore ton père et ta mère; et:"
+              ]
+            },
+            {
               "type": "graft",
               "subtype": "xref",
               "target": "ZjMwYjFiMmIt"
-            }, {
-              "type": "wrapper",
-              "subtype": "usfm:wj",
-              "content": ["Celui qui maudira son père ou sa mère sera puni de mort."]
             },
-            " ", {
+            {
+              "type": "wrapper",
+              "subtype": "usfm:span",
+              "content": [
+                "Celui qui maudira son père ou sa mère sera puni de mort."
+              ]
+            },
+            " ",
+            {
               "type": "mark",
               "subtype": "verses",
               "atts": {
                 "number": "11"
               }
-            }, {
-              "type": "wrapper",
-              "subtype": "usfm:wj",
-              "content": ["Mais vous, vous dites: Si un homme dit à son père ou à sa mère: Ce dont j’aurais pu t’assister est corban, c’est-à-dire, une offrande à Dieu,"]
             },
-            " ", {
+            {
+              "type": "wrapper",
+              "subtype": "usfm:span",
+              "content": [
+                "Mais vous, vous dites: Si un homme dit à son père ou à sa mère: Ce dont j’aurais pu t’assister est corban, c’est-à-dire, une offrande à Dieu,"
+              ]
+            },
+            " ",
+            {
               "type": "mark",
               "subtype": "verses",
               "atts": {
                 "number": "12"
               }
-            }, {
-              "type": "wrapper",
-              "subtype": "usfm:wj",
-              "content": ["vous ne le laissez plus rien faire pour son père ou pour sa mère,"]
             },
-            " ", {
+            {
+              "type": "wrapper",
+              "subtype": "usfm:span",
+              "content": [
+                "vous ne le laissez plus rien faire pour son père ou pour sa mère,"
+              ]
+            },
+            " ",
+            {
               "type": "mark",
               "subtype": "verses",
               "atts": {
                 "number": "13"
               }
-            }, {
+            },
+            {
               "type": "graft",
               "subtype": "xref",
               "target": "MjhhMTg4MTMt"
-            }, {
+            },
+            {
               "type": "wrapper",
-              "subtype": "usfm:wj",
-              "content": ["annulant ainsi la parole de Dieu par votre tradition, que vous avez établie. Et vous faites beaucoup d’autres choses semblables."]
+              "subtype": "usfm:span",
+              "content": [
+                "annulant ainsi la parole de Dieu par votre tradition, que vous avez établie. Et vous faites beaucoup d’autres choses semblables."
+              ]
             }
           ]
-        }, {
+        },
+        {
           "type": "graft",
           "subtype": "heading",
           "target": "MzJjMGYyOTQt"
-        }, {
+        },
+        {
           "type": "paragraph",
           "subtype": "usfm:p",
           "content": [
@@ -3714,18 +4232,23 @@
               "atts": {
                 "number": "14"
               }
-            }, {
+            },
+            {
               "type": "graft",
               "subtype": "xref",
               "target": "YTI1ZTVhMjEt"
             },
-            "Ensuite, ayant de nouveau appelé la foule à lui, il lui dit: ", {
+            "Ensuite, ayant de nouveau appelé la foule à lui, il lui dit: ",
+            {
               "type": "wrapper",
-              "subtype": "usfm:wj",
-              "content": ["Écoutez-moi tous, et comprenez."]
+              "subtype": "usfm:span",
+              "content": [
+                "Écoutez-moi tous, et comprenez."
+              ]
             }
           ]
-        }, {
+        },
+        {
           "type": "paragraph",
           "subtype": "usfm:p",
           "content": [
@@ -3743,45 +4266,58 @@
             },
             {
               "type": "wrapper",
-              "subtype": "usfm:wj",
-              "content": ["Il n’est hors de l’homme rien qui, entrant en lui, puisse le souiller; mais ce qui sort de l’homme, c’est ce qui le souille."]
+              "subtype": "usfm:span",
+              "content": [
+                "Il n’est hors de l’homme rien qui, entrant en lui, puisse le souiller; mais ce qui sort de l’homme, c’est ce qui le souille."
+              ]
             },
-            " ", {
+            " ",
+            {
               "type": "mark",
               "subtype": "verses",
               "atts": {
                 "number": "16"
               }
-            }, {
-              "type": "wrapper",
-              "subtype": "usfm:wj",
-              "content": ["Si quelqu’un a des oreilles pour entendre, qu’il entende."]
             },
-            " ", {
+            {
+              "type": "wrapper",
+              "subtype": "usfm:span",
+              "content": [
+                "Si quelqu’un a des oreilles pour entendre, qu’il entende."
+              ]
+            },
+            " ",
+            {
               "type": "mark",
               "subtype": "verses",
               "atts": {
                 "number": "17"
               }
-            }, {
+            },
+            {
               "type": "graft",
               "subtype": "xref",
               "target": "MmEwZTFhMDYt"
             },
-            "Lorsqu’il fut entré dans la maison, loin de la foule, ses disciples l’interrogèrent sur cette parabole. ", {
+            "Lorsqu’il fut entré dans la maison, loin de la foule, ses disciples l’interrogèrent sur cette parabole. ",
+            {
               "type": "mark",
               "subtype": "verses",
               "atts": {
                 "number": "18"
               }
             },
-            "Il leur dit: ", {
+            "Il leur dit: ",
+            {
               "type": "wrapper",
-              "subtype": "usfm:wj",
-              "content": ["Vous aussi, êtes-vous donc sans intelligence? Ne comprenez-vous pas que rien de ce qui du dehors entre dans l’homme ne peut le souiller?"]
+              "subtype": "usfm:span",
+              "content": [
+                "Vous aussi, êtes-vous donc sans intelligence? Ne comprenez-vous pas que rien de ce qui du dehors entre dans l’homme ne peut le souiller?"
+              ]
             }
           ]
-        }, {
+        },
+        {
           "type": "paragraph",
           "subtype": "usfm:p",
           "content": [
@@ -3794,8 +4330,10 @@
             },
             {
               "type": "wrapper",
-              "subtype": "usfm:wj",
-              "content": ["Car cela n’entre pas dans son cœur, mais dans son ventre, puis s’en va dans les lieux secrets, qui purifient tous les aliments."]
+              "subtype": "usfm:span",
+              "content": [
+                "Car cela n’entre pas dans son cœur, mais dans son ventre, puis s’en va dans les lieux secrets, qui purifient tous les aliments."
+              ]
             },
             " ",
             {
@@ -3805,13 +4343,17 @@
                 "number": "20"
               }
             },
-            "Il dit encore: ", {
+            "Il dit encore: ",
+            {
               "type": "wrapper",
-              "subtype": "usfm:wj",
-              "content": ["Ce qui sort de l’homme, c’est ce qui souille l’homme."]
+              "subtype": "usfm:span",
+              "content": [
+                "Ce qui sort de l’homme, c’est ce qui souille l’homme."
+              ]
             }
           ]
-        }, {
+        },
+        {
           "type": "paragraph",
           "subtype": "usfm:p",
           "content": [
@@ -3829,41 +4371,54 @@
             },
             {
               "type": "wrapper",
-              "subtype": "usfm:wj",
-              "content": ["Car c’est du dedans, c’est du cœur des hommes, que sortent les mauvaises pensées, les adultères, les impudicités, les meurtres,"]
+              "subtype": "usfm:span",
+              "content": [
+                "Car c’est du dedans, c’est du cœur des hommes, que sortent les mauvaises pensées, les adultères, les impudicités, les meurtres,"
+              ]
             },
-            " ", {
+            " ",
+            {
               "type": "mark",
               "subtype": "verses",
               "atts": {
                 "number": "22"
               }
-            }, {
-              "type": "wrapper",
-              "subtype": "usfm:wj",
-              "content": ["les vols, les cupidités, les méchancetés, la fraude, le dérèglement, le regard envieux, la calomnie, l’orgueil, la folie."]
             },
-            " ", {
+            {
+              "type": "wrapper",
+              "subtype": "usfm:span",
+              "content": [
+                "les vols, les cupidités, les méchancetés, la fraude, le dérèglement, le regard envieux, la calomnie, l’orgueil, la folie."
+              ]
+            },
+            " ",
+            {
               "type": "mark",
               "subtype": "verses",
               "atts": {
                 "number": "23"
               }
-            }, {
+            },
+            {
               "type": "wrapper",
-              "subtype": "usfm:wj",
-              "content": ["Toutes ces choses mauvaises sortent du dedans, et souillent l’homme."]
+              "subtype": "usfm:span",
+              "content": [
+                "Toutes ces choses mauvaises sortent du dedans, et souillent l’homme."
+              ]
             }
           ]
-        }, {
+        },
+        {
           "type": "graft",
           "subtype": "heading",
           "target": "ZTk2ZDRlNjYt"
-        }, {
+        },
+        {
           "type": "graft",
           "subtype": "heading",
           "target": "NDJmNjlhZGQt"
-        }, {
+        },
+        {
           "type": "paragraph",
           "subtype": "usfm:p",
           "content": [
@@ -3881,17 +4436,14 @@
             },
             "Jésus, étant parti de là, s’en alla dans le territoire de Tyr et de Sidon. Il entra dans une maison, désirant que personne ne le sût; mais il ne put rester caché. ",
             {
-              "type": "wrapper",
-              "subtype": "meta_content",
-              "meta_content": ["<== Long verse (33 words)"]
-            }, {
               "type": "mark",
               "subtype": "verses",
               "atts": {
                 "number": "25"
               }
             },
-            "Car une femme, dont la fille était possédée d’un esprit impur, entendit parler de lui, et vint se jeter à ses pieds. ", {
+            "Car une femme, dont la fille était possédée d’un esprit impur, entendit parler de lui, et vint se jeter à ses pieds. ",
+            {
               "type": "mark",
               "subtype": "verses",
               "atts": {
@@ -3900,7 +4452,8 @@
             },
             "Cette femme était grecque, syro-phénicienne d’origine. Elle le pria de chasser le démon hors de sa fille. Jésus lui dit:"
           ]
-        }, {
+        },
+        {
           "type": "paragraph",
           "subtype": "usfm:p",
           "content": [
@@ -3913,8 +4466,10 @@
             },
             {
               "type": "wrapper",
-              "subtype": "usfm:wj",
-              "content": ["Laisse d’abord les enfants se rassasier; car il n’est pas bien de prendre le pain des enfants, et de le jeter aux petits chiens."]
+              "subtype": "usfm:span",
+              "content": [
+                "Laisse d’abord les enfants se rassasier; car il n’est pas bien de prendre le pain des enfants, et de le jeter aux petits chiens."
+              ]
             },
             " ",
             {
@@ -3924,19 +4479,24 @@
                 "number": "28"
               }
             },
-            "Oui, Seigneur, lui répondit-elle, mais les petits chiens, sous la table, mangent les miettes des enfants. ", {
+            "Oui, Seigneur, lui répondit-elle, mais les petits chiens, sous la table, mangent les miettes des enfants. ",
+            {
               "type": "mark",
               "subtype": "verses",
               "atts": {
                 "number": "29"
               }
             },
-            "Alors il lui dit: ", {
+            "Alors il lui dit: ",
+            {
               "type": "wrapper",
-              "subtype": "usfm:wj",
-              "content": ["à cause de cette parole, va, le démon est sorti de ta fille."]
+              "subtype": "usfm:span",
+              "content": [
+                "à cause de cette parole, va, le démon est sorti de ta fille."
+              ]
             },
-            " ", {
+            " ",
+            {
               "type": "mark",
               "subtype": "verses",
               "atts": {
@@ -3945,15 +4505,18 @@
             },
             "Et, quand elle rentra dans sa maison, elle trouva l’enfant couchée sur le lit, le démon étant sorti."
           ]
-        }, {
+        },
+        {
           "type": "graft",
           "subtype": "heading",
           "target": "ZjQwYzdjNWIt"
-        }, {
+        },
+        {
           "type": "graft",
           "subtype": "heading",
           "target": "YmNhYjgyNjct"
-        }, {
+        },
+        {
           "type": "paragraph",
           "subtype": "usfm:p",
           "content": [
@@ -3976,72 +4539,88 @@
               "atts": {
                 "number": "32"
               }
-            }, {
+            },
+            {
               "type": "graft",
               "subtype": "xref",
               "target": "OGY5YjlhZjgt"
             },
-            "On lui amena un sourd, qui avait de la difficulté à parler, et on le pria de lui imposer les mains. ", {
+            "On lui amena un sourd, qui avait de la difficulté à parler, et on le pria de lui imposer les mains. ",
+            {
               "type": "mark",
               "subtype": "verses",
               "atts": {
                 "number": "33"
               }
             },
-            "Il le prit à part loin de la foule, lui mit les doigts dans les oreilles, et lui toucha la langue avec sa propre salive; ", {
+            "Il le prit à part loin de la foule, lui mit les doigts dans les oreilles, et lui toucha la langue avec sa propre salive; ",
+            {
               "type": "mark",
               "subtype": "verses",
               "atts": {
                 "number": "34"
               }
             },
-            "puis, levant les yeux au ciel, il soupira, et dit: ", {
+            "puis, levant les yeux au ciel, il soupira, et dit: ",
+            {
               "type": "wrapper",
-              "subtype": "usfm:wj",
-              "content": ["Éphphatha,"]
+              "subtype": "usfm:span",
+              "content": [
+                "Éphphatha,"
+              ]
             },
-            " c’est-à-dire, ", {
+            " c’est-à-dire, ",
+            {
               "type": "wrapper",
-              "subtype": "usfm:wj",
-              "content": ["ouvre-toi."]
+              "subtype": "usfm:span",
+              "content": [
+                "ouvre-toi."
+              ]
             },
-            " ", {
+            " ",
+            {
               "type": "mark",
               "subtype": "verses",
               "atts": {
                 "number": "35"
               }
             },
-            "Aussitôt ses oreilles s’ouvrirent, sa langue se délia, et il parla très bien. ", {
+            "Aussitôt ses oreilles s’ouvrirent, sa langue se délia, et il parla très bien. ",
+            {
               "type": "mark",
               "subtype": "verses",
               "atts": {
                 "number": "36"
               }
             },
-            "Jésus leur recommanda de n’en parler à personne; mais plus il le leur recommanda, plus ils le publièrent. ", {
+            "Jésus leur recommanda de n’en parler à personne; mais plus il le leur recommanda, plus ils le publièrent. ",
+            {
               "type": "mark",
               "subtype": "verses",
               "atts": {
                 "number": "37"
               }
             },
-            "Ils étaient dans le plus grand étonnement, et disaient: ", {
+            "Ils étaient dans le plus grand étonnement, et disaient: ",
+            {
               "type": "graft",
               "subtype": "xref",
               "target": "ZGNiYzM0OWUt"
             },
             "Il fait tout à merveille; même il fait entendre les sourds, et parler les muets."
           ]
-        }, {
+        },
+        {
           "type": "graft",
           "subtype": "heading",
           "target": "ZGYxMjU5NWMt"
-        }, {
+        },
+        {
           "type": "graft",
           "subtype": "heading",
           "target": "ZGVlNzIzODkt"
-        }, {
+        },
+        {
           "type": "paragraph",
           "subtype": "usfm:p",
           "content": [
@@ -4051,20 +4630,23 @@
               "atts": {
                 "number": "8"
               }
-            }, {
+            },
+            {
               "type": "mark",
               "subtype": "verses",
               "atts": {
                 "number": "1"
               }
-            }, {
+            },
+            {
               "type": "graft",
               "subtype": "xref",
               "target": "NzA3MDM5Yzkt"
             },
             "En ces jours-là, une foule nombreuse s’étant de nouveau réunie et n’ayant pas de quoi manger, Jésus appela les disciples, et leur dit:"
           ]
-        }, {
+        },
+        {
           "type": "paragraph",
           "subtype": "usfm:p",
           "content": [
@@ -4077,8 +4659,10 @@
             },
             {
               "type": "wrapper",
-              "subtype": "usfm:wj",
-              "content": ["Je suis ému de compassion pour cette foule; car voilà trois jours qu’ils sont près de moi, et ils n’ont rien à manger."]
+              "subtype": "usfm:span",
+              "content": [
+                "Je suis ému de compassion pour cette foule; car voilà trois jours qu’ils sont près de moi, et ils n’ont rien à manger."
+              ]
             },
             " ",
             {
@@ -4087,56 +4671,64 @@
               "atts": {
                 "number": "3"
               }
-            }, {
-              "type": "wrapper",
-              "subtype": "usfm:wj",
-              "content": ["Si je les renvoie chez eux à jeun, les forces leur manqueront en chemin; car quelques-uns d’entre eux sont venus de loin."]
             },
-            " ", {
+            {
+              "type": "wrapper",
+              "subtype": "usfm:span",
+              "content": [
+                "Si je les renvoie chez eux à jeun, les forces leur manqueront en chemin; car quelques-uns d’entre eux sont venus de loin."
+              ]
+            },
+            " ",
+            {
               "type": "mark",
               "subtype": "verses",
               "atts": {
                 "number": "4"
               }
             },
-            "Ses disciples lui répondirent: Comment pourrait-on les rassasier de pains, ici, dans un lieu désert? ", {
+            "Ses disciples lui répondirent: Comment pourrait-on les rassasier de pains, ici, dans un lieu désert? ",
+            {
               "type": "mark",
               "subtype": "verses",
               "atts": {
                 "number": "5"
               }
             },
-            "Jésus leur demanda: ", {
+            "Jésus leur demanda: ",
+            {
               "type": "wrapper",
-              "subtype": "usfm:wj",
-              "content": ["Combien avez-vous de pains?"]
+              "subtype": "usfm:span",
+              "content": [
+                "Combien avez-vous de pains?"
+              ]
             },
-            " Sept, répondirent-ils. ", {
+            " Sept, répondirent-ils. ",
+            {
               "type": "mark",
               "subtype": "verses",
               "atts": {
                 "number": "6"
               }
             },
-            "Alors il fit asseoir la foule par terre, prit les sept pains, et, après avoir rendu grâces, il les rompit, et les donna à ses disciples pour les distribuer; et ils les distribuèrent à la foule. ", {
-              "type": "wrapper",
-              "subtype": "meta_content",
-              "meta_content": ["<== Long verse (37 words)"]
-            }, {
+            "Alors il fit asseoir la foule par terre, prit les sept pains, et, après avoir rendu grâces, il les rompit, et les donna à ses disciples pour les distribuer; et ils les distribuèrent à la foule. ",
+            {
               "type": "mark",
               "subtype": "verses",
               "atts": {
                 "number": "7"
               }
             },
-            "Ils avaient encore quelques petits poissons, et Jésus, ayant rendu grâces, les fit aussi distribuer. ", {
+            "Ils avaient encore quelques petits poissons, et Jésus, ayant rendu grâces, les fit aussi distribuer. ",
+            {
               "type": "mark",
               "subtype": "verses",
               "atts": {
                 "number": "8"
               }
             },
-            "Ils mangèrent et furent rassasiés, et l’on emporta sept corbeilles pleines des morceaux qui restaient. ", {
+            "Ils mangèrent et furent rassasiés, et l’on emporta sept corbeilles pleines des morceaux qui restaient. ",
+            {
               "type": "mark",
               "subtype": "verses",
               "atts": {
@@ -4145,15 +4737,18 @@
             },
             "Ils étaient environ quatre mille. Ensuite Jésus les renvoya."
           ]
-        }, {
+        },
+        {
           "type": "graft",
           "subtype": "heading",
           "target": "ZjY5MDI2MzEt"
-        }, {
+        },
+        {
           "type": "graft",
           "subtype": "heading",
           "target": "OTdmNTMxZGIt"
-        }, {
+        },
+        {
           "type": "paragraph",
           "subtype": "usfm:p",
           "content": [
@@ -4177,86 +4772,104 @@
                 "number": "11"
               }
             },
-            "Les pharisiens survinrent, se mirent à discuter avec Jésus, et, pour l’éprouver, ", {
+            "Les pharisiens survinrent, se mirent à discuter avec Jésus, et, pour l’éprouver, ",
+            {
               "type": "graft",
               "subtype": "xref",
               "target": "MjNiNDBkMzct"
             },
-            "lui demandèrent un signe venant du ciel. ", {
+            "lui demandèrent un signe venant du ciel. ",
+            {
               "type": "mark",
               "subtype": "verses",
               "atts": {
                 "number": "12"
               }
             },
-            "Jésus, soupirant profondément en son esprit, dit: ", {
+            "Jésus, soupirant profondément en son esprit, dit: ",
+            {
               "type": "wrapper",
-              "subtype": "usfm:wj",
-              "content": ["Pourquoi cette génération demande-t-elle un signe?"]
-            }, {
+              "subtype": "usfm:span",
+              "content": [
+                "Pourquoi cette génération demande-t-elle un signe?"
+              ]
+            },
+            {
               "type": "graft",
               "subtype": "xref",
               "target": "YmIzZmM3Yjgt"
-            }, {
-              "type": "wrapper",
-              "subtype": "usfm:wj",
-              "content": ["Je vous le dis en vérité, il ne sera point donné de signe à cette génération."]
             },
-            " ", {
+            {
               "type": "wrapper",
-              "subtype": "meta_content",
-              "meta_content": ["<== Long verse (32 words)"]
-            }, {
+              "subtype": "usfm:span",
+              "content": [
+                "Je vous le dis en vérité, il ne sera point donné de signe à cette génération."
+              ]
+            },
+            " ",
+            {
               "type": "mark",
               "subtype": "verses",
               "atts": {
                 "number": "13"
               }
             },
-            "Puis il les quitta, et remonta dans la barque, pour passer sur l’autre bord. ", {
+            "Puis il les quitta, et remonta dans la barque, pour passer sur l’autre bord. ",
+            {
               "type": "mark",
               "subtype": "verses",
               "atts": {
                 "number": "14"
               }
             },
-            "Les disciples avaient oublié de prendre des pains; ils n’en avaient qu’un seul avec eux dans la barque. ", {
+            "Les disciples avaient oublié de prendre des pains; ils n’en avaient qu’un seul avec eux dans la barque. ",
+            {
               "type": "mark",
               "subtype": "verses",
               "atts": {
                 "number": "15"
               }
             },
-            "Jésus leur fit cette recommandation: ", {
+            "Jésus leur fit cette recommandation: ",
+            {
               "type": "graft",
               "subtype": "xref",
               "target": "YzQzYTU2Y2Qt"
-            }, {
-              "type": "wrapper",
-              "subtype": "usfm:wj",
-              "content": ["Gardez-vous avec soin du levain des pharisiens et du levain d’Hérode."]
             },
-            " ", {
+            {
+              "type": "wrapper",
+              "subtype": "usfm:span",
+              "content": [
+                "Gardez-vous avec soin du levain des pharisiens et du levain d’Hérode."
+              ]
+            },
+            " ",
+            {
               "type": "mark",
               "subtype": "verses",
               "atts": {
                 "number": "16"
               }
             },
-            "Les disciples raisonnaient entre eux, et disaient: C’est parce que nous n’avons pas de pains. ", {
+            "Les disciples raisonnaient entre eux, et disaient: C’est parce que nous n’avons pas de pains. ",
+            {
               "type": "mark",
               "subtype": "verses",
               "atts": {
                 "number": "17"
               }
             },
-            "Jésus, l’ayant connu, leur dit: ", {
+            "Jésus, l’ayant connu, leur dit: ",
+            {
               "type": "wrapper",
-              "subtype": "usfm:wj",
-              "content": ["Pourquoi raisonnez-vous sur ce que vous n’avez pas de pains? Êtes-vous encore sans intelligence, et ne comprenez-vous pas?"]
+              "subtype": "usfm:span",
+              "content": [
+                "Pourquoi raisonnez-vous sur ce que vous n’avez pas de pains? Êtes-vous encore sans intelligence, et ne comprenez-vous pas?"
+              ]
             }
           ]
-        }, {
+        },
+        {
           "type": "paragraph",
           "subtype": "usfm:p",
           "content": [
@@ -4274,27 +4887,35 @@
             },
             {
               "type": "wrapper",
-              "subtype": "usfm:wj",
-              "content": ["Avez-vous le cœur endurci? Ayant des yeux, ne voyez-vous pas? Ayant des oreilles, n’entendez-vous pas? Et n’avez-vous point de mémoire?"]
+              "subtype": "usfm:span",
+              "content": [
+                "Avez-vous le cœur endurci? Ayant des yeux, ne voyez-vous pas? Ayant des oreilles, n’entendez-vous pas? Et n’avez-vous point de mémoire?"
+              ]
             },
-            " ", {
+            " ",
+            {
               "type": "mark",
               "subtype": "verses",
               "atts": {
                 "number": "19"
               }
-            }, {
+            },
+            {
               "type": "graft",
               "subtype": "xref",
               "target": "NDMwYWMxZWEt"
-            }, {
+            },
+            {
               "type": "wrapper",
-              "subtype": "usfm:wj",
-              "content": ["Quand j’ai rompu les cinq pains pour les cinq mille hommes, combien de paniers pleins de morceaux avez-vous emportés?"]
+              "subtype": "usfm:span",
+              "content": [
+                "Quand j’ai rompu les cinq pains pour les cinq mille hommes, combien de paniers pleins de morceaux avez-vous emportés?"
+              ]
             },
             " Douze, lui répondirent-ils."
           ]
-        }, {
+        },
+        {
           "type": "paragraph",
           "subtype": "usfm:p",
           "content": [
@@ -4312,31 +4933,40 @@
             },
             {
               "type": "wrapper",
-              "subtype": "usfm:wj",
-              "content": ["Et quand j’ai rompu les sept pains pour les quatre mille hommes, combien de corbeilles pleines de morceaux avez-vous emportées?"]
+              "subtype": "usfm:span",
+              "content": [
+                "Et quand j’ai rompu les sept pains pour les quatre mille hommes, combien de corbeilles pleines de morceaux avez-vous emportées?"
+              ]
             },
-            " Sept, répondirent-ils. ", {
+            " Sept, répondirent-ils. ",
+            {
               "type": "mark",
               "subtype": "verses",
               "atts": {
                 "number": "21"
               }
             },
-            "Et il leur dit: ", {
+            "Et il leur dit: ",
+            {
               "type": "wrapper",
-              "subtype": "usfm:wj",
-              "content": ["Ne comprenez-vous pas encore?"]
+              "subtype": "usfm:span",
+              "content": [
+                "Ne comprenez-vous pas encore?"
+              ]
             }
           ]
-        }, {
+        },
+        {
           "type": "graft",
           "subtype": "heading",
           "target": "NTEwY2IxYjgt"
-        }, {
+        },
+        {
           "type": "graft",
           "subtype": "heading",
           "target": "YWJkMTZmNWQt"
-        }, {
+        },
+        {
           "type": "paragraph",
           "subtype": "usfm:p",
           "content": [
@@ -4355,56 +4985,63 @@
                 "number": "23"
               }
             },
-            "Il prit l’aveugle par la main, et le conduisit hors du village; ", {
+            "Il prit l’aveugle par la main, et le conduisit hors du village; ",
+            {
               "type": "graft",
               "subtype": "xref",
               "target": "ZTlhNWM3Zjct"
             },
-            "puis il lui mit de la salive sur les yeux, ", {
+            "puis il lui mit de la salive sur les yeux, ",
+            {
               "type": "graft",
               "subtype": "xref",
               "target": "MjA2OTViZWQt"
             },
-            "lui imposa les mains, et lui demanda s’il voyait quelque chose. ", {
-              "type": "wrapper",
-              "subtype": "meta_content",
-              "meta_content": ["<== Long verse (36 words)"]
-            }, {
+            "lui imposa les mains, et lui demanda s’il voyait quelque chose. ",
+            {
               "type": "mark",
               "subtype": "verses",
               "atts": {
                 "number": "24"
               }
             },
-            "Il regarda, et dit: J’aperçois les hommes, mais j’en vois comme des arbres, et qui marchent. ", {
+            "Il regarda, et dit: J’aperçois les hommes, mais j’en vois comme des arbres, et qui marchent. ",
+            {
               "type": "mark",
               "subtype": "verses",
               "atts": {
                 "number": "25"
               }
             },
-            "Jésus lui mit de nouveau les mains sur les yeux; et, quand l’aveugle regarda fixement, il fut guéri, et vit tout distinctement. ", {
+            "Jésus lui mit de nouveau les mains sur les yeux; et, quand l’aveugle regarda fixement, il fut guéri, et vit tout distinctement. ",
+            {
               "type": "mark",
               "subtype": "verses",
               "atts": {
                 "number": "26"
               }
             },
-            "Alors Jésus le renvoya dans sa maison, en disant: ", {
+            "Alors Jésus le renvoya dans sa maison, en disant: ",
+            {
               "type": "wrapper",
-              "subtype": "usfm:wj",
-              "content": ["N’entre pas au village."]
+              "subtype": "usfm:span",
+              "content": [
+                "N’entre pas au village."
+              ]
             }
           ]
-        }, {
+        },
+        {
           "type": "graft",
           "subtype": "heading",
           "target": "NjJmMDA1Njgt"
-        }, {
+        },
+        {
           "type": "graft",
           "subtype": "heading",
           "target": "YzJlMGI3NzMt"
-        }, {
+        },
+        {
           "type": "paragraph",
           "subtype": "usfm:p",
           "content": [
@@ -4423,24 +5060,29 @@
             "Jésus s’en alla, avec ses disciples, dans les villages de Césarée de Philippe, et il leur posa en chemin cette question: ",
             {
               "type": "wrapper",
-              "subtype": "usfm:wj",
-              "content": ["Qui dit-on que je suis?"]
+              "subtype": "usfm:span",
+              "content": [
+                "Qui dit-on que je suis?"
+              ]
             },
-            " ", {
+            " ",
+            {
               "type": "mark",
               "subtype": "verses",
               "atts": {
                 "number": "28"
               }
             },
-            "Ils répondirent: ", {
+            "Ils répondirent: ",
+            {
               "type": "graft",
               "subtype": "xref",
               "target": "ZTdmOTYxMmEt"
             },
             "Jean-Baptiste; les autres, Élie, les autres, l’un des prophètes."
           ]
-        }, {
+        },
+        {
           "type": "paragraph",
           "subtype": "usfm:p",
           "content": [
@@ -4453,21 +5095,27 @@
             },
             {
               "type": "wrapper",
-              "subtype": "usfm:wj",
-              "content": ["Et vous,"]
+              "subtype": "usfm:span",
+              "content": [
+                "Et vous,"
+              ]
             },
             " leur demanda-t-il, ",
             {
               "type": "wrapper",
-              "subtype": "usfm:wj",
-              "content": ["qui dites-vous que je suis?"]
+              "subtype": "usfm:span",
+              "content": [
+                "qui dites-vous que je suis?"
+              ]
             },
-            " Pierre lui répondit: ", {
+            " Pierre lui répondit: ",
+            {
               "type": "graft",
               "subtype": "xref",
               "target": "YTViYzhhYWEt"
             },
-            "Tu es le Christ. ", {
+            "Tu es le Christ. ",
+            {
               "type": "mark",
               "subtype": "verses",
               "atts": {
@@ -4476,15 +5124,18 @@
             },
             "Jésus leur recommanda sévèrement de ne dire cela de lui à personne."
           ]
-        }, {
+        },
+        {
           "type": "graft",
           "subtype": "heading",
           "target": "MzUzZTJmMmUt"
-        }, {
+        },
+        {
           "type": "graft",
           "subtype": "heading",
           "target": "YjFiMDE3ZTkt"
-        }, {
+        },
+        {
           "type": "paragraph",
           "subtype": "usfm:p",
           "content": [
@@ -4502,62 +5153,60 @@
             },
             "Alors il commença à leur apprendre qu’il fallait que le Fils de l’homme souffrît beaucoup, qu’il fût rejeté par les anciens, par les principaux sacrificateurs et par les scribes, qu’il fût mis à mort, et qu’il ressuscitât trois jours après. ",
             {
-              "type": "wrapper",
-              "subtype": "meta_content",
-              "meta_content": ["<== Long verse (41 words)"]
-            }, {
               "type": "mark",
               "subtype": "verses",
               "atts": {
                 "number": "32"
               }
             },
-            "Il leur disait ces choses ouvertement. Et Pierre, l’ayant pris à part, se mit à le reprendre. ", {
+            "Il leur disait ces choses ouvertement. Et Pierre, l’ayant pris à part, se mit à le reprendre. ",
+            {
               "type": "mark",
               "subtype": "verses",
               "atts": {
                 "number": "33"
               }
             },
-            "Mais Jésus, se retournant et regardant ses disciples, réprimanda Pierre, et dit: ", {
+            "Mais Jésus, se retournant et regardant ses disciples, réprimanda Pierre, et dit: ",
+            {
               "type": "graft",
               "subtype": "xref",
               "target": "NWUxZWFiZjUt"
-            }, {
-              "type": "wrapper",
-              "subtype": "usfm:wj",
-              "content": ["Arrière de moi, Satan! Car tu ne conçois pas les choses de Dieu, tu n’as que des pensées humaines."]
             },
-            " ", {
+            {
               "type": "wrapper",
-              "subtype": "meta_content",
-              "meta_content": ["<== Long verse (34 words)"]
-            }, {
+              "subtype": "usfm:span",
+              "content": [
+                "Arrière de moi, Satan! Car tu ne conçois pas les choses de Dieu, tu n’as que des pensées humaines."
+              ]
+            },
+            " ",
+            {
               "type": "mark",
               "subtype": "verses",
               "atts": {
                 "number": "34"
               }
             },
-            "Puis, ayant appelé la foule avec ses disciples, il leur dit: ", {
+            "Puis, ayant appelé la foule avec ses disciples, il leur dit: ",
+            {
               "type": "graft",
               "subtype": "xref",
               "target": "YmE3MDRhNDUt"
-            }, {
+            },
+            {
               "type": "wrapper",
-              "subtype": "usfm:wj",
-              "content": ["Si quelqu’un veut venir après moi, qu’il renonce à lui-même, qu’il se charge de sa croix, et qu’il me suive."]
+              "subtype": "usfm:span",
+              "content": [
+                "Si quelqu’un veut venir après moi, qu’il renonce à lui-même, qu’il se charge de sa croix, et qu’il me suive."
+              ]
             }
           ]
-        }, {
+        },
+        {
           "type": "paragraph",
           "subtype": "usfm:p",
           "content": [
-            {
-              "type": "wrapper",
-              "subtype": "meta_content",
-              "meta_content": ["<== Long verse (32 words)"]
-            },
             {
               "type": "mark",
               "subtype": "verses",
@@ -4572,56 +5221,76 @@
             },
             {
               "type": "wrapper",
-              "subtype": "usfm:wj",
-              "content": ["Car celui qui voudra sauver sa vie la perdra, mais celui qui perdra sa vie à cause de moi et de la bonne nouvelle la sauvera."]
+              "subtype": "usfm:span",
+              "content": [
+                "Car celui qui voudra sauver sa vie la perdra, mais celui qui perdra sa vie à cause de moi et de la bonne nouvelle la sauvera."
+              ]
             },
-            " ", {
+            " ",
+            {
               "type": "mark",
               "subtype": "verses",
               "atts": {
                 "number": "36"
               }
-            }, {
-              "type": "wrapper",
-              "subtype": "usfm:wj",
-              "content": ["Et que sert-il à un homme de gagner tout le monde, s’il perd son âme?"]
             },
-            " ", {
+            {
+              "type": "wrapper",
+              "subtype": "usfm:span",
+              "content": [
+                "Et que sert-il à un homme de gagner tout le monde, s’il perd son âme?"
+              ]
+            },
+            " ",
+            {
               "type": "mark",
               "subtype": "verses",
               "atts": {
                 "number": "37"
               }
-            }, {
+            },
+            {
               "type": "wrapper",
-              "subtype": "usfm:wj",
-              "content": ["Que donnerait un homme"]
-            }, {
+              "subtype": "usfm:span",
+              "content": [
+                "Que donnerait un homme"
+              ]
+            },
+            {
               "type": "graft",
               "subtype": "xref",
               "target": "ODUwZThlMWEt"
-            }, {
-              "type": "wrapper",
-              "subtype": "usfm:wj",
-              "content": ["en échange de son âme?"]
             },
-            " ", {
+            {
+              "type": "wrapper",
+              "subtype": "usfm:span",
+              "content": [
+                "en échange de son âme?"
+              ]
+            },
+            " ",
+            {
               "type": "mark",
               "subtype": "verses",
               "atts": {
                 "number": "38"
               }
-            }, {
+            },
+            {
               "type": "graft",
               "subtype": "xref",
               "target": "Mjc1ZWVkYjUt"
-            }, {
+            },
+            {
               "type": "wrapper",
-              "subtype": "usfm:wj",
-              "content": ["Car quiconque aura honte de moi et de mes paroles au milieu de cette génération adultère et pécheresse, le Fils de l’homme aura aussi honte de lui, quand il viendra dans la gloire de son Père, avec les saints anges."]
+              "subtype": "usfm:span",
+              "content": [
+                "Car quiconque aura honte de moi et de mes paroles au milieu de cette génération adultère et pécheresse, le Fils de l’homme aura aussi honte de lui, quand il viendra dans la gloire de son Père, avec les saints anges."
+              ]
             }
           ]
-        }, {
+        },
+        {
           "type": "paragraph",
           "subtype": "usfm:p",
           "content": [
@@ -4631,11 +5300,6 @@
               "atts": {
                 "number": "9"
               }
-            },
-            {
-              "type": "wrapper",
-              "subtype": "meta_content",
-              "meta_content": ["<== Long verse (40 words)"]
             },
             {
               "type": "mark",
@@ -4649,29 +5313,30 @@
               "subtype": "xref",
               "target": "ZTZlMmY3YjQt"
             },
-            "Il leur dit encore: ", {
+            "Il leur dit encore: ",
+            {
               "type": "wrapper",
-              "subtype": "usfm:wj",
-              "content": ["Je vous le dis en vérité, quelques-uns de ceux qui sont ici ne mourront point, qu’ils n’aient vu le royaume de Dieu venir avec puissance."]
+              "subtype": "usfm:span",
+              "content": [
+                "Je vous le dis en vérité, quelques-uns de ceux qui sont ici ne mourront point, qu’ils n’aient vu le royaume de Dieu venir avec puissance."
+              ]
             }
           ]
-        }, {
+        },
+        {
           "type": "graft",
           "subtype": "heading",
           "target": "OGQ5ZWI4NmIt"
-        }, {
+        },
+        {
           "type": "graft",
           "subtype": "heading",
           "target": "YmExNjQ4MzQt"
-        }, {
+        },
+        {
           "type": "paragraph",
           "subtype": "usfm:p",
           "content": [
-            {
-              "type": "wrapper",
-              "subtype": "meta_content",
-              "meta_content": ["<== Long verse (30 words)"]
-            },
             {
               "type": "mark",
               "subtype": "verses",
@@ -4684,114 +5349,132 @@
               "subtype": "xref",
               "target": "Yzk1Yjc3ZWUt"
             },
-            "Six jours après, Jésus prit avec lui Pierre, Jacques et Jean, et il les conduisit seuls à l’écart sur une haute montagne. Il fut transfiguré devant eux; ", {
+            "Six jours après, Jésus prit avec lui Pierre, Jacques et Jean, et il les conduisit seuls à l’écart sur une haute montagne. Il fut transfiguré devant eux; ",
+            {
               "type": "mark",
               "subtype": "verses",
               "atts": {
                 "number": "3"
               }
             },
-            "ses vêtements devinrent resplendissants, et d’une telle blancheur qu’il n’est pas de foulon sur la terre qui puisse blanchir ainsi. ", {
+            "ses vêtements devinrent resplendissants, et d’une telle blancheur qu’il n’est pas de foulon sur la terre qui puisse blanchir ainsi. ",
+            {
               "type": "mark",
               "subtype": "verses",
               "atts": {
                 "number": "4"
               }
             },
-            "Élie et Moïse leur apparurent, s’entretenant avec Jésus. ", {
+            "Élie et Moïse leur apparurent, s’entretenant avec Jésus. ",
+            {
               "type": "mark",
               "subtype": "verses",
               "atts": {
                 "number": "5"
               }
             },
-            "Pierre, prenant la parole, dit à Jésus: Rabbi, il est bon que nous soyons ici; dressons trois tentes, une pour toi, une pour Moïse, et une pour Élie. ", {
+            "Pierre, prenant la parole, dit à Jésus: Rabbi, il est bon que nous soyons ici; dressons trois tentes, une pour toi, une pour Moïse, et une pour Élie. ",
+            {
               "type": "mark",
               "subtype": "verses",
               "atts": {
                 "number": "6"
               }
             },
-            "Car il ne savait que dire, l’effroi les ayant saisis. ", {
+            "Car il ne savait que dire, l’effroi les ayant saisis. ",
+            {
               "type": "mark",
               "subtype": "verses",
               "atts": {
                 "number": "7"
               }
             },
-            "Une nuée vint les couvrir, et de la nuée sortit une voix: ", {
+            "Une nuée vint les couvrir, et de la nuée sortit une voix: ",
+            {
               "type": "graft",
               "subtype": "xref",
               "target": "NzRlZmJhYmIt"
             },
-            "Celui-ci est mon Fils bien-aimé: ", {
+            "Celui-ci est mon Fils bien-aimé: ",
+            {
               "type": "graft",
               "subtype": "xref",
               "target": "MTlhZDY2Mzgt"
             },
-            "écoutez-le! ", {
+            "écoutez-le! ",
+            {
               "type": "mark",
               "subtype": "verses",
               "atts": {
                 "number": "8"
               }
             },
-            "Aussitôt les disciples regardèrent tout autour, et ils ne virent que Jésus seul avec eux. ", {
+            "Aussitôt les disciples regardèrent tout autour, et ils ne virent que Jésus seul avec eux. ",
+            {
               "type": "mark",
               "subtype": "verses",
               "atts": {
                 "number": "9"
               }
-            }, {
+            },
+            {
               "type": "graft",
               "subtype": "xref",
               "target": "OGJkNzMyMWYt"
             },
-            "Comme ils descendaient de la montagne, Jésus leur recommanda de ne dire à personne ce qu’ils avaient vu, jusqu’à ce que le Fils de l’homme fût ressuscité des morts. ", {
-              "type": "wrapper",
-              "subtype": "meta_content",
-              "meta_content": ["<== Long verse (30 words)"]
-            }, {
+            "Comme ils descendaient de la montagne, Jésus leur recommanda de ne dire à personne ce qu’ils avaient vu, jusqu’à ce que le Fils de l’homme fût ressuscité des morts. ",
+            {
               "type": "mark",
               "subtype": "verses",
               "atts": {
                 "number": "10"
               }
             },
-            "Ils retinrent cette parole, se demandant entre eux ce que c’est que ressusciter des morts. ", {
+            "Ils retinrent cette parole, se demandant entre eux ce que c’est que ressusciter des morts. ",
+            {
               "type": "mark",
               "subtype": "verses",
               "atts": {
                 "number": "11"
               }
             },
-            "Les disciples lui firent cette question: Pourquoi les scribes disent-ils ", {
+            "Les disciples lui firent cette question: Pourquoi les scribes disent-ils ",
+            {
               "type": "graft",
               "subtype": "xref",
               "target": "ZTVkZjg1ZDEt"
             },
-            "qu’il faut qu’Élie vienne premièrement? ", {
+            "qu’il faut qu’Élie vienne premièrement? ",
+            {
               "type": "mark",
               "subtype": "verses",
               "atts": {
                 "number": "12"
               }
             },
-            "Il leur répondit: ", {
+            "Il leur répondit: ",
+            {
               "type": "wrapper",
-              "subtype": "usfm:wj",
-              "content": ["Élie viendra premièrement, et rétablira toutes choses."]
-            }, {
+              "subtype": "usfm:span",
+              "content": [
+                "Élie viendra premièrement, et rétablira toutes choses."
+              ]
+            },
+            {
               "type": "graft",
               "subtype": "xref",
               "target": "Y2M0ZTdiODkt"
-            }, {
+            },
+            {
               "type": "wrapper",
-              "subtype": "usfm:wj",
-              "content": ["Et pourquoi est-il écrit du Fils de l’homme qu’il doit souffrir beaucoup et être méprisé?"]
+              "subtype": "usfm:span",
+              "content": [
+                "Et pourquoi est-il écrit du Fils de l’homme qu’il doit souffrir beaucoup et être méprisé?"
+              ]
             }
           ]
-        }, {
+        },
+        {
           "type": "paragraph",
           "subtype": "usfm:p",
           "content": [
@@ -4801,29 +5484,39 @@
               "atts": {
                 "number": "13"
               }
-            }, {
+            },
+            {
               "type": "wrapper",
-              "subtype": "usfm:wj",
-              "content": ["Mais je vous dis qu’Élie est venu, et qu’ils l’ont traité comme ils ont voulu,"]
-            }, {
+              "subtype": "usfm:span",
+              "content": [
+                "Mais je vous dis qu’Élie est venu, et qu’ils l’ont traité comme ils ont voulu,"
+              ]
+            },
+            {
               "type": "graft",
               "subtype": "xref",
               "target": "NjI2ZDJkNGIt"
-            }, {
+            },
+            {
               "type": "wrapper",
-              "subtype": "usfm:wj",
-              "content": ["selon qu’il est écrit de lui."]
+              "subtype": "usfm:span",
+              "content": [
+                "selon qu’il est écrit de lui."
+              ]
             }
           ]
-        }, {
+        },
+        {
           "type": "graft",
           "subtype": "heading",
           "target": "MGNiNjVhNzIt"
-        }, {
+        },
+        {
           "type": "graft",
           "subtype": "heading",
           "target": "NDU2MTc4OGEt"
-        }, {
+        },
+        {
           "type": "paragraph",
           "subtype": "usfm:p",
           "content": [
@@ -4842,30 +5535,37 @@
                 "number": "15"
               }
             },
-            "Dès que la foule vit Jésus, elle fut surprise, et accourut pour le saluer. ", {
+            "Dès que la foule vit Jésus, elle fut surprise, et accourut pour le saluer. ",
+            {
               "type": "mark",
               "subtype": "verses",
               "atts": {
                 "number": "16"
               }
             },
-            "Il leur demanda: ", {
+            "Il leur demanda: ",
+            {
               "type": "wrapper",
-              "subtype": "usfm:wj",
-              "content": ["Sur quoi discutez-vous avec eux?"]
+              "subtype": "usfm:span",
+              "content": [
+                "Sur quoi discutez-vous avec eux?"
+              ]
             },
-            " ", {
+            " ",
+            {
               "type": "mark",
               "subtype": "verses",
               "atts": {
                 "number": "17"
               }
-            }, {
+            },
+            {
               "type": "graft",
               "subtype": "xref",
               "target": "YTA2NWY1NTct"
             },
-            "Et un homme de la foule lui répondit: Maître, j’ai amené auprès de toi mon fils, qui est possédé d’un esprit muet. ", {
+            "Et un homme de la foule lui répondit: Maître, j’ai amené auprès de toi mon fils, qui est possédé d’un esprit muet. ",
+            {
               "type": "mark",
               "subtype": "verses",
               "atts": {
@@ -4874,15 +5574,11 @@
             },
             "En quelque lieu qu’il le saisisse, il le jette par terre; l’enfant écume, grince des dents, et devient tout raide. J’ai prié tes disciples de chasser l’esprit, et ils n’ont pas pu."
           ]
-        }, {
+        },
+        {
           "type": "paragraph",
           "subtype": "usfm:p",
           "content": [
-            {
-              "type": "wrapper",
-              "subtype": "meta_content",
-              "meta_content": ["<== Long verse (32 words)"]
-            },
             {
               "type": "mark",
               "subtype": "verses",
@@ -4892,134 +5588,166 @@
             },
             {
               "type": "wrapper",
-              "subtype": "usfm:wj",
-              "content": ["Race incrédule,"]
+              "subtype": "usfm:span",
+              "content": [
+                "Race incrédule,"
+              ]
             },
-            " leur dit Jésus, ", {
+            " leur dit Jésus, ",
+            {
               "type": "wrapper",
-              "subtype": "usfm:wj",
-              "content": ["jusques à quand serai-je avec vous? Jusques à quand vous supporterai-je? Amenez-le-moi."]
+              "subtype": "usfm:span",
+              "content": [
+                "jusques à quand serai-je avec vous? Jusques à quand vous supporterai-je? Amenez-le-moi."
+              ]
             },
-            " On le lui amena. ", {
+            " On le lui amena. ",
+            {
               "type": "mark",
               "subtype": "verses",
               "atts": {
                 "number": "20"
               }
-            }, {
+            },
+            {
               "type": "graft",
               "subtype": "xref",
               "target": "NjU0N2VkNzAt"
             },
-            "Et aussitôt que l’enfant vit Jésus, l’esprit l’agita avec violence; il tomba par terre, et se roulait en écumant. ", {
+            "Et aussitôt que l’enfant vit Jésus, l’esprit l’agita avec violence; il tomba par terre, et se roulait en écumant. ",
+            {
               "type": "mark",
               "subtype": "verses",
               "atts": {
                 "number": "21"
               }
             },
-            "Jésus demanda au père: ", {
+            "Jésus demanda au père: ",
+            {
               "type": "wrapper",
-              "subtype": "usfm:wj",
-              "content": ["Combien y a-t-il de temps que cela lui arrive?"]
+              "subtype": "usfm:span",
+              "content": [
+                "Combien y a-t-il de temps que cela lui arrive?"
+              ]
             },
-            " Depuis son enfance, répondit-il. ", {
+            " Depuis son enfance, répondit-il. ",
+            {
               "type": "mark",
               "subtype": "verses",
               "atts": {
                 "number": "22"
               }
             },
-            "Et souvent l’esprit l’a jeté dans le feu et dans l’eau pour le faire périr. Mais, si tu peux quelque chose, viens à notre secours, aie compassion de nous. ", {
-              "type": "wrapper",
-              "subtype": "meta_content",
-              "meta_content": ["<== Long verse (30 words)"]
-            }, {
+            "Et souvent l’esprit l’a jeté dans le feu et dans l’eau pour le faire périr. Mais, si tu peux quelque chose, viens à notre secours, aie compassion de nous. ",
+            {
               "type": "mark",
               "subtype": "verses",
               "atts": {
                 "number": "23"
               }
             },
-            "Jésus lui dit: ", {
+            "Jésus lui dit: ",
+            {
               "type": "wrapper",
-              "subtype": "usfm:wj",
-              "content": ["Si tu peux!…"]
-            }, {
+              "subtype": "usfm:span",
+              "content": [
+                "Si tu peux!…"
+              ]
+            },
+            {
               "type": "graft",
               "subtype": "xref",
               "target": "YzI4NTIwNTMt"
-            }, {
-              "type": "wrapper",
-              "subtype": "usfm:wj",
-              "content": ["Tout est possible à celui qui croit."]
             },
-            " ", {
+            {
+              "type": "wrapper",
+              "subtype": "usfm:span",
+              "content": [
+                "Tout est possible à celui qui croit."
+              ]
+            },
+            " ",
+            {
               "type": "mark",
               "subtype": "verses",
               "atts": {
                 "number": "24"
               }
             },
-            "Aussitôt le père de l’enfant s’écria: Je crois! Viens au secours de mon incrédulité! ", {
+            "Aussitôt le père de l’enfant s’écria: Je crois! Viens au secours de mon incrédulité! ",
+            {
               "type": "mark",
               "subtype": "verses",
               "atts": {
                 "number": "25"
               }
             },
-            "Jésus, voyant accourir la foule, menaça l’esprit impur, et lui dit: ", {
+            "Jésus, voyant accourir la foule, menaça l’esprit impur, et lui dit: ",
+            {
               "type": "wrapper",
-              "subtype": "usfm:wj",
-              "content": ["Esprit muet et sourd, je te l’ordonne, sors de cet enfant, et n’y rentre plus."]
+              "subtype": "usfm:span",
+              "content": [
+                "Esprit muet et sourd, je te l’ordonne, sors de cet enfant, et n’y rentre plus."
+              ]
             },
-            " ", {
+            " ",
+            {
               "type": "mark",
               "subtype": "verses",
               "atts": {
                 "number": "26"
               }
             },
-            "Et il sortit, en poussant des cris, et en l’agitant avec une grande violence. L’enfant devint comme mort, de sorte que plusieurs disaient qu’il était mort. ", {
+            "Et il sortit, en poussant des cris, et en l’agitant avec une grande violence. L’enfant devint comme mort, de sorte que plusieurs disaient qu’il était mort. ",
+            {
               "type": "mark",
               "subtype": "verses",
               "atts": {
                 "number": "27"
               }
             },
-            "Mais Jésus, l’ayant pris par la main, le fit lever. Et il se tint debout. ", {
+            "Mais Jésus, l’ayant pris par la main, le fit lever. Et il se tint debout. ",
+            {
               "type": "mark",
               "subtype": "verses",
               "atts": {
                 "number": "28"
               }
-            }, {
+            },
+            {
               "type": "graft",
               "subtype": "xref",
               "target": "YzIxYWI4NDMt"
             },
-            "Quand Jésus fut entré dans la maison, ses disciples lui demandèrent en particulier: Pourquoi n’avons-nous pu chasser cet esprit? ", {
+            "Quand Jésus fut entré dans la maison, ses disciples lui demandèrent en particulier: Pourquoi n’avons-nous pu chasser cet esprit? ",
+            {
               "type": "mark",
               "subtype": "verses",
               "atts": {
                 "number": "29"
               }
             },
-            "Il leur dit: ", {
+            "Il leur dit: ",
+            {
               "type": "wrapper",
-              "subtype": "usfm:wj",
-              "content": ["Cette espèce-là ne peut sortir que par la prière."]
+              "subtype": "usfm:span",
+              "content": [
+                "Cette espèce-là ne peut sortir que par la prière."
+              ]
             }
           ]
-        }, {
+        },
+        {
           "type": "graft",
           "subtype": "heading",
           "target": "NzM3ZWEzYzgt"
-        }, {
+        },
+        {
           "type": "graft",
           "subtype": "heading",
           "target": "ZDNmYWNhNzkt"
-        }, {
+        },
+        {
           "type": "paragraph",
           "subtype": "usfm:p",
           "content": [
@@ -5043,16 +5771,16 @@
                 "number": "31"
               }
             },
-            "Car il enseignait ses disciples, et il leur dit: ", {
+            "Car il enseignait ses disciples, et il leur dit: ",
+            {
               "type": "wrapper",
-              "subtype": "usfm:wj",
-              "content": ["Le Fils de l’homme sera livré entre les mains des hommes; ils le feront mourir, et, trois jours après qu’il aura été mis à mort, il ressuscitera."]
+              "subtype": "usfm:span",
+              "content": [
+                "Le Fils de l’homme sera livré entre les mains des hommes; ils le feront mourir, et, trois jours après qu’il aura été mis à mort, il ressuscitera."
+              ]
             },
-            " ", {
-              "type": "wrapper",
-              "subtype": "meta_content",
-              "meta_content": ["<== Long verse (39 words)"]
-            }, {
+            " ",
+            {
               "type": "mark",
               "subtype": "verses",
               "atts": {
@@ -5061,15 +5789,18 @@
             },
             "Mais les disciples ne comprenaient pas cette parole, et ils craignaient de l’interroger."
           ]
-        }, {
+        },
+        {
           "type": "graft",
           "subtype": "heading",
           "target": "NzA0NTM4NTQt"
-        }, {
+        },
+        {
           "type": "graft",
           "subtype": "heading",
           "target": "YTMzYjViODIt"
-        }, {
+        },
+        {
           "type": "paragraph",
           "subtype": "usfm:p",
           "content": [
@@ -5088,47 +5819,58 @@
             "Ils arrivèrent à Capernaüm. Lorsqu’il fut dans la maison, Jésus leur demanda: ",
             {
               "type": "wrapper",
-              "subtype": "usfm:wj",
-              "content": ["De quoi discutiez-vous en chemin?"]
+              "subtype": "usfm:span",
+              "content": [
+                "De quoi discutiez-vous en chemin?"
+              ]
             },
-            " ", {
+            " ",
+            {
               "type": "mark",
               "subtype": "verses",
               "atts": {
                 "number": "34"
               }
             },
-            "Mais ils gardèrent le silence, car en chemin ils avaient discuté entre eux pour savoir qui était le plus grand. ", {
+            "Mais ils gardèrent le silence, car en chemin ils avaient discuté entre eux pour savoir qui était le plus grand. ",
+            {
               "type": "mark",
               "subtype": "verses",
               "atts": {
                 "number": "35"
               }
             },
-            "Alors il s’assit, appela les douze, et leur dit: ", {
+            "Alors il s’assit, appela les douze, et leur dit: ",
+            {
               "type": "graft",
               "subtype": "xref",
               "target": "MmU0NGJmNTUt"
-            }, {
-              "type": "wrapper",
-              "subtype": "usfm:wj",
-              "content": ["Si quelqu’un veut être le premier, il sera le dernier de tous et le serviteur de tous."]
             },
-            " ", {
+            {
+              "type": "wrapper",
+              "subtype": "usfm:span",
+              "content": [
+                "Si quelqu’un veut être le premier, il sera le dernier de tous et le serviteur de tous."
+              ]
+            },
+            " ",
+            {
               "type": "mark",
               "subtype": "verses",
               "atts": {
                 "number": "36"
               }
             },
-            "Et il prit un petit enfant, le plaça au milieu d’eux, et ", {
+            "Et il prit un petit enfant, le plaça au milieu d’eux, et ",
+            {
               "type": "graft",
               "subtype": "xref",
               "target": "N2NkZDUxOTEt"
             },
             "l’ayant pris dans ses bras, il leur dit:"
           ]
-        }, {
+        },
+        {
           "type": "paragraph",
           "subtype": "usfm:p",
           "content": [
@@ -5138,25 +5880,32 @@
               "atts": {
                 "number": "37"
               }
-            }, {
+            },
+            {
               "type": "graft",
               "subtype": "xref",
               "target": "NjlhYTc0YjIt"
-            }, {
+            },
+            {
               "type": "wrapper",
-              "subtype": "usfm:wj",
-              "content": ["Quiconque reçoit en mon nom un de ces petits enfants me reçoit moi-même; et quiconque me reçoit, reçoit non pas moi, mais celui qui m’a envoyé."]
+              "subtype": "usfm:span",
+              "content": [
+                "Quiconque reçoit en mon nom un de ces petits enfants me reçoit moi-même; et quiconque me reçoit, reçoit non pas moi, mais celui qui m’a envoyé."
+              ]
             }
           ]
-        }, {
+        },
+        {
           "type": "graft",
           "subtype": "heading",
           "target": "NWJkNjNkMmIt"
-        }, {
+        },
+        {
           "type": "graft",
           "subtype": "heading",
           "target": "MmY4MjA1MDct"
-        }, {
+        },
+        {
           "type": "paragraph",
           "subtype": "usfm:p",
           "content": [
@@ -5166,14 +5915,16 @@
               "atts": {
                 "number": "38"
               }
-            }, {
+            },
+            {
               "type": "graft",
               "subtype": "xref",
               "target": "OGMzOTg3ZjUt"
             },
             "Jean lui dit: Maître, nous avons vu un homme qui chasse des démons en ton nom; et nous l’en avons empêché, parce qu’il ne nous suit pas."
           ]
-        }, {
+        },
+        {
           "type": "paragraph",
           "subtype": "usfm:p",
           "content": [
@@ -5191,200 +5942,256 @@
             },
             {
               "type": "wrapper",
-              "subtype": "usfm:wj",
-              "content": ["Ne l’en empêchez pas,"]
+              "subtype": "usfm:span",
+              "content": [
+                "Ne l’en empêchez pas,"
+              ]
             },
-            " répondit Jésus, ", {
+            " répondit Jésus, ",
+            {
               "type": "wrapper",
-              "subtype": "usfm:wj",
-              "content": ["car il n’est personne qui, faisant un miracle en mon nom, puisse aussitôt après parler mal de moi."]
+              "subtype": "usfm:span",
+              "content": [
+                "car il n’est personne qui, faisant un miracle en mon nom, puisse aussitôt après parler mal de moi."
+              ]
             },
-            " ", {
+            " ",
+            {
               "type": "mark",
               "subtype": "verses",
               "atts": {
                 "number": "40"
               }
-            }, {
-              "type": "wrapper",
-              "subtype": "usfm:wj",
-              "content": ["Qui n’est pas contre nous est pour nous."]
             },
-            " ", {
+            {
+              "type": "wrapper",
+              "subtype": "usfm:span",
+              "content": [
+                "Qui n’est pas contre nous est pour nous."
+              ]
+            },
+            " ",
+            {
               "type": "mark",
               "subtype": "verses",
               "atts": {
                 "number": "41"
               }
-            }, {
+            },
+            {
               "type": "wrapper",
-              "subtype": "usfm:wj",
-              "content": ["Et"]
-            }, {
+              "subtype": "usfm:span",
+              "content": [
+                "Et"
+              ]
+            },
+            {
               "type": "graft",
               "subtype": "xref",
               "target": "Y2Q0MjkzYzEt"
-            }, {
-              "type": "wrapper",
-              "subtype": "usfm:wj",
-              "content": ["quiconque vous donnera à boire un verre d’eau en mon nom, parce que vous appartenez à Christ, je vous le dis en vérité, il ne perdra point sa récompense."]
             },
-            " ", {
+            {
               "type": "wrapper",
-              "subtype": "meta_content",
-              "meta_content": ["<== Long verse (32 words)"]
-            }, {
+              "subtype": "usfm:span",
+              "content": [
+                "quiconque vous donnera à boire un verre d’eau en mon nom, parce que vous appartenez à Christ, je vous le dis en vérité, il ne perdra point sa récompense."
+              ]
+            },
+            " ",
+            {
               "type": "mark",
               "subtype": "verses",
               "atts": {
                 "number": "42"
               }
-            }, {
+            },
+            {
               "type": "graft",
               "subtype": "xref",
               "target": "ZTI0ZWIzNDMt"
-            }, {
-              "type": "wrapper",
-              "subtype": "usfm:wj",
-              "content": ["Mais, si quelqu’un scandalisait un de ces petits qui croient, il vaudrait mieux pour lui qu’on lui mît au cou une grosse meule de moulin, et qu’on le jetât dans la mer."]
             },
-            " ", {
+            {
               "type": "wrapper",
-              "subtype": "meta_content",
-              "meta_content": ["<== Long verse (34 words)"]
-            }, {
+              "subtype": "usfm:span",
+              "content": [
+                "Mais, si quelqu’un scandalisait un de ces petits qui croient, il vaudrait mieux pour lui qu’on lui mît au cou une grosse meule de moulin, et qu’on le jetât dans la mer."
+              ]
+            },
+            " ",
+            {
               "type": "mark",
               "subtype": "verses",
               "atts": {
                 "number": "43"
               }
-            }, {
+            },
+            {
               "type": "graft",
               "subtype": "xref",
               "target": "ZTUyYTEyZjUt"
-            }, {
-              "type": "wrapper",
-              "subtype": "usfm:wj",
-              "content": ["Si ta main est pour toi une occasion de chute, coupe-la; mieux vaut pour toi entrer manchot dans la vie,"]
             },
-            " ", {
+            {
+              "type": "wrapper",
+              "subtype": "usfm:span",
+              "content": [
+                "Si ta main est pour toi une occasion de chute, coupe-la; mieux vaut pour toi entrer manchot dans la vie,"
+              ]
+            },
+            " ",
+            {
               "type": "mark",
               "subtype": "verses",
               "atts": {
                 "number": "44"
               }
-            }, {
-              "type": "wrapper",
-              "subtype": "usfm:wj",
-              "content": ["que d’avoir les deux mains et d’aller dans la géhenne, dans le feu qui ne s’éteint point."]
             },
-            " ", {
+            {
+              "type": "wrapper",
+              "subtype": "usfm:span",
+              "content": [
+                "que d’avoir les deux mains et d’aller dans la géhenne, dans le feu qui ne s’éteint point."
+              ]
+            },
+            " ",
+            {
               "type": "mark",
               "subtype": "verses",
               "atts": {
                 "number": "45"
               }
-            }, {
-              "type": "wrapper",
-              "subtype": "usfm:wj",
-              "content": ["Si ton pied est pour toi une occasion de chute, coupe-le; mieux vaut pour toi entrer boiteux dans la vie,"]
             },
-            " ", {
+            {
+              "type": "wrapper",
+              "subtype": "usfm:span",
+              "content": [
+                "Si ton pied est pour toi une occasion de chute, coupe-le; mieux vaut pour toi entrer boiteux dans la vie,"
+              ]
+            },
+            " ",
+            {
               "type": "mark",
               "subtype": "verses",
               "atts": {
                 "number": "46"
               }
-            }, {
-              "type": "wrapper",
-              "subtype": "usfm:wj",
-              "content": ["que d’avoir les deux pieds et d’être jeté dans la géhenne, dans le feu qui ne s’éteint point."]
             },
-            " ", {
+            {
+              "type": "wrapper",
+              "subtype": "usfm:span",
+              "content": [
+                "que d’avoir les deux pieds et d’être jeté dans la géhenne, dans le feu qui ne s’éteint point."
+              ]
+            },
+            " ",
+            {
               "type": "mark",
               "subtype": "verses",
               "atts": {
                 "number": "47"
               }
-            }, {
-              "type": "wrapper",
-              "subtype": "usfm:wj",
-              "content": ["Et si ton œil est pour toi une occasion de chute, arrache-le; mieux vaut pour toi entrer dans le royaume de Dieu n’ayant qu’un œil, que d’avoir deux yeux et d’être jeté dans la géhenne,"]
             },
-            " ", {
+            {
               "type": "wrapper",
-              "subtype": "meta_content",
-              "meta_content": ["<== Long verse (37 words)"]
-            }, {
+              "subtype": "usfm:span",
+              "content": [
+                "Et si ton œil est pour toi une occasion de chute, arrache-le; mieux vaut pour toi entrer dans le royaume de Dieu n’ayant qu’un œil, que d’avoir deux yeux et d’être jeté dans la géhenne,"
+              ]
+            },
+            " ",
+            {
               "type": "mark",
               "subtype": "verses",
               "atts": {
                 "number": "48"
               }
-            }, {
-              "type": "wrapper",
-              "subtype": "usfm:wj",
-              "content": ["où leur ver ne meurt point, et où le feu ne s’éteint point."]
             },
-            " ", {
+            {
+              "type": "wrapper",
+              "subtype": "usfm:span",
+              "content": [
+                "où leur ver ne meurt point, et où le feu ne s’éteint point."
+              ]
+            },
+            " ",
+            {
               "type": "mark",
               "subtype": "verses",
               "atts": {
                 "number": "49"
               }
-            }, {
+            },
+            {
               "type": "wrapper",
-              "subtype": "usfm:wj",
-              "content": ["Car tout homme sera"]
-            }, {
+              "subtype": "usfm:span",
+              "content": [
+                "Car tout homme sera"
+              ]
+            },
+            {
               "type": "graft",
               "subtype": "xref",
               "target": "ZmQxZWI5YmIt"
-            }, {
-              "type": "wrapper",
-              "subtype": "usfm:wj",
-              "content": ["salé de feu."]
             },
-            " ", {
+            {
+              "type": "wrapper",
+              "subtype": "usfm:span",
+              "content": [
+                "salé de feu."
+              ]
+            },
+            " ",
+            {
               "type": "mark",
               "subtype": "verses",
               "atts": {
                 "number": "50"
               }
-            }, {
+            },
+            {
               "type": "graft",
               "subtype": "xref",
               "target": "Yjc5YzUxYzEt"
-            }, {
-              "type": "wrapper",
-              "subtype": "usfm:wj",
-              "content": ["Le sel est une bonne chose; mais si le sel devient sans saveur, avec quoi l’assaisonnerez-vous?"]
             },
-            " ", {
+            {
+              "type": "wrapper",
+              "subtype": "usfm:span",
+              "content": [
+                "Le sel est une bonne chose; mais si le sel devient sans saveur, avec quoi l’assaisonnerez-vous?"
+              ]
+            },
+            " ",
+            {
               "type": "mark",
               "subtype": "verses",
               "atts": {
                 "number": "51"
               }
-            }, {
+            },
+            {
               "type": "graft",
               "subtype": "xref",
               "target": "NzBkYjk3ODEt"
-            }, {
+            },
+            {
               "type": "wrapper",
-              "subtype": "usfm:wj",
-              "content": ["Ayez du sel en vous-mêmes, et soyez en paix les uns avec les autres."]
+              "subtype": "usfm:span",
+              "content": [
+                "Ayez du sel en vous-mêmes, et soyez en paix les uns avec les autres."
+              ]
             }
           ]
-        }, {
+        },
+        {
           "type": "graft",
           "subtype": "heading",
           "target": "OWQ4OGEyMmEt"
-        }, {
+        },
+        {
           "type": "graft",
           "subtype": "heading",
           "target": "NmM1NGU1MWYt"
-        }, {
+        },
+        {
           "type": "paragraph",
           "subtype": "usfm:p",
           "content": [
@@ -5407,54 +6214,62 @@
               "subtype": "xref",
               "target": "NGE0MzNhNGUt"
             },
-            "Jésus, étant parti de là, se rendit dans le territoire de la Judée au-delà du Jourdain. La foule s’assembla de nouveau près de lui, et selon sa coutume, il se mit encore à l’enseigner. ", {
-              "type": "wrapper",
-              "subtype": "meta_content",
-              "meta_content": ["<== Long verse (35 words)"]
-            }, {
+            "Jésus, étant parti de là, se rendit dans le territoire de la Judée au-delà du Jourdain. La foule s’assembla de nouveau près de lui, et selon sa coutume, il se mit encore à l’enseigner. ",
+            {
               "type": "mark",
               "subtype": "verses",
               "atts": {
                 "number": "2"
               }
             },
-            "Les pharisiens l’abordèrent; et, pour l’éprouver, ils lui demandèrent s’il est permis à un homme de répudier sa femme. ", {
+            "Les pharisiens l’abordèrent; et, pour l’éprouver, ils lui demandèrent s’il est permis à un homme de répudier sa femme. ",
+            {
               "type": "mark",
               "subtype": "verses",
               "atts": {
                 "number": "3"
               }
             },
-            "Il leur répondit: ", {
+            "Il leur répondit: ",
+            {
               "type": "wrapper",
-              "subtype": "usfm:wj",
-              "content": ["Que vous a prescrit Moïse?"]
+              "subtype": "usfm:span",
+              "content": [
+                "Que vous a prescrit Moïse?"
+              ]
             },
-            " ", {
+            " ",
+            {
               "type": "mark",
               "subtype": "verses",
               "atts": {
                 "number": "4"
               }
-            }, {
+            },
+            {
               "type": "graft",
               "subtype": "xref",
               "target": "NGY0Y2Q1M2Yt"
             },
-            "Moïse, dirent-ils, a permis d’écrire une lettre de divorce et de répudier. ", {
+            "Moïse, dirent-ils, a permis d’écrire une lettre de divorce et de répudier. ",
+            {
               "type": "mark",
               "subtype": "verses",
               "atts": {
                 "number": "5"
               }
             },
-            "Et Jésus leur dit: ", {
+            "Et Jésus leur dit: ",
+            {
               "type": "wrapper",
-              "subtype": "usfm:wj",
-              "content": ["C’est à cause de la dureté de votre cœur que Moïse vous a donné ce précepte."]
+              "subtype": "usfm:span",
+              "content": [
+                "C’est à cause de la dureté de votre cœur que Moïse vous a donné ce précepte."
+              ]
             }
           ]
-        }, {
+        },
+        {
           "type": "paragraph",
           "subtype": "usfm:p",
           "content": [
@@ -5472,75 +6287,98 @@
             },
             {
               "type": "wrapper",
-              "subtype": "usfm:wj",
-              "content": ["Mais au commencement de la création, Dieu fit l’homme et la femme;"]
+              "subtype": "usfm:span",
+              "content": [
+                "Mais au commencement de la création, Dieu fit l’homme et la femme;"
+              ]
             },
-            " ", {
+            " ",
+            {
               "type": "mark",
               "subtype": "verses",
               "atts": {
                 "number": "7"
               }
-            }, {
+            },
+            {
               "type": "graft",
               "subtype": "xref",
               "target": "MjkzMmExNDgt"
-            }, {
-              "type": "wrapper",
-              "subtype": "usfm:wj",
-              "content": ["c’est pourquoi l’homme quittera son père et sa mère, et s’attachera à sa femme,"]
             },
-            " ", {
+            {
+              "type": "wrapper",
+              "subtype": "usfm:span",
+              "content": [
+                "c’est pourquoi l’homme quittera son père et sa mère, et s’attachera à sa femme,"
+              ]
+            },
+            " ",
+            {
               "type": "mark",
               "subtype": "verses",
               "atts": {
                 "number": "8"
               }
-            }, {
-              "type": "wrapper",
-              "subtype": "usfm:wj",
-              "content": ["et les deux deviendront une seule chair. Ainsi ils ne sont plus deux, mais ils sont une seule chair."]
             },
-            " ", {
+            {
+              "type": "wrapper",
+              "subtype": "usfm:span",
+              "content": [
+                "et les deux deviendront une seule chair. Ainsi ils ne sont plus deux, mais ils sont une seule chair."
+              ]
+            },
+            " ",
+            {
               "type": "mark",
               "subtype": "verses",
               "atts": {
                 "number": "9"
               }
-            }, {
+            },
+            {
               "type": "graft",
               "subtype": "xref",
               "target": "MDlmYTdjMzgt"
-            }, {
-              "type": "wrapper",
-              "subtype": "usfm:wj",
-              "content": ["Que l’homme donc ne sépare pas ce que Dieu a joint."]
             },
-            " ", {
+            {
+              "type": "wrapper",
+              "subtype": "usfm:span",
+              "content": [
+                "Que l’homme donc ne sépare pas ce que Dieu a joint."
+              ]
+            },
+            " ",
+            {
               "type": "mark",
               "subtype": "verses",
               "atts": {
                 "number": "10"
               }
             },
-            "Lorsqu’ils furent dans la maison, les disciples l’interrogèrent encore là-dessus. ", {
+            "Lorsqu’ils furent dans la maison, les disciples l’interrogèrent encore là-dessus. ",
+            {
               "type": "mark",
               "subtype": "verses",
               "atts": {
                 "number": "11"
               }
-            }, {
+            },
+            {
               "type": "graft",
               "subtype": "xref",
               "target": "M2I1ZTY3OTEt"
             },
-            "Il leur dit: ", {
+            "Il leur dit: ",
+            {
               "type": "wrapper",
-              "subtype": "usfm:wj",
-              "content": ["Celui qui répudie sa femme et qui en épouse une autre, commet un adultère à son égard;"]
+              "subtype": "usfm:span",
+              "content": [
+                "Celui qui répudie sa femme et qui en épouse une autre, commet un adultère à son égard;"
+              ]
             }
           ]
-        }, {
+        },
+        {
           "type": "paragraph",
           "subtype": "usfm:p",
           "content": [
@@ -5550,21 +6388,27 @@
               "atts": {
                 "number": "12"
               }
-            }, {
+            },
+            {
               "type": "wrapper",
-              "subtype": "usfm:wj",
-              "content": ["et si une femme quitte son mari et en épouse un autre, elle commet un adultère."]
+              "subtype": "usfm:span",
+              "content": [
+                "et si une femme quitte son mari et en épouse un autre, elle commet un adultère."
+              ]
             }
           ]
-        }, {
+        },
+        {
           "type": "graft",
           "subtype": "heading",
           "target": "OGNiZjcwM2It"
-        }, {
+        },
+        {
           "type": "graft",
           "subtype": "heading",
           "target": "YWU2ZjZjODMt"
-        }, {
+        },
+        {
           "type": "paragraph",
           "subtype": "usfm:p",
           "content": [
@@ -5588,29 +6432,32 @@
                 "number": "14"
               }
             },
-            "Jésus, voyant cela, fut indigné, et leur dit: ", {
+            "Jésus, voyant cela, fut indigné, et leur dit: ",
+            {
               "type": "wrapper",
-              "subtype": "usfm:wj",
-              "content": ["Laissez venir à moi les petits enfants, et ne les en empêchez pas;"]
-            }, {
+              "subtype": "usfm:span",
+              "content": [
+                "Laissez venir à moi les petits enfants, et ne les en empêchez pas;"
+              ]
+            },
+            {
               "type": "graft",
               "subtype": "xref",
               "target": "ZmYwNjNlMzUt"
-            }, {
+            },
+            {
               "type": "wrapper",
-              "subtype": "usfm:wj",
-              "content": ["car le royaume de Dieu est pour ceux qui leur ressemblent."]
+              "subtype": "usfm:span",
+              "content": [
+                "car le royaume de Dieu est pour ceux qui leur ressemblent."
+              ]
             }
           ]
-        }, {
+        },
+        {
           "type": "paragraph",
           "subtype": "usfm:p",
           "content": [
-            {
-              "type": "wrapper",
-              "subtype": "meta_content",
-              "meta_content": ["<== Long verse (33 words)"]
-            },
             {
               "type": "mark",
               "subtype": "verses",
@@ -5620,31 +6467,38 @@
             },
             {
               "type": "wrapper",
-              "subtype": "usfm:wj",
-              "content": ["Je vous le dis en vérité, quiconque ne recevra pas le royaume de Dieu comme un petit enfant n’y entrera point."]
+              "subtype": "usfm:span",
+              "content": [
+                "Je vous le dis en vérité, quiconque ne recevra pas le royaume de Dieu comme un petit enfant n’y entrera point."
+              ]
             },
-            " ", {
+            " ",
+            {
               "type": "mark",
               "subtype": "verses",
               "atts": {
                 "number": "16"
               }
-            }, {
+            },
+            {
               "type": "graft",
               "subtype": "xref",
               "target": "N2JiZjdkYWMt"
             },
             "Puis il les prit dans ses bras, et les bénit, en leur imposant les mains."
           ]
-        }, {
+        },
+        {
           "type": "graft",
           "subtype": "heading",
           "target": "NWQ3YjFhOGYt"
-        }, {
+        },
+        {
           "type": "graft",
           "subtype": "heading",
           "target": "MWYyZWE5YjYt"
-        }, {
+        },
+        {
           "type": "paragraph",
           "subtype": "usfm:p",
           "content": [
@@ -5668,13 +6522,17 @@
                 "number": "18"
               }
             },
-            "Jésus lui dit: ", {
+            "Jésus lui dit: ",
+            {
               "type": "wrapper",
-              "subtype": "usfm:wj",
-              "content": ["Pourquoi m’appelles-tu bon? Il n’y a de bon que Dieu seul."]
+              "subtype": "usfm:span",
+              "content": [
+                "Pourquoi m’appelles-tu bon? Il n’y a de bon que Dieu seul."
+              ]
             }
           ]
-        }, {
+        },
+        {
           "type": "paragraph",
           "subtype": "usfm:p",
           "content": [
@@ -5687,8 +6545,10 @@
             },
             {
               "type": "wrapper",
-              "subtype": "usfm:wj",
-              "content": ["Tu connais les commandements:"]
+              "subtype": "usfm:span",
+              "content": [
+                "Tu connais les commandements:"
+              ]
             },
             {
               "type": "graft",
@@ -5697,85 +6557,91 @@
             },
             {
               "type": "wrapper",
-              "subtype": "usfm:wj",
-              "content": ["Tu ne commettras point d’adultère; tu ne tueras point; tu ne déroberas point; tu ne diras point de faux témoignage; tu ne feras tort à personne; honore ton père et ta mère."]
+              "subtype": "usfm:span",
+              "content": [
+                "Tu ne commettras point d’adultère; tu ne tueras point; tu ne déroberas point; tu ne diras point de faux témoignage; tu ne feras tort à personne; honore ton père et ta mère."
+              ]
             },
-            " ", {
-              "type": "wrapper",
-              "subtype": "meta_content",
-              "meta_content": ["<== Long verse (38 words)"]
-            }, {
+            " ",
+            {
               "type": "mark",
               "subtype": "verses",
               "atts": {
                 "number": "20"
               }
             },
-            "Il lui répondit: Maître, j’ai observé toutes ces choses dès ma jeunesse. ", {
+            "Il lui répondit: Maître, j’ai observé toutes ces choses dès ma jeunesse. ",
+            {
               "type": "mark",
               "subtype": "verses",
               "atts": {
                 "number": "21"
               }
             },
-            "Jésus, l’ayant regardé, l’aima, et lui dit: ", {
+            "Jésus, l’ayant regardé, l’aima, et lui dit: ",
+            {
               "type": "graft",
               "subtype": "xref",
               "target": "MDExNmMwMjct"
-            }, {
-              "type": "wrapper",
-              "subtype": "usfm:wj",
-              "content": ["Il te manque une chose; va, vends tout ce que tu as, donne-le aux pauvres, et tu auras un trésor dans le ciel. Puis viens, et suis-moi."]
             },
-            " ", {
+            {
               "type": "wrapper",
-              "subtype": "meta_content",
-              "meta_content": ["<== Long verse (37 words)"]
-            }, {
+              "subtype": "usfm:span",
+              "content": [
+                "Il te manque une chose; va, vends tout ce que tu as, donne-le aux pauvres, et tu auras un trésor dans le ciel. Puis viens, et suis-moi."
+              ]
+            },
+            " ",
+            {
               "type": "mark",
               "subtype": "verses",
               "atts": {
                 "number": "22"
               }
             },
-            "Mais, affligé de cette parole, cet homme s’en alla tout triste; car il avait de grands biens. ", {
+            "Mais, affligé de cette parole, cet homme s’en alla tout triste; car il avait de grands biens. ",
+            {
               "type": "mark",
               "subtype": "verses",
               "atts": {
                 "number": "23"
               }
             },
-            "Jésus, regardant autour de lui, dit à ses disciples: ", {
+            "Jésus, regardant autour de lui, dit à ses disciples: ",
+            {
               "type": "graft",
               "subtype": "xref",
               "target": "NDA4ZWYxOWIt"
-            }, {
-              "type": "wrapper",
-              "subtype": "usfm:wj",
-              "content": ["Qu’il sera difficile à ceux qui ont des richesses d’entrer dans le royaume de Dieu!"]
             },
-            " ", {
+            {
+              "type": "wrapper",
+              "subtype": "usfm:span",
+              "content": [
+                "Qu’il sera difficile à ceux qui ont des richesses d’entrer dans le royaume de Dieu!"
+              ]
+            },
+            " ",
+            {
               "type": "mark",
               "subtype": "verses",
               "atts": {
                 "number": "24"
               }
             },
-            "Les disciples furent étonnés de ce que Jésus parlait ainsi. Et, reprenant, il leur dit: ", {
+            "Les disciples furent étonnés de ce que Jésus parlait ainsi. Et, reprenant, il leur dit: ",
+            {
               "type": "wrapper",
-              "subtype": "usfm:wj",
-              "content": ["Mes enfants, qu’il est difficile à ceux qui se confient dans les richesses d’entrer dans le royaume de Dieu!"]
+              "subtype": "usfm:span",
+              "content": [
+                "Mes enfants, qu’il est difficile à ceux qui se confient dans les richesses d’entrer dans le royaume de Dieu!"
+              ]
             }
           ]
-        }, {
+        },
+        {
           "type": "paragraph",
           "subtype": "usfm:p",
           "content": [
-            {
-              "type": "wrapper",
-              "subtype": "meta_content",
-              "meta_content": ["<== Long verse (35 words)"]
-            },
             {
               "type": "mark",
               "subtype": "verses",
@@ -5785,46 +6651,60 @@
             },
             {
               "type": "wrapper",
-              "subtype": "usfm:wj",
-              "content": ["Il est plus facile à un chameau de passer par le trou d’une aiguille qu’à un riche d’entrer dans le royaume de Dieu."]
+              "subtype": "usfm:span",
+              "content": [
+                "Il est plus facile à un chameau de passer par le trou d’une aiguille qu’à un riche d’entrer dans le royaume de Dieu."
+              ]
             },
-            " ", {
+            " ",
+            {
               "type": "mark",
               "subtype": "verses",
               "atts": {
                 "number": "26"
               }
             },
-            "Les disciples furent encore plus étonnés, et ils se dirent les uns aux autres; Et qui peut être sauvé? ", {
+            "Les disciples furent encore plus étonnés, et ils se dirent les uns aux autres; Et qui peut être sauvé? ",
+            {
               "type": "mark",
               "subtype": "verses",
               "atts": {
                 "number": "27"
               }
             },
-            "Jésus les regarda, et dit: ", {
+            "Jésus les regarda, et dit: ",
+            {
               "type": "wrapper",
-              "subtype": "usfm:wj",
-              "content": ["Cela est impossible aux hommes, mais non à Dieu:"]
-            }, {
+              "subtype": "usfm:span",
+              "content": [
+                "Cela est impossible aux hommes, mais non à Dieu:"
+              ]
+            },
+            {
               "type": "graft",
               "subtype": "xref",
               "target": "NWQ5MTcxOGMt"
-            }, {
+            },
+            {
               "type": "wrapper",
-              "subtype": "usfm:wj",
-              "content": ["car tout est possible à Dieu."]
+              "subtype": "usfm:span",
+              "content": [
+                "car tout est possible à Dieu."
+              ]
             }
           ]
-        }, {
+        },
+        {
           "type": "graft",
           "subtype": "heading",
           "target": "NWRhYmE3MzIt"
-        }, {
+        },
+        {
           "type": "graft",
           "subtype": "heading",
           "target": "NTg1MGIyODQt"
-        }, {
+        },
+        {
           "type": "paragraph",
           "subtype": "usfm:p",
           "content": [
@@ -5848,21 +6728,20 @@
                 "number": "29"
               }
             },
-            "Jésus répondit: ", {
+            "Jésus répondit: ",
+            {
               "type": "wrapper",
-              "subtype": "usfm:wj",
-              "content": ["Je vous le dis en vérité, il n’est personne qui, ayant quitté, à cause de moi et à cause de la bonne nouvelle, sa maison, ou ses frères, ou ses sœurs, ou sa mère, ou son père, ou ses enfants, ou ses terres,"]
+              "subtype": "usfm:span",
+              "content": [
+                "Je vous le dis en vérité, il n’est personne qui, ayant quitté, à cause de moi et à cause de la bonne nouvelle, sa maison, ou ses frères, ou ses sœurs, ou sa mère, ou son père, ou ses enfants, ou ses terres,"
+              ]
             }
           ]
-        }, {
+        },
+        {
           "type": "paragraph",
           "subtype": "usfm:p",
           "content": [
-            {
-              "type": "wrapper",
-              "subtype": "meta_content",
-              "meta_content": ["<== Long verse (46 words)"]
-            },
             {
               "type": "mark",
               "subtype": "verses",
@@ -5872,38 +6751,44 @@
             },
             {
               "type": "wrapper",
-              "subtype": "usfm:wj",
-              "content": ["ne reçoive au centuple, présentement dans ce siècle-ci, des maisons, des frères, des sœurs, des mères, des enfants, et des terres, avec des persécutions, et, dans le siècle à venir, la vie éternelle."]
+              "subtype": "usfm:span",
+              "content": [
+                "ne reçoive au centuple, présentement dans ce siècle-ci, des maisons, des frères, des sœurs, des mères, des enfants, et des terres, avec des persécutions, et, dans le siècle à venir, la vie éternelle."
+              ]
             },
-            " ", {
-              "type": "wrapper",
-              "subtype": "meta_content",
-              "meta_content": ["<== Long verse (35 words)"]
-            }, {
+            " ",
+            {
               "type": "mark",
               "subtype": "verses",
               "atts": {
                 "number": "31"
               }
-            }, {
+            },
+            {
               "type": "graft",
               "subtype": "xref",
               "target": "NmZkYjIzN2Qt"
-            }, {
+            },
+            {
               "type": "wrapper",
-              "subtype": "usfm:wj",
-              "content": ["Plusieurs des premiers seront les derniers, et plusieurs des derniers seront les premiers."]
+              "subtype": "usfm:span",
+              "content": [
+                "Plusieurs des premiers seront les derniers, et plusieurs des derniers seront les premiers."
+              ]
             }
           ]
-        }, {
+        },
+        {
           "type": "graft",
           "subtype": "heading",
           "target": "N2ZhNzQ3N2Yt"
-        }, {
+        },
+        {
           "type": "graft",
           "subtype": "heading",
           "target": "OTQxYzRkYjQt"
-        }, {
+        },
+        {
           "type": "paragraph",
           "subtype": "usfm:p",
           "content": [
@@ -5913,22 +6798,19 @@
               "atts": {
                 "number": "32"
               }
-            }, {
+            },
+            {
               "type": "graft",
               "subtype": "xref",
               "target": "NDUyMDdmMTct"
             },
             "Ils étaient en chemin pour monter à Jérusalem, et Jésus allait devant eux. Les disciples étaient troublés, et le suivaient avec crainte. Et Jésus prit de nouveau les douze auprès de lui, et commença à leur dire ce qui devait lui arriver:"
           ]
-        }, {
+        },
+        {
           "type": "paragraph",
           "subtype": "usfm:p",
           "content": [
-            {
-              "type": "wrapper",
-              "subtype": "meta_content",
-              "meta_content": ["<== Long verse (42 words)"]
-            },
             {
               "type": "mark",
               "subtype": "verses",
@@ -5938,34 +6820,39 @@
             },
             {
               "type": "wrapper",
-              "subtype": "usfm:wj",
-              "content": ["Voici, nous montons à Jérusalem, et le Fils de l’homme sera livré aux principaux sacrificateurs et aux scribes. Ils le condamneront à mort, et ils le livreront aux païens,"]
+              "subtype": "usfm:span",
+              "content": [
+                "Voici, nous montons à Jérusalem, et le Fils de l’homme sera livré aux principaux sacrificateurs et aux scribes. Ils le condamneront à mort, et ils le livreront aux païens,"
+              ]
             },
-            " ", {
-              "type": "wrapper",
-              "subtype": "meta_content",
-              "meta_content": ["<== Long verse (31 words)"]
-            }, {
+            " ",
+            {
               "type": "mark",
               "subtype": "verses",
               "atts": {
                 "number": "34"
               }
-            }, {
+            },
+            {
               "type": "wrapper",
-              "subtype": "usfm:wj",
-              "content": ["qui se moqueront de lui, cracheront sur lui, le battront de verges, et le feront mourir; et, trois jours après, il ressuscitera."]
+              "subtype": "usfm:span",
+              "content": [
+                "qui se moqueront de lui, cracheront sur lui, le battront de verges, et le feront mourir; et, trois jours après, il ressuscitera."
+              ]
             }
           ]
-        }, {
+        },
+        {
           "type": "graft",
           "subtype": "heading",
           "target": "ZWI4YTY1ZTUt"
-        }, {
+        },
+        {
           "type": "graft",
           "subtype": "heading",
           "target": "ZGExMTVmZjct"
-        }, {
+        },
+        {
           "type": "paragraph",
           "subtype": "usfm:p",
           "content": [
@@ -5989,56 +6876,69 @@
                 "number": "36"
               }
             },
-            "Il leur dit: ", {
+            "Il leur dit: ",
+            {
               "type": "wrapper",
-              "subtype": "usfm:wj",
-              "content": ["Que voulez-vous que je fasse pour vous?"]
+              "subtype": "usfm:span",
+              "content": [
+                "Que voulez-vous que je fasse pour vous?"
+              ]
             },
-            " ", {
+            " ",
+            {
               "type": "mark",
               "subtype": "verses",
               "atts": {
                 "number": "37"
               }
             },
-            "Accorde-nous, lui dirent-ils, d’être assis l’un à ta droite et l’autre à ta gauche, quand tu seras dans ta gloire. ", {
+            "Accorde-nous, lui dirent-ils, d’être assis l’un à ta droite et l’autre à ta gauche, quand tu seras dans ta gloire. ",
+            {
               "type": "mark",
               "subtype": "verses",
               "atts": {
                 "number": "38"
               }
             },
-            "Jésus leur répondit: ", {
+            "Jésus leur répondit: ",
+            {
               "type": "wrapper",
-              "subtype": "usfm:wj",
-              "content": ["Vous ne savez ce que vous demandez. Pouvez-vous boire la coupe que je dois boire, ou être baptisés du baptême"]
-            }, {
+              "subtype": "usfm:span",
+              "content": [
+                "Vous ne savez ce que vous demandez. Pouvez-vous boire la coupe que je dois boire, ou être baptisés du baptême"
+              ]
+            },
+            {
               "type": "graft",
               "subtype": "xref",
               "target": "Nzg3MTBmOWEt"
-            }, {
-              "type": "wrapper",
-              "subtype": "usfm:wj",
-              "content": ["dont je dois être baptisé?"]
             },
-            " Nous le pouvons, dirent-ils. ", {
+            {
               "type": "wrapper",
-              "subtype": "meta_content",
-              "meta_content": ["<== Long verse (35 words)"]
-            }, {
+              "subtype": "usfm:span",
+              "content": [
+                "dont je dois être baptisé?"
+              ]
+            },
+            " Nous le pouvons, dirent-ils. ",
+            {
               "type": "mark",
               "subtype": "verses",
               "atts": {
                 "number": "39"
               }
             },
-            "Et Jésus leur répondit: ", {
+            "Et Jésus leur répondit: ",
+            {
               "type": "wrapper",
-              "subtype": "usfm:wj",
-              "content": ["Il est vrai que vous boirez la coupe que je dois boire, et que vous serez baptisés du baptême dont je dois être baptisé;"]
+              "subtype": "usfm:span",
+              "content": [
+                "Il est vrai que vous boirez la coupe que je dois boire, et que vous serez baptisés du baptême dont je dois être baptisé;"
+              ]
             }
           ]
-        }, {
+        },
+        {
           "type": "paragraph",
           "subtype": "usfm:p",
           "content": [
@@ -6056,46 +6956,55 @@
             },
             {
               "type": "wrapper",
-              "subtype": "usfm:wj",
-              "content": ["mais pour ce qui est d’être assis à ma droite ou à ma gauche, cela ne dépend pas de moi, et ne sera donné qu’à ceux à qui cela est réservé."]
+              "subtype": "usfm:span",
+              "content": [
+                "mais pour ce qui est d’être assis à ma droite ou à ma gauche, cela ne dépend pas de moi, et ne sera donné qu’à ceux à qui cela est réservé."
+              ]
             },
-            " ", {
-              "type": "wrapper",
-              "subtype": "meta_content",
-              "meta_content": ["<== Long verse (33 words)"]
-            }, {
+            " ",
+            {
               "type": "mark",
               "subtype": "verses",
               "atts": {
                 "number": "41"
               }
-            }, {
+            },
+            {
               "type": "graft",
               "subtype": "xref",
               "target": "YjQ2NDIzMzkt"
             },
-            "Les dix, ayant entendu cela, commencèrent à s’indigner contre Jacques et Jean. ", {
+            "Les dix, ayant entendu cela, commencèrent à s’indigner contre Jacques et Jean. ",
+            {
               "type": "mark",
               "subtype": "verses",
               "atts": {
                 "number": "42"
               }
             },
-            "Jésus les appela, et leur dit: ", {
+            "Jésus les appela, et leur dit: ",
+            {
               "type": "wrapper",
-              "subtype": "usfm:wj",
-              "content": ["Vous savez"]
-            }, {
+              "subtype": "usfm:span",
+              "content": [
+                "Vous savez"
+              ]
+            },
+            {
               "type": "graft",
               "subtype": "xref",
               "target": "ZWEzZTdjYTgt"
-            }, {
+            },
+            {
               "type": "wrapper",
-              "subtype": "usfm:wj",
-              "content": ["que ceux qu’on regarde comme les chefs des nations les tyrannisent, et que les grands les dominent."]
+              "subtype": "usfm:span",
+              "content": [
+                "que ceux qu’on regarde comme les chefs des nations les tyrannisent, et que les grands les dominent."
+              ]
             }
           ]
-        }, {
+        },
+        {
           "type": "paragraph",
           "subtype": "usfm:p",
           "content": [
@@ -6113,57 +7022,78 @@
             },
             {
               "type": "wrapper",
-              "subtype": "usfm:wj",
-              "content": ["Il n’en est pas de même au milieu de vous. Mais quiconque veut être grand parmi vous, qu’il soit votre serviteur;"]
+              "subtype": "usfm:span",
+              "content": [
+                "Il n’en est pas de même au milieu de vous. Mais quiconque veut être grand parmi vous, qu’il soit votre serviteur;"
+              ]
             },
-            " ", {
+            " ",
+            {
               "type": "mark",
               "subtype": "verses",
               "atts": {
                 "number": "44"
               }
-            }, {
-              "type": "wrapper",
-              "subtype": "usfm:wj",
-              "content": ["et quiconque veut être le premier parmi vous, qu’il soit l’esclave de tous."]
             },
-            " ", {
+            {
+              "type": "wrapper",
+              "subtype": "usfm:span",
+              "content": [
+                "et quiconque veut être le premier parmi vous, qu’il soit l’esclave de tous."
+              ]
+            },
+            " ",
+            {
               "type": "mark",
               "subtype": "verses",
               "atts": {
                 "number": "45"
               }
-            }, {
+            },
+            {
               "type": "wrapper",
-              "subtype": "usfm:wj",
-              "content": ["Car le Fils de l’homme est venu,"]
-            }, {
+              "subtype": "usfm:span",
+              "content": [
+                "Car le Fils de l’homme est venu,"
+              ]
+            },
+            {
               "type": "graft",
               "subtype": "xref",
               "target": "NDczYjI3YTAt"
-            }, {
+            },
+            {
               "type": "wrapper",
-              "subtype": "usfm:wj",
-              "content": ["non pour être servi, mais pour servir et"]
-            }, {
+              "subtype": "usfm:span",
+              "content": [
+                "non pour être servi, mais pour servir et"
+              ]
+            },
+            {
               "type": "graft",
               "subtype": "xref",
               "target": "MTAyNWMzZTct"
-            }, {
+            },
+            {
               "type": "wrapper",
-              "subtype": "usfm:wj",
-              "content": ["donner sa vie comme la rançon de plusieurs."]
+              "subtype": "usfm:span",
+              "content": [
+                "donner sa vie comme la rançon de plusieurs."
+              ]
             }
           ]
-        }, {
+        },
+        {
           "type": "graft",
           "subtype": "heading",
           "target": "NDZhNzJmZjct"
-        }, {
+        },
+        {
           "type": "graft",
           "subtype": "heading",
           "target": "MTM1ZTI1NjYt"
-        }, {
+        },
+        {
           "type": "paragraph",
           "subtype": "usfm:p",
           "content": [
@@ -6181,75 +7111,90 @@
             },
             "Ils arrivèrent à Jéricho. Et, lorsque Jésus en sortit, avec ses disciples et une assez grande foule, le fils de Timée, Bartimée, mendiant aveugle, était assis au bord du chemin. ",
             {
-              "type": "wrapper",
-              "subtype": "meta_content",
-              "meta_content": ["<== Long verse (31 words)"]
-            }, {
               "type": "mark",
               "subtype": "verses",
               "atts": {
                 "number": "47"
               }
             },
-            "Il entendit que c’était Jésus de Nazareth, et il se mit à crier; Fils de David, Jésus aie pitié de moi! ", {
+            "Il entendit que c’était Jésus de Nazareth, et il se mit à crier; Fils de David, Jésus aie pitié de moi! ",
+            {
               "type": "mark",
               "subtype": "verses",
               "atts": {
                 "number": "48"
               }
             },
-            "Plusieurs le reprenaient, pour le faire taire; mais il criait beaucoup plus fort; Fils de David, aie pitié de moi! ", {
+            "Plusieurs le reprenaient, pour le faire taire; mais il criait beaucoup plus fort; Fils de David, aie pitié de moi! ",
+            {
               "type": "mark",
               "subtype": "verses",
               "atts": {
                 "number": "49"
               }
             },
-            "Jésus s’arrêta, et dit: ", {
+            "Jésus s’arrêta, et dit: ",
+            {
               "type": "wrapper",
-              "subtype": "usfm:wj",
-              "content": ["Appelez-le."]
+              "subtype": "usfm:span",
+              "content": [
+                "Appelez-le."
+              ]
             },
-            " Ils appelèrent l’aveugle, en lui disant: Prends courage, lève-toi, il t’appelle. ", {
+            " Ils appelèrent l’aveugle, en lui disant: Prends courage, lève-toi, il t’appelle. ",
+            {
               "type": "mark",
               "subtype": "verses",
               "atts": {
                 "number": "50"
               }
             },
-            "L’aveugle jeta son manteau, et, se levant d’un bond, vint vers Jésus. ", {
+            "L’aveugle jeta son manteau, et, se levant d’un bond, vint vers Jésus. ",
+            {
               "type": "mark",
               "subtype": "verses",
               "atts": {
                 "number": "51"
               }
             },
-            "Jésus, prenant la parole, lui dit: ", {
+            "Jésus, prenant la parole, lui dit: ",
+            {
               "type": "wrapper",
-              "subtype": "usfm:wj",
-              "content": ["Que veux-tu que je te fasse?"]
+              "subtype": "usfm:span",
+              "content": [
+                "Que veux-tu que je te fasse?"
+              ]
             },
-            " Rabbouni, lui répondit l’aveugle, que je recouvre la vue. ", {
+            " Rabbouni, lui répondit l’aveugle, que je recouvre la vue. ",
+            {
               "type": "mark",
               "subtype": "verses",
               "atts": {
                 "number": "52"
               }
             },
-            "Et Jésus lui dit: ", {
+            "Et Jésus lui dit: ",
+            {
               "type": "wrapper",
-              "subtype": "usfm:wj",
-              "content": ["Va,"]
-            }, {
+              "subtype": "usfm:span",
+              "content": [
+                "Va,"
+              ]
+            },
+            {
               "type": "graft",
               "subtype": "xref",
               "target": "MTliZGVlNzIt"
-            }, {
-              "type": "wrapper",
-              "subtype": "usfm:wj",
-              "content": ["ta foi t’a sauvé."]
             },
-            " ", {
+            {
+              "type": "wrapper",
+              "subtype": "usfm:span",
+              "content": [
+                "ta foi t’a sauvé."
+              ]
+            },
+            " ",
+            {
               "type": "mark",
               "subtype": "verses",
               "atts": {
@@ -6258,15 +7203,18 @@
             },
             "Aussitôt il recouvra la vue, et suivit Jésus dans le chemin."
           ]
-        }, {
+        },
+        {
           "type": "graft",
           "subtype": "heading",
           "target": "NGRjZThiZWYt"
-        }, {
+        },
+        {
           "type": "graft",
           "subtype": "heading",
           "target": "ZGFhMzdiN2Qt"
-        }, {
+        },
+        {
           "type": "paragraph",
           "subtype": "usfm:p",
           "content": [
@@ -6289,28 +7237,28 @@
               "subtype": "xref",
               "target": "YzhjZTc2YzYt"
             },
-            "Lorsqu’ils approchèrent de Jérusalem, et qu’ils furent près de Bethphagé et de Béthanie, vers la montagne des oliviers, Jésus envoya deux de ses disciples, ", {
+            "Lorsqu’ils approchèrent de Jérusalem, et qu’ils furent près de Bethphagé et de Béthanie, vers la montagne des oliviers, Jésus envoya deux de ses disciples, ",
+            {
               "type": "mark",
               "subtype": "verses",
               "atts": {
                 "number": "2"
               }
             },
-            "en leur disant: ", {
+            "en leur disant: ",
+            {
               "type": "wrapper",
-              "subtype": "usfm:wj",
-              "content": ["Allez au village qui est devant vous; dès que vous y serez entrés, vous trouverez un ânon attaché, sur lequel aucun homme ne s’est encore assis; détachez-le, et amenez-le."]
+              "subtype": "usfm:span",
+              "content": [
+                "Allez au village qui est devant vous; dès que vous y serez entrés, vous trouverez un ânon attaché, sur lequel aucun homme ne s’est encore assis; détachez-le, et amenez-le."
+              ]
             }
           ]
-        }, {
+        },
+        {
           "type": "paragraph",
           "subtype": "usfm:p",
           "content": [
-            {
-              "type": "wrapper",
-              "subtype": "meta_content",
-              "meta_content": ["<== Long verse (33 words)"]
-            },
             {
               "type": "mark",
               "subtype": "verses",
@@ -6320,95 +7268,112 @@
             },
             {
               "type": "wrapper",
-              "subtype": "usfm:wj",
-              "content": ["Si quelqu’un vous dit: Pourquoi faites-vous cela? Répondez: Le Seigneur en a besoin. Et à l’instant il le laissera venir ici."]
+              "subtype": "usfm:span",
+              "content": [
+                "Si quelqu’un vous dit: Pourquoi faites-vous cela? Répondez: Le Seigneur en a besoin. Et à l’instant il le laissera venir ici."
+              ]
             },
-            " ", {
+            " ",
+            {
               "type": "mark",
               "subtype": "verses",
               "atts": {
                 "number": "4"
               }
             },
-            "les disciples, étant allés, trouvèrent l’ânon attaché dehors près d’une porte, au contour du chemin, et ils le détachèrent. ", {
+            "les disciples, étant allés, trouvèrent l’ânon attaché dehors près d’une porte, au contour du chemin, et ils le détachèrent. ",
+            {
               "type": "mark",
               "subtype": "verses",
               "atts": {
                 "number": "5"
               }
             },
-            "Quelques-uns de ceux qui étaient là leur dirent: Que faites-vous? Pourquoi détachez-vous cet ânon? ", {
+            "Quelques-uns de ceux qui étaient là leur dirent: Que faites-vous? Pourquoi détachez-vous cet ânon? ",
+            {
               "type": "mark",
               "subtype": "verses",
               "atts": {
                 "number": "6"
               }
             },
-            "Ils répondirent comme Jésus l’avait dit. Et on les laissa aller. ", {
+            "Ils répondirent comme Jésus l’avait dit. Et on les laissa aller. ",
+            {
               "type": "mark",
               "subtype": "verses",
               "atts": {
                 "number": "7"
               }
             },
-            "Ils amenèrent à Jésus ", {
+            "Ils amenèrent à Jésus ",
+            {
               "type": "graft",
               "subtype": "xref",
               "target": "NWU1OGM0NDQt"
             },
-            "l’ânon, sur lequel ils jetèrent ", {
+            "l’ânon, sur lequel ils jetèrent ",
+            {
               "type": "graft",
               "subtype": "xref",
               "target": "NGVhNzUxYzIt"
             },
-            "leurs vêtements, et Jésus s’assit dessus. ", {
+            "leurs vêtements, et Jésus s’assit dessus. ",
+            {
               "type": "mark",
               "subtype": "verses",
               "atts": {
                 "number": "8"
               }
             },
-            "Beaucoup de gens étendirent leurs vêtements sur le chemin, et d’autres des branches qu’ils coupèrent dans les champs. ", {
+            "Beaucoup de gens étendirent leurs vêtements sur le chemin, et d’autres des branches qu’ils coupèrent dans les champs. ",
+            {
               "type": "mark",
               "subtype": "verses",
               "atts": {
                 "number": "9"
               }
             },
-            "Ceux qui précédaient et ceux qui suivaient Jésus criaient: Hosanna! ", {
+            "Ceux qui précédaient et ceux qui suivaient Jésus criaient: Hosanna! ",
+            {
               "type": "graft",
               "subtype": "xref",
               "target": "ZGE1Zjc0MzYt"
             },
-            "Béni soit celui qui vient au nom du Seigneur! ", {
+            "Béni soit celui qui vient au nom du Seigneur! ",
+            {
               "type": "mark",
               "subtype": "verses",
               "atts": {
                 "number": "10"
               }
             },
-            "Béni soit le règne qui vient, le règne de David, notre père! Hosanna dans les lieux très hauts! ", {
+            "Béni soit le règne qui vient, le règne de David, notre père! Hosanna dans les lieux très hauts! ",
+            {
               "type": "mark",
               "subtype": "verses",
               "atts": {
                 "number": "11"
               }
-            }, {
+            },
+            {
               "type": "graft",
               "subtype": "xref",
               "target": "MjM4MzRkMDct"
             },
             "Jésus entra à Jérusalem, dans le temple. Quand il eut tout considéré, comme il était déjà tard, il s’en alla à Béthanie avec les douze."
           ]
-        }, {
+        },
+        {
           "type": "graft",
           "subtype": "heading",
           "target": "ZWFkNTRmZTkt"
-        }, {
+        },
+        {
           "type": "graft",
           "subtype": "heading",
           "target": "NTkwNGY2ZTIt"
-        }, {
+        },
+        {
           "type": "paragraph",
           "subtype": "usfm:p",
           "content": [
@@ -6432,98 +7397,105 @@
                 "number": "13"
               }
             },
-            "Apercevant de loin un figuier qui avait des feuilles, il alla voir s’il y trouverait quelque chose; et, s’en étant approché, il ne trouva que des feuilles, car ce n’était pas la saison des figues. ", {
-              "type": "wrapper",
-              "subtype": "meta_content",
-              "meta_content": ["<== Long verse (36 words)"]
-            }, {
+            "Apercevant de loin un figuier qui avait des feuilles, il alla voir s’il y trouverait quelque chose; et, s’en étant approché, il ne trouva que des feuilles, car ce n’était pas la saison des figues. ",
+            {
               "type": "mark",
               "subtype": "verses",
               "atts": {
                 "number": "14"
               }
             },
-            "Prenant alors la parole, il lui dit: ", {
+            "Prenant alors la parole, il lui dit: ",
+            {
               "type": "wrapper",
-              "subtype": "usfm:wj",
-              "content": ["Que jamais personne ne mange de ton fruit!"]
+              "subtype": "usfm:span",
+              "content": [
+                "Que jamais personne ne mange de ton fruit!"
+              ]
             },
-            " Et ses disciples l’entendirent. ", {
+            " Et ses disciples l’entendirent. ",
+            {
               "type": "mark",
               "subtype": "verses",
               "atts": {
                 "number": "15"
               }
             },
-            "Ils arrivèrent à Jérusalem, ", {
+            "Ils arrivèrent à Jérusalem, ",
+            {
               "type": "graft",
               "subtype": "xref",
               "target": "MzQ5OTI4NTIt"
             },
-            "et Jésus entra dans le temple. Il se mit à chasser ceux qui vendaient et qui achetaient dans le temple; il renversa les tables des changeurs, et les sièges des vendeurs de pigeons; ", {
-              "type": "wrapper",
-              "subtype": "meta_content",
-              "meta_content": ["<== Long verse (39 words)"]
-            }, {
+            "et Jésus entra dans le temple. Il se mit à chasser ceux qui vendaient et qui achetaient dans le temple; il renversa les tables des changeurs, et les sièges des vendeurs de pigeons; ",
+            {
               "type": "mark",
               "subtype": "verses",
               "atts": {
                 "number": "16"
               }
             },
-            "et il ne laissait personne transporter aucun objet à travers le temple. ", {
+            "et il ne laissait personne transporter aucun objet à travers le temple. ",
+            {
               "type": "mark",
               "subtype": "verses",
               "atts": {
                 "number": "17"
               }
-            }, {
+            },
+            {
               "type": "graft",
               "subtype": "xref",
               "target": "MWZiMmI0NDYt"
             },
-            "Et il enseignait et disait: ", {
+            "Et il enseignait et disait: ",
+            {
               "type": "wrapper",
-              "subtype": "usfm:wj",
-              "content": ["N’est-il pas écrit:"]
-            }, {
+              "subtype": "usfm:span",
+              "content": [
+                "N’est-il pas écrit:"
+              ]
+            },
+            {
               "type": "graft",
               "subtype": "xref",
               "target": "NThkMWRkZjYt"
-            }, {
+            },
+            {
               "type": "wrapper",
-              "subtype": "usfm:wj",
-              "content": ["Ma maison sera appelée une maison de prière pour toutes les nations?"]
-            }, {
+              "subtype": "usfm:span",
+              "content": [
+                "Ma maison sera appelée une maison de prière pour toutes les nations?"
+              ]
+            },
+            {
               "type": "graft",
               "subtype": "xref",
               "target": "MjhhZjNmNGYt"
-            }, {
-              "type": "wrapper",
-              "subtype": "usfm:wj",
-              "content": ["Mais vous, vous en avez fait une caverne de voleurs."]
             },
-            " ", {
+            {
               "type": "wrapper",
-              "subtype": "meta_content",
-              "meta_content": ["<== Long verse (33 words)"]
-            }, {
+              "subtype": "usfm:span",
+              "content": [
+                "Mais vous, vous en avez fait une caverne de voleurs."
+              ]
+            },
+            " ",
+            {
               "type": "mark",
               "subtype": "verses",
               "atts": {
                 "number": "18"
               }
             },
-            "Les principaux sacrificateurs et les scribes, l’ayant entendu, ", {
+            "Les principaux sacrificateurs et les scribes, l’ayant entendu, ",
+            {
               "type": "graft",
               "subtype": "xref",
               "target": "Y2M3ODczZWUt"
             },
-            "cherchèrent les moyens de le faire périr; car ils le craignaient, parce que toute la foule était frappée de sa doctrine. ", {
-              "type": "wrapper",
-              "subtype": "meta_content",
-              "meta_content": ["<== Long verse (31 words)"]
-            }, {
+            "cherchèrent les moyens de le faire périr; car ils le craignaient, parce que toute la foule était frappée de sa doctrine. ",
+            {
               "type": "mark",
               "subtype": "verses",
               "atts": {
@@ -6532,15 +7504,18 @@
             },
             "Quand le soir fut venu, Jésus sortit de la ville."
           ]
-        }, {
+        },
+        {
           "type": "graft",
           "subtype": "heading",
           "target": "YzBkZWVlODUt"
-        }, {
+        },
+        {
           "type": "graft",
           "subtype": "heading",
           "target": "NWJkMzQ4MzEt"
-        }, {
+        },
+        {
           "type": "paragraph",
           "subtype": "usfm:p",
           "content": [
@@ -6559,20 +7534,25 @@
                 "number": "21"
               }
             },
-            "Pierre, se rappelant ce qui s’était passé, dit à Jésus: Rabbi, regarde, le figuier que tu as maudit a séché. ", {
+            "Pierre, se rappelant ce qui s’était passé, dit à Jésus: Rabbi, regarde, le figuier que tu as maudit a séché. ",
+            {
               "type": "mark",
               "subtype": "verses",
               "atts": {
                 "number": "22"
               }
             },
-            "Jésus prit la parole, et leur dit: ", {
+            "Jésus prit la parole, et leur dit: ",
+            {
               "type": "wrapper",
-              "subtype": "usfm:wj",
-              "content": ["Ayez foi en Dieu."]
+              "subtype": "usfm:span",
+              "content": [
+                "Ayez foi en Dieu."
+              ]
             }
           ]
-        }, {
+        },
+        {
           "type": "paragraph",
           "subtype": "usfm:p",
           "content": [
@@ -6590,80 +7570,98 @@
             },
             {
               "type": "wrapper",
-              "subtype": "usfm:wj",
-              "content": ["Je vous le dis en vérité, si quelqu’un dit à cette montagne: Ote-toi de là et jette-toi dans la mer, et s’il ne doute point en son cœur, mais croit que ce qu’il dit arrive, il le verra s’accomplir."]
+              "subtype": "usfm:span",
+              "content": [
+                "Je vous le dis en vérité, si quelqu’un dit à cette montagne: Ote-toi de là et jette-toi dans la mer, et s’il ne doute point en son cœur, mais croit que ce qu’il dit arrive, il le verra s’accomplir."
+              ]
             },
-            " ", {
-              "type": "wrapper",
-              "subtype": "meta_content",
-              "meta_content": ["<== Long verse (41 words)"]
-            }, {
+            " ",
+            {
               "type": "mark",
               "subtype": "verses",
               "atts": {
                 "number": "24"
               }
-            }, {
+            },
+            {
               "type": "wrapper",
-              "subtype": "usfm:wj",
-              "content": ["C’est pourquoi je vous dis:"]
-            }, {
+              "subtype": "usfm:span",
+              "content": [
+                "C’est pourquoi je vous dis:"
+              ]
+            },
+            {
               "type": "graft",
               "subtype": "xref",
               "target": "MmJlMDVlNjQt"
-            }, {
-              "type": "wrapper",
-              "subtype": "usfm:wj",
-              "content": ["Tout ce que vous demanderez en priant, croyez que vous l’avez reçu, et vous le verrez s’accomplir."]
             },
-            " ", {
+            {
+              "type": "wrapper",
+              "subtype": "usfm:span",
+              "content": [
+                "Tout ce que vous demanderez en priant, croyez que vous l’avez reçu, et vous le verrez s’accomplir."
+              ]
+            },
+            " ",
+            {
               "type": "mark",
               "subtype": "verses",
               "atts": {
                 "number": "25"
               }
-            }, {
+            },
+            {
               "type": "wrapper",
-              "subtype": "usfm:wj",
-              "content": ["Et, lorsque vous êtes debout faisant votre prière, si vous avez quelque chose contre quelqu’un,"]
-            }, {
+              "subtype": "usfm:span",
+              "content": [
+                "Et, lorsque vous êtes debout faisant votre prière, si vous avez quelque chose contre quelqu’un,"
+              ]
+            },
+            {
               "type": "graft",
               "subtype": "xref",
               "target": "N2ZiODgzNGMt"
-            }, {
-              "type": "wrapper",
-              "subtype": "usfm:wj",
-              "content": ["pardonnez, afin que votre Père qui est dans les cieux vous pardonne aussi vos offenses."]
             },
-            " ", {
+            {
               "type": "wrapper",
-              "subtype": "meta_content",
-              "meta_content": ["<== Long verse (32 words)"]
-            }, {
+              "subtype": "usfm:span",
+              "content": [
+                "pardonnez, afin que votre Père qui est dans les cieux vous pardonne aussi vos offenses."
+              ]
+            },
+            " ",
+            {
               "type": "mark",
               "subtype": "verses",
               "atts": {
                 "number": "26"
               }
-            }, {
+            },
+            {
               "type": "graft",
               "subtype": "xref",
               "target": "ZDU0ODQ4MzQt"
-            }, {
+            },
+            {
               "type": "wrapper",
-              "subtype": "usfm:wj",
-              "content": ["Mais si vous ne pardonnez pas, votre Père qui est dans les cieux ne vous pardonnera pas non plus vos offenses."]
+              "subtype": "usfm:span",
+              "content": [
+                "Mais si vous ne pardonnez pas, votre Père qui est dans les cieux ne vous pardonnera pas non plus vos offenses."
+              ]
             }
           ]
-        }, {
+        },
+        {
           "type": "graft",
           "subtype": "heading",
           "target": "MDE2ZGMxYjkt"
-        }, {
+        },
+        {
           "type": "graft",
           "subtype": "heading",
           "target": "ODRhN2JhYzUt"
-        }, {
+        },
+        {
           "type": "paragraph",
           "subtype": "usfm:p",
           "content": [
@@ -6687,25 +7685,31 @@
                 "number": "28"
               }
             },
-            "et lui dirent: ", {
+            "et lui dirent: ",
+            {
               "type": "graft",
               "subtype": "xref",
               "target": "YmUxMWZmOWYt"
             },
-            "Par quelle autorité fais-tu ces choses, et qui t’a donné l’autorité de les faire? ", {
+            "Par quelle autorité fais-tu ces choses, et qui t’a donné l’autorité de les faire? ",
+            {
               "type": "mark",
               "subtype": "verses",
               "atts": {
                 "number": "29"
               }
             },
-            "Jésus leur répondit: ", {
+            "Jésus leur répondit: ",
+            {
               "type": "wrapper",
-              "subtype": "usfm:wj",
-              "content": ["Je vous adresserai aussi une question; répondez-moi, et je vous dirai par quelle autorité je fais ces choses."]
+              "subtype": "usfm:span",
+              "content": [
+                "Je vous adresserai aussi une question; répondez-moi, et je vous dirai par quelle autorité je fais ces choses."
+              ]
             }
           ]
-        }, {
+        },
+        {
           "type": "paragraph",
           "subtype": "usfm:p",
           "content": [
@@ -6718,8 +7722,10 @@
             },
             {
               "type": "wrapper",
-              "subtype": "usfm:wj",
-              "content": ["Le baptême de Jean venait-il du ciel, ou des hommes? Répondez-moi."]
+              "subtype": "usfm:span",
+              "content": [
+                "Le baptême de Jean venait-il du ciel, ou des hommes? Répondez-moi."
+              ]
             },
             " ",
             {
@@ -6729,40 +7735,49 @@
                 "number": "31"
               }
             },
-            "Mais ils raisonnèrent ainsi entre eux: Si nous répondons: Du ciel, il dira: Pourquoi donc n’avez-vous pas cru en lui? ", {
+            "Mais ils raisonnèrent ainsi entre eux: Si nous répondons: Du ciel, il dira: Pourquoi donc n’avez-vous pas cru en lui? ",
+            {
               "type": "mark",
               "subtype": "verses",
               "atts": {
                 "number": "32"
               }
             },
-            "Et si nous répondons: Des hommes… Ils craignaient le peuple, ", {
+            "Et si nous répondons: Des hommes… Ils craignaient le peuple, ",
+            {
               "type": "graft",
               "subtype": "xref",
               "target": "OWY5YzFiZTMt"
             },
-            "car tous tenaient réellement Jean pour un prophète. ", {
+            "car tous tenaient réellement Jean pour un prophète. ",
+            {
               "type": "mark",
               "subtype": "verses",
               "atts": {
                 "number": "33"
               }
             },
-            "Alors ils répondirent à Jésus: Nous ne savons. Et Jésus leur dit: ", {
+            "Alors ils répondirent à Jésus: Nous ne savons. Et Jésus leur dit: ",
+            {
               "type": "wrapper",
-              "subtype": "usfm:wj",
-              "content": ["Moi non plus, je ne vous dirai pas par quelle autorité je fais ces choses."]
+              "subtype": "usfm:span",
+              "content": [
+                "Moi non plus, je ne vous dirai pas par quelle autorité je fais ces choses."
+              ]
             }
           ]
-        }, {
+        },
+        {
           "type": "graft",
           "subtype": "heading",
           "target": "NDgzOTUzMzMt"
-        }, {
+        },
+        {
           "type": "graft",
           "subtype": "heading",
           "target": "OTg3NDRlMWQt"
-        }, {
+        },
+        {
           "type": "paragraph",
           "subtype": "usfm:p",
           "content": [
@@ -6785,29 +7800,32 @@
               "subtype": "xref",
               "target": "MjM3OTAwNzIt"
             },
-            "Jésus se mit ensuite à leur parler en paraboles. ", {
+            "Jésus se mit ensuite à leur parler en paraboles. ",
+            {
               "type": "wrapper",
-              "subtype": "usfm:wj",
-              "content": ["Un"]
-            }, {
+              "subtype": "usfm:span",
+              "content": [
+                "Un"
+              ]
+            },
+            {
               "type": "graft",
               "subtype": "xref",
               "target": "MjEyYzY3Njgt"
-            }, {
+            },
+            {
               "type": "wrapper",
-              "subtype": "usfm:wj",
-              "content": ["homme planta une vigne. Il l’entoura d’une haie, creusa un pressoir, et bâtit une tour; puis il l’afferma à des vignerons, et quitta le pays."]
+              "subtype": "usfm:span",
+              "content": [
+                "homme planta une vigne. Il l’entoura d’une haie, creusa un pressoir, et bâtit une tour; puis il l’afferma à des vignerons, et quitta le pays."
+              ]
             }
           ]
-        }, {
+        },
+        {
           "type": "paragraph",
           "subtype": "usfm:p",
           "content": [
-            {
-              "type": "wrapper",
-              "subtype": "meta_content",
-              "meta_content": ["<== Long verse (36 words)"]
-            },
             {
               "type": "mark",
               "subtype": "verses",
@@ -6817,115 +7835,158 @@
             },
             {
               "type": "wrapper",
-              "subtype": "usfm:wj",
-              "content": ["Au temps de la récolte, il envoya un serviteur vers les vignerons, pour recevoir d’eux une part du produit de la vigne."]
+              "subtype": "usfm:span",
+              "content": [
+                "Au temps de la récolte, il envoya un serviteur vers les vignerons, pour recevoir d’eux une part du produit de la vigne."
+              ]
             },
-            " ", {
+            " ",
+            {
               "type": "mark",
               "subtype": "verses",
               "atts": {
                 "number": "3"
               }
-            }, {
-              "type": "wrapper",
-              "subtype": "usfm:wj",
-              "content": ["S’étant saisis de lui, ils le battirent, et le renvoyèrent à vide."]
             },
-            " ", {
+            {
+              "type": "wrapper",
+              "subtype": "usfm:span",
+              "content": [
+                "S’étant saisis de lui, ils le battirent, et le renvoyèrent à vide."
+              ]
+            },
+            " ",
+            {
               "type": "mark",
               "subtype": "verses",
               "atts": {
                 "number": "4"
               }
-            }, {
-              "type": "wrapper",
-              "subtype": "usfm:wj",
-              "content": ["Il envoya de nouveau vers eux un autre serviteur; ils le frappèrent à la tête, et l’outragèrent."]
             },
-            " ", {
+            {
+              "type": "wrapper",
+              "subtype": "usfm:span",
+              "content": [
+                "Il envoya de nouveau vers eux un autre serviteur; ils le frappèrent à la tête, et l’outragèrent."
+              ]
+            },
+            " ",
+            {
               "type": "mark",
               "subtype": "verses",
               "atts": {
                 "number": "5"
               }
-            }, {
-              "type": "wrapper",
-              "subtype": "usfm:wj",
-              "content": ["Il en envoya un troisième, qu’ils tuèrent; puis plusieurs autres, qu’ils battirent ou tuèrent."]
             },
-            " ", {
+            {
+              "type": "wrapper",
+              "subtype": "usfm:span",
+              "content": [
+                "Il en envoya un troisième, qu’ils tuèrent; puis plusieurs autres, qu’ils battirent ou tuèrent."
+              ]
+            },
+            " ",
+            {
               "type": "mark",
               "subtype": "verses",
               "atts": {
                 "number": "6"
               }
-            }, {
-              "type": "wrapper",
-              "subtype": "usfm:wj",
-              "content": ["Il avait encore un fils bien-aimé; il l’envoya vers eux le dernier, en disant: Ils auront du respect pour mon fils."]
             },
-            " ", {
+            {
+              "type": "wrapper",
+              "subtype": "usfm:span",
+              "content": [
+                "Il avait encore un fils bien-aimé; il l’envoya vers eux le dernier, en disant: Ils auront du respect pour mon fils."
+              ]
+            },
+            " ",
+            {
               "type": "mark",
               "subtype": "verses",
               "atts": {
                 "number": "7"
               }
-            }, {
+            },
+            {
               "type": "wrapper",
-              "subtype": "usfm:wj",
-              "content": ["Mais ces vignerons dirent entre eux:"]
-            }, {
+              "subtype": "usfm:span",
+              "content": [
+                "Mais ces vignerons dirent entre eux:"
+              ]
+            },
+            {
               "type": "graft",
               "subtype": "xref",
               "target": "MzkxZTY3ODAt"
-            }, {
+            },
+            {
               "type": "wrapper",
-              "subtype": "usfm:wj",
-              "content": ["Voici l’héritier;"]
-            }, {
+              "subtype": "usfm:span",
+              "content": [
+                "Voici l’héritier;"
+              ]
+            },
+            {
               "type": "graft",
               "subtype": "xref",
               "target": "OTJjNTBhNjgt"
-            }, {
-              "type": "wrapper",
-              "subtype": "usfm:wj",
-              "content": ["venez, tuons-le, et l’héritage sera à nous."]
             },
-            " ", {
+            {
+              "type": "wrapper",
+              "subtype": "usfm:span",
+              "content": [
+                "venez, tuons-le, et l’héritage sera à nous."
+              ]
+            },
+            " ",
+            {
               "type": "mark",
               "subtype": "verses",
               "atts": {
                 "number": "8"
               }
-            }, {
-              "type": "wrapper",
-              "subtype": "usfm:wj",
-              "content": ["Et ils se saisirent de lui, le tuèrent, et le jetèrent hors de la vigne."]
             },
-            " ", {
+            {
+              "type": "wrapper",
+              "subtype": "usfm:span",
+              "content": [
+                "Et ils se saisirent de lui, le tuèrent, et le jetèrent hors de la vigne."
+              ]
+            },
+            " ",
+            {
               "type": "mark",
               "subtype": "verses",
               "atts": {
                 "number": "9"
               }
-            }, {
-              "type": "wrapper",
-              "subtype": "usfm:wj",
-              "content": ["Maintenant, que fera le maître de la vigne? Il viendra, fera périr les vignerons, et il donnera la vigne à d’autres."]
             },
-            " ", {
+            {
+              "type": "wrapper",
+              "subtype": "usfm:span",
+              "content": [
+                "Maintenant, que fera le maître de la vigne? Il viendra, fera périr les vignerons, et il donnera la vigne à d’autres."
+              ]
+            },
+            " ",
+            {
               "type": "mark",
               "subtype": "verses",
               "atts": {
                 "number": "10"
               }
-            }, {
+            },
+            {
               "type": "wrapper",
-              "subtype": "usfm:wj",
-              "content": ["N’avez-vous pas lu cette parole de l’Écriture:"]
+              "subtype": "usfm:span",
+              "content": [
+                "N’avez-vous pas lu cette parole de l’Écriture:"
+              ]
             }
           ]
-        }, {
+        },
+        {
           "type": "paragraph",
           "subtype": "usfm:q",
           "content": [
@@ -6933,23 +7994,30 @@
               "type": "graft",
               "subtype": "xref",
               "target": "ODUwMmJkNDMt"
-            }, {
+            },
+            {
               "type": "wrapper",
-              "subtype": "usfm:wj",
-              "content": ["La pierre qu’ont rejetée ceux qui bâtissaient"]
+              "subtype": "usfm:span",
+              "content": [
+                "La pierre qu’ont rejetée ceux qui bâtissaient"
+              ]
             }
           ]
-        }, {
+        },
+        {
           "type": "paragraph",
           "subtype": "usfm:q",
           "content": [
             {
               "type": "wrapper",
-              "subtype": "usfm:wj",
-              "content": ["Est devenue la principale de l’angle;"]
+              "subtype": "usfm:span",
+              "content": [
+                "Est devenue la principale de l’angle;"
+              ]
             }
           ]
-        }, {
+        },
+        {
           "type": "paragraph",
           "subtype": "usfm:q",
           "content": [
@@ -6959,23 +8027,30 @@
               "atts": {
                 "number": "11"
               }
-            }, {
+            },
+            {
               "type": "wrapper",
-              "subtype": "usfm:wj",
-              "content": ["C’est par la volonté du Seigneur qu’elle l’est devenue,"]
+              "subtype": "usfm:span",
+              "content": [
+                "C’est par la volonté du Seigneur qu’elle l’est devenue,"
+              ]
             }
           ]
-        }, {
+        },
+        {
           "type": "paragraph",
           "subtype": "usfm:q",
           "content": [
             {
               "type": "wrapper",
-              "subtype": "usfm:wj",
-              "content": ["Et c’est un prodige à nos yeux?"]
+              "subtype": "usfm:span",
+              "content": [
+                "Et c’est un prodige à nos yeux?"
+              ]
             }
           ]
-        }, {
+        },
+        {
           "type": "paragraph",
           "subtype": "usfm:m",
           "content": [
@@ -6988,23 +8063,21 @@
             },
             "Ils cherchaient à se saisir de lui, mais ils craignaient la foule. Ils avaient compris que c’était pour eux que Jésus avait dit cette parabole. Et ils le quittèrent, et s’en allèrent."
           ]
-        }, {
+        },
+        {
           "type": "graft",
           "subtype": "heading",
           "target": "MGUzOWE4NDMt"
-        }, {
+        },
+        {
           "type": "graft",
           "subtype": "heading",
           "target": "MzZhYzljNzEt"
-        }, {
+        },
+        {
           "type": "paragraph",
           "subtype": "usfm:p",
           "content": [
-            {
-              "type": "wrapper",
-              "subtype": "meta_content",
-              "meta_content": ["<== Long verse (32 words)"]
-            },
             {
               "type": "mark",
               "subtype": "verses",
@@ -7017,72 +8090,79 @@
               "subtype": "xref",
               "target": "YjIxYjI5ZDct"
             },
-            "Ils envoyèrent auprès de Jésus quelques-uns des pharisiens et des hérodiens, afin de le surprendre par ses propres paroles. ", {
+            "Ils envoyèrent auprès de Jésus quelques-uns des pharisiens et des hérodiens, afin de le surprendre par ses propres paroles. ",
+            {
               "type": "mark",
               "subtype": "verses",
               "atts": {
                 "number": "14"
               }
             },
-            "Et ils vinrent lui dire: Maître, nous savons que tu es vrai, et que tu ne t’inquiètes de personne; car tu ne regardes pas à l’apparence des hommes, et tu enseignes la voie de Dieu selon la vérité. Est-il permis, ou non, de payer le tribut à César? Devons-nous payer, ou ne pas payer? ", {
-              "type": "wrapper",
-              "subtype": "meta_content",
-              "meta_content": ["<== Long verse (55 words)"]
-            }, {
+            "Et ils vinrent lui dire: Maître, nous savons que tu es vrai, et que tu ne t’inquiètes de personne; car tu ne regardes pas à l’apparence des hommes, et tu enseignes la voie de Dieu selon la vérité. Est-il permis, ou non, de payer le tribut à César? Devons-nous payer, ou ne pas payer? ",
+            {
               "type": "mark",
               "subtype": "verses",
               "atts": {
                 "number": "15"
               }
             },
-            "Jésus, connaissant leur hypocrisie, leur répondit: ", {
+            "Jésus, connaissant leur hypocrisie, leur répondit: ",
+            {
               "type": "wrapper",
-              "subtype": "usfm:wj",
-              "content": ["Pourquoi me tentez-vous? Apportez-moi un denier, afin que je le voie."]
+              "subtype": "usfm:span",
+              "content": [
+                "Pourquoi me tentez-vous? Apportez-moi un denier, afin que je le voie."
+              ]
             },
-            " ", {
+            " ",
+            {
               "type": "mark",
               "subtype": "verses",
               "atts": {
                 "number": "16"
               }
             },
-            "Ils en apportèrent un; et Jésus leur demanda: ", {
+            "Ils en apportèrent un; et Jésus leur demanda: ",
+            {
               "type": "wrapper",
-              "subtype": "usfm:wj",
-              "content": ["De qui sont cette effigie et cette inscription?"]
+              "subtype": "usfm:span",
+              "content": [
+                "De qui sont cette effigie et cette inscription?"
+              ]
             },
-            " De César, lui répondirent-ils. ", {
+            " De César, lui répondirent-ils. ",
+            {
               "type": "mark",
               "subtype": "verses",
               "atts": {
                 "number": "17"
               }
             },
-            "Alors il leur dit: ", {
+            "Alors il leur dit: ",
+            {
               "type": "graft",
               "subtype": "xref",
               "target": "ODE3OThjNjQt"
-            }, {
+            },
+            {
               "type": "wrapper",
-              "subtype": "usfm:wj",
-              "content": ["Rendez à César ce qui est à César, et à Dieu ce qui est à Dieu."]
+              "subtype": "usfm:span",
+              "content": [
+                "Rendez à César ce qui est à César, et à Dieu ce qui est à Dieu."
+              ]
             },
             " Et ils furent à son égard dans l’étonnement."
           ]
-        }, {
+        },
+        {
           "type": "graft",
           "subtype": "heading",
           "target": "OGNmNGJiZWYt"
-        }, {
+        },
+        {
           "type": "paragraph",
           "subtype": "usfm:p",
           "content": [
-            {
-              "type": "wrapper",
-              "subtype": "meta_content",
-              "meta_content": ["<== Long verse (30 words)"]
-            },
             {
               "type": "mark",
               "subtype": "verses",
@@ -7095,64 +8175,71 @@
               "subtype": "xref",
               "target": "MzZiMTkyYTIt"
             },
-            "Les sadducéens, qui disent qu’il n’y a point de résurrection, vinrent auprès de Jésus, et lui firent cette question: ", {
+            "Les sadducéens, qui disent qu’il n’y a point de résurrection, vinrent auprès de Jésus, et lui firent cette question: ",
+            {
               "type": "mark",
               "subtype": "verses",
               "atts": {
                 "number": "19"
               }
             },
-            "Maître, voici ce que Moïse nous a prescrit: ", {
+            "Maître, voici ce que Moïse nous a prescrit: ",
+            {
               "type": "graft",
               "subtype": "xref",
               "target": "MWRiYjRlNGYt"
             },
-            "Si le frère de quelqu’un meurt, et laisse une femme, sans avoir d’enfants, son frère épousera sa veuve, et suscitera une postérité à son frère. ", {
-              "type": "wrapper",
-              "subtype": "meta_content",
-              "meta_content": ["<== Long verse (35 words)"]
-            }, {
+            "Si le frère de quelqu’un meurt, et laisse une femme, sans avoir d’enfants, son frère épousera sa veuve, et suscitera une postérité à son frère. ",
+            {
               "type": "mark",
               "subtype": "verses",
               "atts": {
                 "number": "20"
               }
             },
-            "Or, il y avait sept frères. Le premier se maria, et mourut sans laisser de postérité. ", {
+            "Or, il y avait sept frères. Le premier se maria, et mourut sans laisser de postérité. ",
+            {
               "type": "mark",
               "subtype": "verses",
               "atts": {
                 "number": "21"
               }
             },
-            "Le second prit la veuve pour femme, et mourut sans laisser de postérité. Il en fut de même du troisième, ", {
+            "Le second prit la veuve pour femme, et mourut sans laisser de postérité. Il en fut de même du troisième, ",
+            {
               "type": "mark",
               "subtype": "verses",
               "atts": {
                 "number": "22"
               }
             },
-            "et aucun des sept ne laissa de postérité. Après eux tous, la femme mourut aussi. ", {
+            "et aucun des sept ne laissa de postérité. Après eux tous, la femme mourut aussi. ",
+            {
               "type": "mark",
               "subtype": "verses",
               "atts": {
                 "number": "23"
               }
             },
-            "A la résurrection, duquel d’entre eux sera-t-elle la femme? Car les sept l’ont eue pour femme. ", {
+            "A la résurrection, duquel d’entre eux sera-t-elle la femme? Car les sept l’ont eue pour femme. ",
+            {
               "type": "mark",
               "subtype": "verses",
               "atts": {
                 "number": "24"
               }
             },
-            "Jésus leur répondit: ", {
+            "Jésus leur répondit: ",
+            {
               "type": "wrapper",
-              "subtype": "usfm:wj",
-              "content": ["N’êtes-vous pas dans l’erreur, parce que vous ne comprenez ni les Écritures, ni la puissance de Dieu?"]
+              "subtype": "usfm:span",
+              "content": [
+                "N’êtes-vous pas dans l’erreur, parce que vous ne comprenez ni les Écritures, ni la puissance de Dieu?"
+              ]
             }
           ]
-        }, {
+        },
+        {
           "type": "paragraph",
           "subtype": "usfm:p",
           "content": [
@@ -7165,8 +8252,10 @@
             },
             {
               "type": "wrapper",
-              "subtype": "usfm:wj",
-              "content": ["Car, à la résurrection des morts, les hommes ne prendront point de femmes, ni les femmes de maris, mais ils seront"]
+              "subtype": "usfm:span",
+              "content": [
+                "Car, à la résurrection des morts, les hommes ne prendront point de femmes, ni les femmes de maris, mais ils seront"
+              ]
             },
             {
               "type": "graft",
@@ -7175,49 +8264,61 @@
             },
             {
               "type": "wrapper",
-              "subtype": "usfm:wj",
-              "content": ["comme les anges dans les cieux."]
+              "subtype": "usfm:span",
+              "content": [
+                "comme les anges dans les cieux."
+              ]
             },
-            " ", {
+            " ",
+            {
               "type": "mark",
               "subtype": "verses",
               "atts": {
                 "number": "26"
               }
-            }, {
+            },
+            {
               "type": "wrapper",
-              "subtype": "usfm:wj",
-              "content": ["Pour ce qui est de la résurrection des morts, n’avez-vous pas lu, dans le livre de Moïse, ce que Dieu lui dit, à propos du buisson:"]
-            }, {
+              "subtype": "usfm:span",
+              "content": [
+                "Pour ce qui est de la résurrection des morts, n’avez-vous pas lu, dans le livre de Moïse, ce que Dieu lui dit, à propos du buisson:"
+              ]
+            },
+            {
               "type": "graft",
               "subtype": "xref",
               "target": "NmI0MzgwYmYt"
-            }, {
-              "type": "wrapper",
-              "subtype": "usfm:wj",
-              "content": ["Je suis le Dieu d’Abraham, le Dieu d’Isaac, et le Dieu de Jacob?"]
             },
-            " ", {
+            {
               "type": "wrapper",
-              "subtype": "meta_content",
-              "meta_content": ["<== Long verse (41 words)"]
-            }, {
+              "subtype": "usfm:span",
+              "content": [
+                "Je suis le Dieu d’Abraham, le Dieu d’Isaac, et le Dieu de Jacob?"
+              ]
+            },
+            " ",
+            {
               "type": "mark",
               "subtype": "verses",
               "atts": {
                 "number": "27"
               }
-            }, {
+            },
+            {
               "type": "wrapper",
-              "subtype": "usfm:wj",
-              "content": ["Dieu n’est pas Dieu des morts, mais des vivants. Vous êtes grandement dans l’erreur."]
+              "subtype": "usfm:span",
+              "content": [
+                "Dieu n’est pas Dieu des morts, mais des vivants. Vous êtes grandement dans l’erreur."
+              ]
             }
           ]
-        }, {
+        },
+        {
           "type": "graft",
           "subtype": "heading",
           "target": "ZjIwZDhjNGIt"
-        }, {
+        },
+        {
           "type": "paragraph",
           "subtype": "usfm:p",
           "content": [
@@ -7241,21 +8342,29 @@
                 "number": "29"
               }
             },
-            "Jésus répondit: ", {
+            "Jésus répondit: ",
+            {
               "type": "wrapper",
-              "subtype": "usfm:wj",
-              "content": ["Voici le premier:"]
-            }, {
+              "subtype": "usfm:span",
+              "content": [
+                "Voici le premier:"
+              ]
+            },
+            {
               "type": "graft",
               "subtype": "xref",
               "target": "MmIwYzU4MDgt"
-            }, {
+            },
+            {
               "type": "wrapper",
-              "subtype": "usfm:wj",
-              "content": ["Écoute, Israël, le Seigneur, notre Dieu, est l’unique Seigneur;"]
+              "subtype": "usfm:span",
+              "content": [
+                "Écoute, Israël, le Seigneur, notre Dieu, est l’unique Seigneur;"
+              ]
             }
           ]
-        }, {
+        },
+        {
           "type": "paragraph",
           "subtype": "usfm:p",
           "content": [
@@ -7268,8 +8377,10 @@
             },
             {
               "type": "wrapper",
-              "subtype": "usfm:wj",
-              "content": ["et: Tu aimeras le Seigneur, ton Dieu, de tout ton cœur, de toute ton âme, de toute ta pensée, et de toute ta force."]
+              "subtype": "usfm:span",
+              "content": [
+                "et: Tu aimeras le Seigneur, ton Dieu, de tout ton cœur, de toute ton âme, de toute ta pensée, et de toute ta force."
+              ]
             },
             " ",
             {
@@ -7278,60 +8389,72 @@
               "atts": {
                 "number": "31"
               }
-            }, {
+            },
+            {
               "type": "wrapper",
-              "subtype": "usfm:wj",
-              "content": ["Voici le second:"]
-            }, {
+              "subtype": "usfm:span",
+              "content": [
+                "Voici le second:"
+              ]
+            },
+            {
               "type": "graft",
               "subtype": "xref",
               "target": "OTBlZmU0NjMt"
-            }, {
-              "type": "wrapper",
-              "subtype": "usfm:wj",
-              "content": ["Tu aimeras ton prochain comme toi-même. Il n’y a pas d’autre commandement plus grand que ceux-là."]
             },
-            " ", {
+            {
+              "type": "wrapper",
+              "subtype": "usfm:span",
+              "content": [
+                "Tu aimeras ton prochain comme toi-même. Il n’y a pas d’autre commandement plus grand que ceux-là."
+              ]
+            },
+            " ",
+            {
               "type": "mark",
               "subtype": "verses",
               "atts": {
                 "number": "32"
               }
             },
-            "Le scribe lui dit: Bien, maître; tu as dit avec vérité que Dieu est unique, et qu’il n’y en a point d’autre que lui, ", {
+            "Le scribe lui dit: Bien, maître; tu as dit avec vérité que Dieu est unique, et qu’il n’y en a point d’autre que lui, ",
+            {
               "type": "mark",
               "subtype": "verses",
               "atts": {
                 "number": "33"
               }
             },
-            "et que l’aimer de tout son cœur, de toute sa pensée, de toute son âme et de toute sa force, et aimer son prochain comme soi-même, c’est plus que tous les holocaustes et tous les sacrifices. ", {
-              "type": "wrapper",
-              "subtype": "meta_content",
-              "meta_content": ["<== Long verse (37 words)"]
-            }, {
+            "et que l’aimer de tout son cœur, de toute sa pensée, de toute son âme et de toute sa force, et aimer son prochain comme soi-même, c’est plus que tous les holocaustes et tous les sacrifices. ",
+            {
               "type": "mark",
               "subtype": "verses",
               "atts": {
                 "number": "34"
               }
             },
-            "Jésus, voyant qu’il avait répondu avec intelligence, lui dit: ", {
+            "Jésus, voyant qu’il avait répondu avec intelligence, lui dit: ",
+            {
               "type": "wrapper",
-              "subtype": "usfm:wj",
-              "content": ["Tu n’es pas loin du royaume de Dieu."]
+              "subtype": "usfm:span",
+              "content": [
+                "Tu n’es pas loin du royaume de Dieu."
+              ]
             },
             " Et personne n’osa plus lui proposer des questions."
           ]
-        }, {
+        },
+        {
           "type": "graft",
           "subtype": "heading",
           "target": "NTNiZTczZTkt"
-        }, {
+        },
+        {
           "type": "graft",
           "subtype": "heading",
           "target": "N2U3NzQxODIt"
-        }, {
+        },
+        {
           "type": "paragraph",
           "subtype": "usfm:p",
           "content": [
@@ -7341,18 +8464,23 @@
               "atts": {
                 "number": "35"
               }
-            }, {
+            },
+            {
               "type": "graft",
               "subtype": "xref",
               "target": "MjA5NTBiNjgt"
             },
-            "Jésus, continuant à enseigner dans le temple, dit: ", {
+            "Jésus, continuant à enseigner dans le temple, dit: ",
+            {
               "type": "wrapper",
-              "subtype": "usfm:wj",
-              "content": ["Comment les scribes disent-ils que le Christ est fils de David?"]
+              "subtype": "usfm:span",
+              "content": [
+                "Comment les scribes disent-ils que le Christ est fils de David?"
+              ]
             }
           ]
-        }, {
+        },
+        {
           "type": "paragraph",
           "subtype": "usfm:p",
           "content": [
@@ -7362,23 +8490,30 @@
               "atts": {
                 "number": "36"
               }
-            }, {
+            },
+            {
               "type": "wrapper",
-              "subtype": "usfm:wj",
-              "content": ["David lui-même, animé par l’Esprit-Saint, a dit:"]
+              "subtype": "usfm:span",
+              "content": [
+                "David lui-même, animé par l’Esprit-Saint, a dit:"
+              ]
             }
           ]
-        }, {
+        },
+        {
           "type": "paragraph",
           "subtype": "usfm:q",
           "content": [
             {
               "type": "wrapper",
-              "subtype": "usfm:wj",
-              "content": ["Le Seigneur a dit à mon Seigneur:"]
+              "subtype": "usfm:span",
+              "content": [
+                "Le Seigneur a dit à mon Seigneur:"
+              ]
             }
           ]
-        }, {
+        },
+        {
           "type": "paragraph",
           "subtype": "usfm:q",
           "content": [
@@ -7386,23 +8521,30 @@
               "type": "graft",
               "subtype": "xref",
               "target": "N2RjYzY3ZTEt"
-            }, {
+            },
+            {
               "type": "wrapper",
-              "subtype": "usfm:wj",
-              "content": ["Assieds-toi à ma droite,"]
+              "subtype": "usfm:span",
+              "content": [
+                "Assieds-toi à ma droite,"
+              ]
             }
           ]
-        }, {
+        },
+        {
           "type": "paragraph",
           "subtype": "usfm:q",
           "content": [
             {
               "type": "wrapper",
-              "subtype": "usfm:wj",
-              "content": ["Jusqu’à ce que je fasse de tes ennemis ton marchepied."]
+              "subtype": "usfm:span",
+              "content": [
+                "Jusqu’à ce que je fasse de tes ennemis ton marchepied."
+              ]
             }
           ]
-        }, {
+        },
+        {
           "type": "paragraph",
           "subtype": "usfm:m",
           "content": [
@@ -7412,22 +8554,28 @@
               "atts": {
                 "number": "37"
               }
-            }, {
+            },
+            {
               "type": "wrapper",
-              "subtype": "usfm:wj",
-              "content": ["David lui-même l’appelle Seigneur; comment donc est-il son fils?"]
+              "subtype": "usfm:span",
+              "content": [
+                "David lui-même l’appelle Seigneur; comment donc est-il son fils?"
+              ]
             },
             " Et une grande foule l’écoutait avec plaisir."
           ]
-        }, {
+        },
+        {
           "type": "graft",
           "subtype": "heading",
           "target": "ZjI0MDgwNDUt"
-        }, {
+        },
+        {
           "type": "graft",
           "subtype": "heading",
           "target": "Y2ViODA4ZGUt"
-        }, {
+        },
+        {
           "type": "paragraph",
           "subtype": "usfm:p",
           "content": [
@@ -7437,18 +8585,23 @@
               "atts": {
                 "number": "38"
               }
-            }, {
+            },
+            {
               "type": "graft",
               "subtype": "xref",
               "target": "NzA3YjQ0ZDIt"
             },
-            "Il leur disait dans son enseignement: ", {
+            "Il leur disait dans son enseignement: ",
+            {
               "type": "wrapper",
-              "subtype": "usfm:wj",
-              "content": ["Gardez-vous des scribes, qui aiment à se promener en robes longues, et à être salués dans les places publiques;"]
+              "subtype": "usfm:span",
+              "content": [
+                "Gardez-vous des scribes, qui aiment à se promener en robes longues, et à être salués dans les places publiques;"
+              ]
             }
           ]
-        }, {
+        },
+        {
           "type": "paragraph",
           "subtype": "usfm:p",
           "content": [
@@ -7461,8 +8614,10 @@
             },
             {
               "type": "wrapper",
-              "subtype": "usfm:wj",
-              "content": ["qui recherchent les premiers sièges dans les synagogues, et les premières places dans les festins;"]
+              "subtype": "usfm:span",
+              "content": [
+                "qui recherchent les premiers sièges dans les synagogues, et les premières places dans les festins;"
+              ]
             },
             " ",
             {
@@ -7471,25 +8626,32 @@
               "atts": {
                 "number": "40"
               }
-            }, {
+            },
+            {
               "type": "graft",
               "subtype": "xref",
               "target": "OTk4MDkzMjEt"
-            }, {
+            },
+            {
               "type": "wrapper",
-              "subtype": "usfm:wj",
-              "content": ["qui dévorent les maisons des veuves, et qui font pour l’apparence de longues prières. Ils seront jugés plus sévèrement."]
+              "subtype": "usfm:span",
+              "content": [
+                "qui dévorent les maisons des veuves, et qui font pour l’apparence de longues prières. Ils seront jugés plus sévèrement."
+              ]
             }
           ]
-        }, {
+        },
+        {
           "type": "graft",
           "subtype": "heading",
           "target": "NmJlNTc0M2Yt"
-        }, {
+        },
+        {
           "type": "graft",
           "subtype": "heading",
           "target": "OTA5ODdlNDct"
-        }, {
+        },
+        {
           "type": "paragraph",
           "subtype": "usfm:p",
           "content": [
@@ -7511,63 +8673,75 @@
               "subtype": "xref",
               "target": "NzE5NjRlZDQt"
             },
-            "du tronc, regardait comment la foule y mettait de l’argent. Plusieurs riches mettaient beaucoup. ", {
+            "du tronc, regardait comment la foule y mettait de l’argent. Plusieurs riches mettaient beaucoup. ",
+            {
               "type": "mark",
               "subtype": "verses",
               "atts": {
                 "number": "42"
               }
             },
-            "Il vint aussi une pauvre veuve, elle y mit deux petites pièces, faisant un quart de sou. ", {
+            "Il vint aussi une pauvre veuve, elle y mit deux petites pièces, faisant un quart de sou. ",
+            {
               "type": "mark",
               "subtype": "verses",
               "atts": {
                 "number": "43"
               }
             },
-            "Alors Jésus, ayant appelé ses disciples, leur dit: ", {
+            "Alors Jésus, ayant appelé ses disciples, leur dit: ",
+            {
               "type": "wrapper",
-              "subtype": "usfm:wj",
-              "content": ["Je vous le dis en vérité,"]
-            }, {
+              "subtype": "usfm:span",
+              "content": [
+                "Je vous le dis en vérité,"
+              ]
+            },
+            {
               "type": "graft",
               "subtype": "xref",
               "target": "ZDE4OTMzOWIt"
-            }, {
+            },
+            {
               "type": "wrapper",
-              "subtype": "usfm:wj",
-              "content": ["cette pauvre veuve a donné plus qu’aucun de ceux qui ont mis dans le tronc;"]
+              "subtype": "usfm:span",
+              "content": [
+                "cette pauvre veuve a donné plus qu’aucun de ceux qui ont mis dans le tronc;"
+              ]
             }
           ]
-        }, {
+        },
+        {
           "type": "paragraph",
           "subtype": "usfm:p",
           "content": [
             {
-              "type": "wrapper",
-              "subtype": "meta_content",
-              "meta_content": ["<== Long verse (30 words)"]
-            }, {
               "type": "mark",
               "subtype": "verses",
               "atts": {
                 "number": "44"
               }
-            }, {
+            },
+            {
               "type": "wrapper",
-              "subtype": "usfm:wj",
-              "content": ["car tous ont mis de leur superflu, mais elle a mis de son nécessaire, tout ce qu’elle possédait, tout ce qu’elle avait pour vivre."]
+              "subtype": "usfm:span",
+              "content": [
+                "car tous ont mis de leur superflu, mais elle a mis de son nécessaire, tout ce qu’elle possédait, tout ce qu’elle avait pour vivre."
+              ]
             }
           ]
-        }, {
+        },
+        {
           "type": "graft",
           "subtype": "heading",
           "target": "NWNmZjVhMDAt"
-        }, {
+        },
+        {
           "type": "graft",
           "subtype": "heading",
           "target": "ODQ1ZTc3NTQt"
-        }, {
+        },
+        {
           "type": "paragraph",
           "subtype": "usfm:p",
           "content": [
@@ -7591,66 +8765,84 @@
               "subtype": "xref",
               "target": "NGUxZGE4MjUt"
             },
-            "sortit du temple, un de ses disciples lui dit: Maître, regarde quelles pierres, et quelles constructions! ", {
+            "sortit du temple, un de ses disciples lui dit: Maître, regarde quelles pierres, et quelles constructions! ",
+            {
               "type": "mark",
               "subtype": "verses",
               "atts": {
                 "number": "2"
               }
             },
-            "Jésus lui répondit: ", {
+            "Jésus lui répondit: ",
+            {
               "type": "wrapper",
-              "subtype": "usfm:wj",
-              "content": ["Vois-tu ces grandes constructions?"]
-            }, {
+              "subtype": "usfm:span",
+              "content": [
+                "Vois-tu ces grandes constructions?"
+              ]
+            },
+            {
               "type": "graft",
               "subtype": "xref",
               "target": "NGYyMjQ2Nzkt"
-            }, {
-              "type": "wrapper",
-              "subtype": "usfm:wj",
-              "content": ["Il ne restera pas pierre sur pierre qui ne soit renversée."]
             },
-            " ", {
+            {
+              "type": "wrapper",
+              "subtype": "usfm:span",
+              "content": [
+                "Il ne restera pas pierre sur pierre qui ne soit renversée."
+              ]
+            },
+            " ",
+            {
               "type": "mark",
               "subtype": "verses",
               "atts": {
                 "number": "3"
               }
-            }, {
+            },
+            {
               "type": "graft",
               "subtype": "xref",
               "target": "NmNiOTg2NmEt"
             },
-            "Il s’assit sur la montagne des oliviers, en face du temple. Et Pierre, Jacques, Jean et André lui firent en particulier cette question: ", {
+            "Il s’assit sur la montagne des oliviers, en face du temple. Et Pierre, Jacques, Jean et André lui firent en particulier cette question: ",
+            {
               "type": "mark",
               "subtype": "verses",
               "atts": {
                 "number": "4"
               }
-            }, {
+            },
+            {
               "type": "graft",
               "subtype": "xref",
               "target": "ZTU3OWUyODYt"
             },
-            "Dis-nous, quand cela arrivera-t-il, et à quel signe connaîtra-t-on que toutes ces choses vont s’accomplir? ", {
+            "Dis-nous, quand cela arrivera-t-il, et à quel signe connaîtra-t-on que toutes ces choses vont s’accomplir? ",
+            {
               "type": "mark",
               "subtype": "verses",
               "atts": {
                 "number": "5"
               }
             },
-            "Jésus se mit alors à leur dire: ", {
+            "Jésus se mit alors à leur dire: ",
+            {
               "type": "graft",
               "subtype": "xref",
               "target": "ZGMxMjlhMmQt"
-            }, {
+            },
+            {
               "type": "wrapper",
-              "subtype": "usfm:wj",
-              "content": ["Prenez garde que personne ne vous séduise."]
+              "subtype": "usfm:span",
+              "content": [
+                "Prenez garde que personne ne vous séduise."
+              ]
             }
           ]
-        }, {
+        },
+        {
           "type": "paragraph",
           "subtype": "usfm:p",
           "content": [
@@ -7663,8 +8855,10 @@
             },
             {
               "type": "wrapper",
-              "subtype": "usfm:wj",
-              "content": ["Car plusieurs viendront"]
+              "subtype": "usfm:span",
+              "content": [
+                "Car plusieurs viendront"
+              ]
             },
             {
               "type": "graft",
@@ -7673,136 +8867,161 @@
             },
             {
               "type": "wrapper",
-              "subtype": "usfm:wj",
-              "content": ["sous mon nom, disant; C’est moi. Et ils séduiront beaucoup de gens."]
+              "subtype": "usfm:span",
+              "content": [
+                "sous mon nom, disant; C’est moi. Et ils séduiront beaucoup de gens."
+              ]
             },
-            " ", {
+            " ",
+            {
               "type": "mark",
               "subtype": "verses",
               "atts": {
                 "number": "7"
               }
-            }, {
-              "type": "wrapper",
-              "subtype": "usfm:wj",
-              "content": ["Quand vous entendrez parler de guerres et de bruits de guerres, ne soyez pas troublés, car il faut que ces choses arrivent. Mais ce ne sera pas encore la fin."]
             },
-            " ", {
+            {
               "type": "wrapper",
-              "subtype": "meta_content",
-              "meta_content": ["<== Long verse (32 words)"]
-            }, {
+              "subtype": "usfm:span",
+              "content": [
+                "Quand vous entendrez parler de guerres et de bruits de guerres, ne soyez pas troublés, car il faut que ces choses arrivent. Mais ce ne sera pas encore la fin."
+              ]
+            },
+            " ",
+            {
               "type": "mark",
               "subtype": "verses",
               "atts": {
                 "number": "8"
               }
-            }, {
+            },
+            {
               "type": "graft",
               "subtype": "xref",
               "target": "ZDI2N2FlYTAt"
-            }, {
-              "type": "wrapper",
-              "subtype": "usfm:wj",
-              "content": ["Une nation s’élèvera contre une nation, et un royaume contre un royaume; il y aura des tremblements de terre en divers lieux, il y aura des famines. Ce ne sera que le commencement des douleurs."]
             },
-            " ", {
+            {
               "type": "wrapper",
-              "subtype": "meta_content",
-              "meta_content": ["<== Long verse (37 words)"]
-            }, {
+              "subtype": "usfm:span",
+              "content": [
+                "Une nation s’élèvera contre une nation, et un royaume contre un royaume; il y aura des tremblements de terre en divers lieux, il y aura des famines. Ce ne sera que le commencement des douleurs."
+              ]
+            },
+            " ",
+            {
               "type": "mark",
               "subtype": "verses",
               "atts": {
                 "number": "9"
               }
-            }, {
+            },
+            {
               "type": "graft",
               "subtype": "xref",
               "target": "NTYxNTMyYmIt"
-            }, {
-              "type": "wrapper",
-              "subtype": "usfm:wj",
-              "content": ["Prenez garde à vous-mêmes. On vous livrera aux tribunaux, et vous serez battus de verges dans les synagogues; vous comparaîtrez devant des gouverneurs et devant des rois, à cause de moi, pour leur servir de témoignage."]
             },
-            " ", {
+            {
               "type": "wrapper",
-              "subtype": "meta_content",
-              "meta_content": ["<== Long verse (38 words)"]
-            }, {
+              "subtype": "usfm:span",
+              "content": [
+                "Prenez garde à vous-mêmes. On vous livrera aux tribunaux, et vous serez battus de verges dans les synagogues; vous comparaîtrez devant des gouverneurs et devant des rois, à cause de moi, pour leur servir de témoignage."
+              ]
+            },
+            " ",
+            {
               "type": "mark",
               "subtype": "verses",
               "atts": {
                 "number": "10"
               }
-            }, {
-              "type": "wrapper",
-              "subtype": "usfm:wj",
-              "content": ["Il faut premièrement que la bonne nouvelle soit prêchée à toutes les nations."]
             },
-            " ", {
+            {
+              "type": "wrapper",
+              "subtype": "usfm:span",
+              "content": [
+                "Il faut premièrement que la bonne nouvelle soit prêchée à toutes les nations."
+              ]
+            },
+            " ",
+            {
               "type": "mark",
               "subtype": "verses",
               "atts": {
                 "number": "11"
               }
-            }, {
+            },
+            {
               "type": "graft",
               "subtype": "xref",
               "target": "MmQzMmQxYzgt"
-            }, {
-              "type": "wrapper",
-              "subtype": "usfm:wj",
-              "content": ["Quand on vous emmènera pour vous livrer, ne vous inquiétez pas d’avance de ce que vous aurez à dire, mais dites ce qui vous sera donné à l’heure même; car ce n’est pas vous qui parlerez, mais l’Esprit-Saint."]
             },
-            " ", {
+            {
               "type": "wrapper",
-              "subtype": "meta_content",
-              "meta_content": ["<== Long verse (40 words)"]
-            }, {
+              "subtype": "usfm:span",
+              "content": [
+                "Quand on vous emmènera pour vous livrer, ne vous inquiétez pas d’avance de ce que vous aurez à dire, mais dites ce qui vous sera donné à l’heure même; car ce n’est pas vous qui parlerez, mais l’Esprit-Saint."
+              ]
+            },
+            " ",
+            {
               "type": "mark",
               "subtype": "verses",
               "atts": {
                 "number": "12"
               }
-            }, {
+            },
+            {
               "type": "graft",
               "subtype": "xref",
               "target": "M2Y1ZGZhYmYt"
-            }, {
-              "type": "wrapper",
-              "subtype": "usfm:wj",
-              "content": ["Le frère livrera son frère à la mort, et le père son enfant; les enfants se soulèveront contre leurs parents, et les feront mourir."]
             },
-            " ", {
+            {
+              "type": "wrapper",
+              "subtype": "usfm:span",
+              "content": [
+                "Le frère livrera son frère à la mort, et le père son enfant; les enfants se soulèveront contre leurs parents, et les feront mourir."
+              ]
+            },
+            " ",
+            {
               "type": "mark",
               "subtype": "verses",
               "atts": {
                 "number": "13"
               }
-            }, {
+            },
+            {
               "type": "wrapper",
-              "subtype": "usfm:wj",
-              "content": ["Vous serez haïs de tous, à cause de mon nom,"]
-            }, {
+              "subtype": "usfm:span",
+              "content": [
+                "Vous serez haïs de tous, à cause de mon nom,"
+              ]
+            },
+            {
               "type": "graft",
               "subtype": "xref",
               "target": "NzRjMTYwYWQt"
-            }, {
+            },
+            {
               "type": "wrapper",
-              "subtype": "usfm:wj",
-              "content": ["mais celui qui persévérera jusqu’à la fin sera sauvé."]
+              "subtype": "usfm:span",
+              "content": [
+                "mais celui qui persévérera jusqu’à la fin sera sauvé."
+              ]
             }
           ]
-        }, {
+        },
+        {
           "type": "graft",
           "subtype": "heading",
           "target": "OTVlNjg1MjEt"
-        }, {
+        },
+        {
           "type": "graft",
           "subtype": "heading",
           "target": "NTgyMzIxZDMt"
-        }, {
+        },
+        {
           "type": "paragraph",
           "subtype": "usfm:p",
           "content": [
@@ -7820,329 +9039,421 @@
             },
             {
               "type": "wrapper",
-              "subtype": "usfm:wj",
-              "content": ["Lorsque vous verrez l’abomination de la désolation établie là où elle ne doit pas être, que celui qui lit fasse attention,"]
+              "subtype": "usfm:span",
+              "content": [
+                "Lorsque vous verrez l’abomination de la désolation établie là où elle ne doit pas être, que celui qui lit fasse attention,"
+              ]
             },
             {
               "type": "graft",
               "subtype": "xref",
               "target": "NmNhZWVhMGEt"
-            }, {
-              "type": "wrapper",
-              "subtype": "usfm:wj",
-              "content": ["alors, que ceux qui seront en Judée fuient dans les montagnes;"]
             },
-            " ", {
+            {
               "type": "wrapper",
-              "subtype": "meta_content",
-              "meta_content": ["<== Long verse (34 words)"]
-            }, {
+              "subtype": "usfm:span",
+              "content": [
+                "alors, que ceux qui seront en Judée fuient dans les montagnes;"
+              ]
+            },
+            " ",
+            {
               "type": "mark",
               "subtype": "verses",
               "atts": {
                 "number": "15"
               }
-            }, {
-              "type": "wrapper",
-              "subtype": "usfm:wj",
-              "content": ["que celui qui sera sur le toit ne descende pas et n’entre pas pour prendre quelque chose dans sa maison;"]
             },
-            " ", {
+            {
+              "type": "wrapper",
+              "subtype": "usfm:span",
+              "content": [
+                "que celui qui sera sur le toit ne descende pas et n’entre pas pour prendre quelque chose dans sa maison;"
+              ]
+            },
+            " ",
+            {
               "type": "mark",
               "subtype": "verses",
               "atts": {
                 "number": "16"
               }
-            }, {
-              "type": "wrapper",
-              "subtype": "usfm:wj",
-              "content": ["et que celui qui sera dans les champs ne retourne pas en arrière pour prendre son manteau."]
             },
-            " ", {
+            {
+              "type": "wrapper",
+              "subtype": "usfm:span",
+              "content": [
+                "et que celui qui sera dans les champs ne retourne pas en arrière pour prendre son manteau."
+              ]
+            },
+            " ",
+            {
               "type": "mark",
               "subtype": "verses",
               "atts": {
                 "number": "17"
               }
-            }, {
-              "type": "wrapper",
-              "subtype": "usfm:wj",
-              "content": ["Malheur aux femmes qui seront enceintes et à celles qui allaiteront en ces jours-là!"]
             },
-            " ", {
+            {
+              "type": "wrapper",
+              "subtype": "usfm:span",
+              "content": [
+                "Malheur aux femmes qui seront enceintes et à celles qui allaiteront en ces jours-là!"
+              ]
+            },
+            " ",
+            {
               "type": "mark",
               "subtype": "verses",
               "atts": {
                 "number": "18"
               }
-            }, {
-              "type": "wrapper",
-              "subtype": "usfm:wj",
-              "content": ["Priez pour que ces choses n’arrivent pas en hiver."]
             },
-            " ", {
+            {
+              "type": "wrapper",
+              "subtype": "usfm:span",
+              "content": [
+                "Priez pour que ces choses n’arrivent pas en hiver."
+              ]
+            },
+            " ",
+            {
               "type": "mark",
               "subtype": "verses",
               "atts": {
                 "number": "19"
               }
-            }, {
-              "type": "wrapper",
-              "subtype": "usfm:wj",
-              "content": ["Car la détresse, en ces jours, sera telle qu’il n’y en a point eu de semblable depuis le commencement du monde que Dieu a créé jusqu’à présent, et qu’il n’y en aura jamais."]
             },
-            " ", {
+            {
               "type": "wrapper",
-              "subtype": "meta_content",
-              "meta_content": ["<== Long verse (35 words)"]
-            }, {
+              "subtype": "usfm:span",
+              "content": [
+                "Car la détresse, en ces jours, sera telle qu’il n’y en a point eu de semblable depuis le commencement du monde que Dieu a créé jusqu’à présent, et qu’il n’y en aura jamais."
+              ]
+            },
+            " ",
+            {
               "type": "mark",
               "subtype": "verses",
               "atts": {
                 "number": "20"
               }
-            }, {
-              "type": "wrapper",
-              "subtype": "usfm:wj",
-              "content": ["Et, si le Seigneur n’avait abrégé ces jours, personne ne serait sauvé; mais il les a abrégés, à cause des élus qu’il a choisis."]
             },
-            " ", {
+            {
+              "type": "wrapper",
+              "subtype": "usfm:span",
+              "content": [
+                "Et, si le Seigneur n’avait abrégé ces jours, personne ne serait sauvé; mais il les a abrégés, à cause des élus qu’il a choisis."
+              ]
+            },
+            " ",
+            {
               "type": "mark",
               "subtype": "verses",
               "atts": {
                 "number": "21"
               }
-            }, {
+            },
+            {
               "type": "graft",
               "subtype": "xref",
               "target": "MzRmZTUzNDUt"
-            }, {
-              "type": "wrapper",
-              "subtype": "usfm:wj",
-              "content": ["Si quelqu’un vous dit alors: Le Christ est ici, ou: Il est là, ne le croyez pas."]
             },
-            " ", {
+            {
+              "type": "wrapper",
+              "subtype": "usfm:span",
+              "content": [
+                "Si quelqu’un vous dit alors: Le Christ est ici, ou: Il est là, ne le croyez pas."
+              ]
+            },
+            " ",
+            {
               "type": "mark",
               "subtype": "verses",
               "atts": {
                 "number": "22"
               }
-            }, {
+            },
+            {
               "type": "graft",
               "subtype": "xref",
               "target": "MmEzMThmYzEt"
-            }, {
-              "type": "wrapper",
-              "subtype": "usfm:wj",
-              "content": ["Car il s’élèvera de faux Christs et de faux prophètes; ils feront des prodiges et des miracles pour séduire les élus, s’il était possible."]
             },
-            " ", {
+            {
+              "type": "wrapper",
+              "subtype": "usfm:span",
+              "content": [
+                "Car il s’élèvera de faux Christs et de faux prophètes; ils feront des prodiges et des miracles pour séduire les élus, s’il était possible."
+              ]
+            },
+            " ",
+            {
               "type": "mark",
               "subtype": "verses",
               "atts": {
                 "number": "23"
               }
-            }, {
-              "type": "wrapper",
-              "subtype": "usfm:wj",
-              "content": ["Soyez sur vos gardes: je vous ai tout annoncé d’avance."]
             },
-            " ", {
+            {
+              "type": "wrapper",
+              "subtype": "usfm:span",
+              "content": [
+                "Soyez sur vos gardes: je vous ai tout annoncé d’avance."
+              ]
+            },
+            " ",
+            {
               "type": "mark",
               "subtype": "verses",
               "atts": {
                 "number": "24"
               }
-            }, {
+            },
+            {
               "type": "graft",
               "subtype": "xref",
               "target": "OGVhY2M0N2Qt"
-            }, {
-              "type": "wrapper",
-              "subtype": "usfm:wj",
-              "content": ["Mais dans ces jours, après cette détresse, le soleil s’obscurcira, la lune ne donnera plus sa lumière,"]
             },
-            " ", {
+            {
+              "type": "wrapper",
+              "subtype": "usfm:span",
+              "content": [
+                "Mais dans ces jours, après cette détresse, le soleil s’obscurcira, la lune ne donnera plus sa lumière,"
+              ]
+            },
+            " ",
+            {
               "type": "mark",
               "subtype": "verses",
               "atts": {
                 "number": "25"
               }
-            }, {
-              "type": "wrapper",
-              "subtype": "usfm:wj",
-              "content": ["les étoiles tomberont du ciel, et les puissances qui sont dans les cieux seront ébranlées."]
             },
-            " ", {
+            {
+              "type": "wrapper",
+              "subtype": "usfm:span",
+              "content": [
+                "les étoiles tomberont du ciel, et les puissances qui sont dans les cieux seront ébranlées."
+              ]
+            },
+            " ",
+            {
               "type": "mark",
               "subtype": "verses",
               "atts": {
                 "number": "26"
               }
-            }, {
+            },
+            {
               "type": "graft",
               "subtype": "xref",
               "target": "NjdiMWRlMDMt"
-            }, {
-              "type": "wrapper",
-              "subtype": "usfm:wj",
-              "content": ["Alors on verra le Fils de l’homme venant sur les nuées avec une grande puissance et avec gloire."]
             },
-            " ", {
+            {
+              "type": "wrapper",
+              "subtype": "usfm:span",
+              "content": [
+                "Alors on verra le Fils de l’homme venant sur les nuées avec une grande puissance et avec gloire."
+              ]
+            },
+            " ",
+            {
               "type": "mark",
               "subtype": "verses",
               "atts": {
                 "number": "27"
               }
-            }, {
-              "type": "wrapper",
-              "subtype": "usfm:wj",
-              "content": ["Alors il enverra les anges, et il rassemblera les élus des quatre vents, de l’extrémité de la terre jusqu’à l’extrémité du ciel."]
             },
-            " ", {
+            {
+              "type": "wrapper",
+              "subtype": "usfm:span",
+              "content": [
+                "Alors il enverra les anges, et il rassemblera les élus des quatre vents, de l’extrémité de la terre jusqu’à l’extrémité du ciel."
+              ]
+            },
+            " ",
+            {
               "type": "mark",
               "subtype": "verses",
               "atts": {
                 "number": "28"
               }
-            }, {
+            },
+            {
               "type": "graft",
               "subtype": "xref",
               "target": "OTA3ZWNiMjkt"
-            }, {
-              "type": "wrapper",
-              "subtype": "usfm:wj",
-              "content": ["Instruisez-vous par une comparaison tirée du figuier. Dès que ses branches deviennent tendres, et que les feuilles poussent, vous connaissez que l’été est proche."]
             },
-            " ", {
+            {
+              "type": "wrapper",
+              "subtype": "usfm:span",
+              "content": [
+                "Instruisez-vous par une comparaison tirée du figuier. Dès que ses branches deviennent tendres, et que les feuilles poussent, vous connaissez que l’été est proche."
+              ]
+            },
+            " ",
+            {
               "type": "mark",
               "subtype": "verses",
               "atts": {
                 "number": "29"
               }
-            }, {
-              "type": "wrapper",
-              "subtype": "usfm:wj",
-              "content": ["De même, quand vous verrez ces choses arriver, sachez que le Fils de l’homme est proche, à la porte."]
             },
-            " ", {
+            {
+              "type": "wrapper",
+              "subtype": "usfm:span",
+              "content": [
+                "De même, quand vous verrez ces choses arriver, sachez que le Fils de l’homme est proche, à la porte."
+              ]
+            },
+            " ",
+            {
               "type": "mark",
               "subtype": "verses",
               "atts": {
                 "number": "30"
               }
-            }, {
-              "type": "wrapper",
-              "subtype": "usfm:wj",
-              "content": ["Je vous le dis en vérité, cette génération ne passera point, que tout cela n’arrive."]
             },
-            " ", {
+            {
+              "type": "wrapper",
+              "subtype": "usfm:span",
+              "content": [
+                "Je vous le dis en vérité, cette génération ne passera point, que tout cela n’arrive."
+              ]
+            },
+            " ",
+            {
               "type": "mark",
               "subtype": "verses",
               "atts": {
                 "number": "31"
               }
-            }, {
+            },
+            {
               "type": "graft",
               "subtype": "xref",
               "target": "ODFmMDIwZmQt"
-            }, {
-              "type": "wrapper",
-              "subtype": "usfm:wj",
-              "content": ["Le ciel et la terre passeront, mais mes paroles ne passeront point."]
             },
-            " ", {
+            {
+              "type": "wrapper",
+              "subtype": "usfm:span",
+              "content": [
+                "Le ciel et la terre passeront, mais mes paroles ne passeront point."
+              ]
+            },
+            " ",
+            {
               "type": "mark",
               "subtype": "verses",
               "atts": {
                 "number": "32"
               }
-            }, {
+            },
+            {
               "type": "graft",
               "subtype": "xref",
               "target": "OWJmZTllNTIt"
-            }, {
-              "type": "wrapper",
-              "subtype": "usfm:wj",
-              "content": ["Pour ce qui est du jour ou de l’heure, personne ne le sait, ni les anges dans le ciel, ni le Fils, mais le Père seul."]
             },
-            " ", {
+            {
+              "type": "wrapper",
+              "subtype": "usfm:span",
+              "content": [
+                "Pour ce qui est du jour ou de l’heure, personne ne le sait, ni les anges dans le ciel, ni le Fils, mais le Père seul."
+              ]
+            },
+            " ",
+            {
               "type": "mark",
               "subtype": "verses",
               "atts": {
                 "number": "33"
               }
-            }, {
+            },
+            {
               "type": "graft",
               "subtype": "xref",
               "target": "MzU5NDI5YWUt"
-            }, {
-              "type": "wrapper",
-              "subtype": "usfm:wj",
-              "content": ["Prenez garde, veillez et priez; car vous ne savez quand ce temps viendra."]
             },
-            " ", {
+            {
+              "type": "wrapper",
+              "subtype": "usfm:span",
+              "content": [
+                "Prenez garde, veillez et priez; car vous ne savez quand ce temps viendra."
+              ]
+            },
+            " ",
+            {
               "type": "mark",
               "subtype": "verses",
               "atts": {
                 "number": "34"
               }
-            }, {
-              "type": "wrapper",
-              "subtype": "usfm:wj",
-              "content": ["Il en sera comme d’un homme qui, partant pour un voyage, laisse sa maison, remet l’autorité à ses serviteurs, indique à chacun sa tâche, et ordonne au portier de veiller."]
             },
-            " ", {
+            {
               "type": "wrapper",
-              "subtype": "meta_content",
-              "meta_content": ["<== Long verse (32 words)"]
-            }, {
+              "subtype": "usfm:span",
+              "content": [
+                "Il en sera comme d’un homme qui, partant pour un voyage, laisse sa maison, remet l’autorité à ses serviteurs, indique à chacun sa tâche, et ordonne au portier de veiller."
+              ]
+            },
+            " ",
+            {
               "type": "mark",
               "subtype": "verses",
               "atts": {
                 "number": "35"
               }
-            }, {
-              "type": "wrapper",
-              "subtype": "usfm:wj",
-              "content": ["Veillez donc, car vous ne savez quand viendra le maître de la maison, ou le soir, ou au milieu de la nuit, ou au chant du coq, ou le matin;"]
             },
-            " ", {
+            {
               "type": "wrapper",
-              "subtype": "meta_content",
-              "meta_content": ["<== Long verse (32 words)"]
-            }, {
+              "subtype": "usfm:span",
+              "content": [
+                "Veillez donc, car vous ne savez quand viendra le maître de la maison, ou le soir, ou au milieu de la nuit, ou au chant du coq, ou le matin;"
+              ]
+            },
+            " ",
+            {
               "type": "mark",
               "subtype": "verses",
               "atts": {
                 "number": "36"
               }
-            }, {
-              "type": "wrapper",
-              "subtype": "usfm:wj",
-              "content": ["craignez qu’il ne vous trouve endormis, à son arrivée soudaine."]
             },
-            " ", {
+            {
+              "type": "wrapper",
+              "subtype": "usfm:span",
+              "content": [
+                "craignez qu’il ne vous trouve endormis, à son arrivée soudaine."
+              ]
+            },
+            " ",
+            {
               "type": "mark",
               "subtype": "verses",
               "atts": {
                 "number": "37"
               }
-            }, {
+            },
+            {
               "type": "wrapper",
-              "subtype": "usfm:wj",
-              "content": ["Ce que je vous dis, je le dis à tous: Veillez."]
+              "subtype": "usfm:span",
+              "content": [
+                "Ce que je vous dis, je le dis à tous: Veillez."
+              ]
             }
           ]
-        }, {
+        },
+        {
           "type": "graft",
           "subtype": "heading",
           "target": "ZGYxNTYyMDgt"
-        }, {
+        },
+        {
           "type": "graft",
           "subtype": "heading",
           "target": "N2QwMTQ4NGQt"
-        }, {
+        },
+        {
           "type": "paragraph",
           "subtype": "usfm:p",
           "content": [
@@ -8165,11 +9476,8 @@
               "subtype": "xref",
               "target": "ZGJiYmNiZDEt"
             },
-            "La fête de Pâque et des pains sans levain devait avoir lieu deux jours après. Les principaux sacrificateurs et les scribes cherchaient les moyens d’arrêter Jésus par ruse, et de le faire mourir. ", {
-              "type": "wrapper",
-              "subtype": "meta_content",
-              "meta_content": ["<== Long verse (34 words)"]
-            }, {
+            "La fête de Pâque et des pains sans levain devait avoir lieu deux jours après. Les principaux sacrificateurs et les scribes cherchaient les moyens d’arrêter Jésus par ruse, et de le faire mourir. ",
+            {
               "type": "mark",
               "subtype": "verses",
               "atts": {
@@ -8178,15 +9486,18 @@
             },
             "Car ils disaient: Que ce ne soit pas pendant la fête, afin qu’il n’y ait pas de tumulte parmi le peuple."
           ]
-        }, {
+        },
+        {
           "type": "graft",
           "subtype": "heading",
           "target": "ZTE5MTJiODEt"
-        }, {
+        },
+        {
           "type": "graft",
           "subtype": "heading",
           "target": "YTgyOTM1MmMt"
-        }, {
+        },
+        {
           "type": "paragraph",
           "subtype": "usfm:p",
           "content": [
@@ -8204,37 +9515,39 @@
             },
             "Comme Jésus était à Béthanie, dans la maison de Simon le lépreux, une femme entra, pendant qu’il se trouvait à table. Elle tenait un vase d’albâtre, qui renfermait un parfum de nard pur de grand prix; et, ayant rompu le vase, elle répandit le parfum sur la tête de Jésus. ",
             {
-              "type": "wrapper",
-              "subtype": "meta_content",
-              "meta_content": ["<== Long verse (51 words)"]
-            }, {
               "type": "mark",
               "subtype": "verses",
               "atts": {
                 "number": "4"
               }
             },
-            "Quelques-uns exprimèrent entre eux leur indignation: A quoi bon perdre ce parfum? ", {
+            "Quelques-uns exprimèrent entre eux leur indignation: A quoi bon perdre ce parfum? ",
+            {
               "type": "mark",
               "subtype": "verses",
               "atts": {
                 "number": "5"
               }
             },
-            "On aurait pu le vendre plus de trois cents deniers, et les donner aux pauvres. Et ils s’irritaient contre cette femme. ", {
+            "On aurait pu le vendre plus de trois cents deniers, et les donner aux pauvres. Et ils s’irritaient contre cette femme. ",
+            {
               "type": "mark",
               "subtype": "verses",
               "atts": {
                 "number": "6"
               }
             },
-            "Mais Jésus dit: ", {
+            "Mais Jésus dit: ",
+            {
               "type": "wrapper",
-              "subtype": "usfm:wj",
-              "content": ["Laissez-la. Pourquoi lui faites-vous de la peine? Elle a fait une bonne action à mon égard;"]
+              "subtype": "usfm:span",
+              "content": [
+                "Laissez-la. Pourquoi lui faites-vous de la peine? Elle a fait une bonne action à mon égard;"
+              ]
             }
           ]
-        }, {
+        },
+        {
           "type": "paragraph",
           "subtype": "usfm:p",
           "content": [
@@ -8252,47 +9565,56 @@
             },
             {
               "type": "wrapper",
-              "subtype": "usfm:wj",
-              "content": ["car vous avez toujours les pauvres avec vous, et vous pouvez leur faire du bien quand vous voulez, mais vous ne m’avez pas toujours."]
+              "subtype": "usfm:span",
+              "content": [
+                "car vous avez toujours les pauvres avec vous, et vous pouvez leur faire du bien quand vous voulez, mais vous ne m’avez pas toujours."
+              ]
             },
-            " ", {
+            " ",
+            {
               "type": "mark",
               "subtype": "verses",
               "atts": {
                 "number": "8"
               }
-            }, {
-              "type": "wrapper",
-              "subtype": "usfm:wj",
-              "content": ["Elle a fait ce qu’elle a pu; elle a d’avance embaumé mon corps pour la sépulture."]
             },
-            " ", {
+            {
+              "type": "wrapper",
+              "subtype": "usfm:span",
+              "content": [
+                "Elle a fait ce qu’elle a pu; elle a d’avance embaumé mon corps pour la sépulture."
+              ]
+            },
+            " ",
+            {
               "type": "mark",
               "subtype": "verses",
               "atts": {
                 "number": "9"
               }
-            }, {
-              "type": "wrapper",
-              "subtype": "usfm:wj",
-              "content": ["Je vous le dis en vérité, partout où la bonne nouvelle sera prêchée, dans le monde entier, on racontera aussi en mémoire de cette femme ce qu’elle a fait."]
             },
-            " ", {
+            {
               "type": "wrapper",
-              "subtype": "meta_content",
-              "meta_content": ["<== Long verse (31 words)"]
-            }, {
+              "subtype": "usfm:span",
+              "content": [
+                "Je vous le dis en vérité, partout où la bonne nouvelle sera prêchée, dans le monde entier, on racontera aussi en mémoire de cette femme ce qu’elle a fait."
+              ]
+            },
+            " ",
+            {
               "type": "mark",
               "subtype": "verses",
               "atts": {
                 "number": "10"
               }
-            }, {
+            },
+            {
               "type": "graft",
               "subtype": "xref",
               "target": "NGUxMTJlNTct"
             },
-            "Judas Iscariot, l’un des douze, alla vers les principaux sacrificateurs, afin de leur livrer Jésus. ", {
+            "Judas Iscariot, l’un des douze, alla vers les principaux sacrificateurs, afin de leur livrer Jésus. ",
+            {
               "type": "mark",
               "subtype": "verses",
               "atts": {
@@ -8301,15 +9623,18 @@
             },
             "Après l’avoir entendu, ils furent dans la joie, et promirent de lui donner de l’argent. Et Judas cherchait une occasion favorable pour le livrer."
           ]
-        }, {
+        },
+        {
           "type": "graft",
           "subtype": "heading",
           "target": "NTFmMDk0MWQt"
-        }, {
+        },
+        {
           "type": "graft",
           "subtype": "heading",
           "target": "YjU0YjVlZjEt"
-        }, {
+        },
+        {
           "type": "paragraph",
           "subtype": "usfm:p",
           "content": [
@@ -8331,20 +9656,25 @@
               "subtype": "xref",
               "target": "YjZiMjg5ZDgt"
             },
-            "des pains sans levain, où l’on immolait la Pâque, les disciples de Jésus lui dirent: Où veux-tu que nous allions te préparer la Pâque? ", {
+            "des pains sans levain, où l’on immolait la Pâque, les disciples de Jésus lui dirent: Où veux-tu que nous allions te préparer la Pâque? ",
+            {
               "type": "mark",
               "subtype": "verses",
               "atts": {
                 "number": "13"
               }
             },
-            "Et il envoya deux de ses disciples, et leur dit: ", {
+            "Et il envoya deux de ses disciples, et leur dit: ",
+            {
               "type": "wrapper",
-              "subtype": "usfm:wj",
-              "content": ["Allez à la ville; vous rencontrerez un homme portant une cruche d’eau, suivez-le."]
+              "subtype": "usfm:span",
+              "content": [
+                "Allez à la ville; vous rencontrerez un homme portant une cruche d’eau, suivez-le."
+              ]
             }
           ]
-        }, {
+        },
+        {
           "type": "paragraph",
           "subtype": "usfm:p",
           "content": [
@@ -8357,8 +9687,10 @@
             },
             {
               "type": "wrapper",
-              "subtype": "usfm:wj",
-              "content": ["Quelque part qu’il entre, dites au maître de la maison: Le maître dit: Où est le lieu où je mangerai la Pâque avec mes disciples?"]
+              "subtype": "usfm:span",
+              "content": [
+                "Quelque part qu’il entre, dites au maître de la maison: Le maître dit: Où est le lieu où je mangerai la Pâque avec mes disciples?"
+              ]
             },
             " ",
             {
@@ -8367,70 +9699,90 @@
               "atts": {
                 "number": "15"
               }
-            }, {
-              "type": "wrapper",
-              "subtype": "usfm:wj",
-              "content": ["Et il vous montrera une grande chambre haute, meublée et toute prête: c’est là que vous nous préparerez la Pâque."]
             },
-            " ", {
+            {
+              "type": "wrapper",
+              "subtype": "usfm:span",
+              "content": [
+                "Et il vous montrera une grande chambre haute, meublée et toute prête: c’est là que vous nous préparerez la Pâque."
+              ]
+            },
+            " ",
+            {
               "type": "mark",
               "subtype": "verses",
               "atts": {
                 "number": "16"
               }
             },
-            "Les disciples partirent, arrivèrent à la ville, et trouvèrent les choses comme il le leur avait dit; et ils préparèrent la Pâque. ", {
+            "Les disciples partirent, arrivèrent à la ville, et trouvèrent les choses comme il le leur avait dit; et ils préparèrent la Pâque. ",
+            {
               "type": "mark",
               "subtype": "verses",
               "atts": {
                 "number": "17"
               }
-            }, {
+            },
+            {
               "type": "graft",
               "subtype": "xref",
               "target": "MDRiOTAxMTgt"
             },
-            "Le soir étant venu, il arriva avec les douze. ", {
+            "Le soir étant venu, il arriva avec les douze. ",
+            {
               "type": "mark",
               "subtype": "verses",
               "atts": {
                 "number": "18"
               }
             },
-            "Pendant qu’ils étaient à table et qu’ils mangeaient, Jésus dit: ", {
+            "Pendant qu’ils étaient à table et qu’ils mangeaient, Jésus dit: ",
+            {
               "type": "wrapper",
-              "subtype": "usfm:wj",
-              "content": ["Je vous le dis en vérité,"]
-            }, {
+              "subtype": "usfm:span",
+              "content": [
+                "Je vous le dis en vérité,"
+              ]
+            },
+            {
               "type": "graft",
               "subtype": "xref",
               "target": "NzQ1YWJhMzQt"
-            }, {
-              "type": "wrapper",
-              "subtype": "usfm:wj",
-              "content": ["l’un de vous, qui mange avec moi, me livrera."]
             },
-            " ", {
+            {
+              "type": "wrapper",
+              "subtype": "usfm:span",
+              "content": [
+                "l’un de vous, qui mange avec moi, me livrera."
+              ]
+            },
+            " ",
+            {
               "type": "mark",
               "subtype": "verses",
               "atts": {
                 "number": "19"
               }
             },
-            "Ils commencèrent à s’attrister, et à lui dire, l’un après l’autre: Est-ce moi? ", {
+            "Ils commencèrent à s’attrister, et à lui dire, l’un après l’autre: Est-ce moi? ",
+            {
               "type": "mark",
               "subtype": "verses",
               "atts": {
                 "number": "20"
               }
             },
-            "Il leur répondit: ", {
+            "Il leur répondit: ",
+            {
               "type": "wrapper",
-              "subtype": "usfm:wj",
-              "content": ["C’est l’un des douze, qui met avec moi la main dans le plat."]
+              "subtype": "usfm:span",
+              "content": [
+                "C’est l’un des douze, qui met avec moi la main dans le plat."
+              ]
             }
           ]
-        }, {
+        },
+        {
           "type": "paragraph",
           "subtype": "usfm:p",
           "content": [
@@ -8440,25 +9792,25 @@
               "atts": {
                 "number": "21"
               }
-            }, {
+            },
+            {
               "type": "wrapper",
-              "subtype": "usfm:wj",
-              "content": ["Le Fils de l’homme s’en va selon ce qui est écrit de lui. Mais malheur à l’homme par qui le Fils de l’homme est livré! Mieux vaudrait pour cet homme qu’il ne fût pas né."]
+              "subtype": "usfm:span",
+              "content": [
+                "Le Fils de l’homme s’en va selon ce qui est écrit de lui. Mais malheur à l’homme par qui le Fils de l’homme est livré! Mieux vaudrait pour cet homme qu’il ne fût pas né."
+              ]
             }
           ]
-        }, {
+        },
+        {
           "type": "graft",
           "subtype": "heading",
           "target": "NmI4NDI2Mzct"
-        }, {
+        },
+        {
           "type": "paragraph",
           "subtype": "usfm:p",
           "content": [
-            {
-              "type": "wrapper",
-              "subtype": "meta_content",
-              "meta_content": ["<== Long verse (35 words)"]
-            },
             {
               "type": "mark",
               "subtype": "verses",
@@ -8471,32 +9823,41 @@
               "subtype": "xref",
               "target": "ZGZiYTEyYjUt"
             },
-            "Pendant qu’ils mangeaient, Jésus prit du pain; et, après avoir rendu grâces, il le rompit, et le leur donna, en disant: ", {
+            "Pendant qu’ils mangeaient, Jésus prit du pain; et, après avoir rendu grâces, il le rompit, et le leur donna, en disant: ",
+            {
               "type": "wrapper",
-              "subtype": "usfm:wj",
-              "content": ["Prenez, ceci est mon corps."]
+              "subtype": "usfm:span",
+              "content": [
+                "Prenez, ceci est mon corps."
+              ]
             },
-            " ", {
+            " ",
+            {
               "type": "mark",
               "subtype": "verses",
               "atts": {
                 "number": "23"
               }
             },
-            "Il prit ensuite une coupe; et, après avoir rendu grâces, il la leur donna, et ils en burent tous. ", {
+            "Il prit ensuite une coupe; et, après avoir rendu grâces, il la leur donna, et ils en burent tous. ",
+            {
               "type": "mark",
               "subtype": "verses",
               "atts": {
                 "number": "24"
               }
             },
-            "Et il leur dit: ", {
+            "Et il leur dit: ",
+            {
               "type": "wrapper",
-              "subtype": "usfm:wj",
-              "content": ["Ceci est mon sang, le sang de l’alliance, qui est répandu pour plusieurs."]
+              "subtype": "usfm:span",
+              "content": [
+                "Ceci est mon sang, le sang de l’alliance, qui est répandu pour plusieurs."
+              ]
             }
           ]
-        }, {
+        },
+        {
           "type": "paragraph",
           "subtype": "usfm:p",
           "content": [
@@ -8506,17 +9867,22 @@
               "atts": {
                 "number": "25"
               }
-            }, {
+            },
+            {
               "type": "wrapper",
-              "subtype": "usfm:wj",
-              "content": ["Je vous le dis en vérité, je ne boirai plus jamais du fruit de la vigne, jusqu’au jour où je le boirai nouveau dans le royaume de Dieu."]
+              "subtype": "usfm:span",
+              "content": [
+                "Je vous le dis en vérité, je ne boirai plus jamais du fruit de la vigne, jusqu’au jour où je le boirai nouveau dans le royaume de Dieu."
+              ]
             }
           ]
-        }, {
+        },
+        {
           "type": "graft",
           "subtype": "heading",
           "target": "NmM4OThlNTYt"
-        }, {
+        },
+        {
           "type": "paragraph",
           "subtype": "usfm:p",
           "content": [
@@ -8540,21 +9906,29 @@
               "subtype": "xref",
               "target": "NDQ2ZTY0ZDQt"
             },
-            "Jésus leur dit: ", {
+            "Jésus leur dit: ",
+            {
               "type": "wrapper",
-              "subtype": "usfm:wj",
-              "content": ["Vous serez tous scandalisés; car il est écrit:"]
-            }, {
+              "subtype": "usfm:span",
+              "content": [
+                "Vous serez tous scandalisés; car il est écrit:"
+              ]
+            },
+            {
               "type": "graft",
               "subtype": "xref",
               "target": "N2VmNmUxZjEt"
-            }, {
+            },
+            {
               "type": "wrapper",
-              "subtype": "usfm:wj",
-              "content": ["Je frapperai le berger, et les brebis seront dispersées."]
+              "subtype": "usfm:span",
+              "content": [
+                "Je frapperai le berger, et les brebis seront dispersées."
+              ]
             }
           ]
-        }, {
+        },
+        {
           "type": "paragraph",
           "subtype": "usfm:p",
           "content": [
@@ -8572,58 +9946,67 @@
             },
             {
               "type": "wrapper",
-              "subtype": "usfm:wj",
-              "content": ["Mais, après que je serai ressuscité, je vous précéderai en Galilée."]
+              "subtype": "usfm:span",
+              "content": [
+                "Mais, après que je serai ressuscité, je vous précéderai en Galilée."
+              ]
             },
-            " ", {
+            " ",
+            {
               "type": "mark",
               "subtype": "verses",
               "atts": {
                 "number": "29"
               }
             },
-            "Pierre lui dit: Quand tous seraient scandalisés, je ne serai pas scandalisé. ", {
+            "Pierre lui dit: Quand tous seraient scandalisés, je ne serai pas scandalisé. ",
+            {
               "type": "mark",
               "subtype": "verses",
               "atts": {
                 "number": "30"
               }
-            }, {
+            },
+            {
               "type": "graft",
               "subtype": "xref",
               "target": "NDkzZTc0YmMt"
             },
-            "Et Jésus lui dit: ", {
+            "Et Jésus lui dit: ",
+            {
               "type": "wrapper",
-              "subtype": "usfm:wj",
-              "content": ["Je te le dis en vérité, toi, aujourd’hui, cette nuit même, avant que le coq chante deux fois, tu me renieras trois fois."]
+              "subtype": "usfm:span",
+              "content": [
+                "Je te le dis en vérité, toi, aujourd’hui, cette nuit même, avant que le coq chante deux fois, tu me renieras trois fois."
+              ]
             },
-            " ", {
-              "type": "wrapper",
-              "subtype": "meta_content",
-              "meta_content": ["<== Long verse (30 words)"]
-            }, {
+            " ",
+            {
               "type": "mark",
               "subtype": "verses",
               "atts": {
                 "number": "31"
               }
-            }, {
+            },
+            {
               "type": "graft",
               "subtype": "xref",
               "target": "MGE1YzcyYmYt"
             },
             "Mais Pierre reprit plus fortement: Quand il me faudrait mourir avec toi, je ne te renierai pas. Et tous dirent la même chose."
           ]
-        }, {
+        },
+        {
           "type": "graft",
           "subtype": "heading",
           "target": "YmEwYzU0YzAt"
-        }, {
+        },
+        {
           "type": "graft",
           "subtype": "heading",
           "target": "NjE1NDMzZDYt"
-        }, {
+        },
+        {
           "type": "paragraph",
           "subtype": "usfm:p",
           "content": [
@@ -8642,81 +10025,105 @@
             "Ils allèrent ensuite dans un lieu appelé Gethsémané, et Jésus dit à ses disciples: ",
             {
               "type": "wrapper",
-              "subtype": "usfm:wj",
-              "content": ["Asseyez-vous ici, pendant que je prierai."]
+              "subtype": "usfm:span",
+              "content": [
+                "Asseyez-vous ici, pendant que je prierai."
+              ]
             },
-            " ", {
+            " ",
+            {
               "type": "mark",
               "subtype": "verses",
               "atts": {
                 "number": "33"
               }
             },
-            "Il prit avec lui Pierre, Jacques et Jean, et il commença à éprouver de la frayeur et des angoisses. ", {
+            "Il prit avec lui Pierre, Jacques et Jean, et il commença à éprouver de la frayeur et des angoisses. ",
+            {
               "type": "mark",
               "subtype": "verses",
               "atts": {
                 "number": "34"
               }
             },
-            "Il leur dit: ", {
+            "Il leur dit: ",
+            {
               "type": "graft",
               "subtype": "xref",
               "target": "MWJiZDFjMjgt"
-            }, {
-              "type": "wrapper",
-              "subtype": "usfm:wj",
-              "content": ["Mon âme est triste jusqu’à la mort; restez ici, et veillez."]
             },
-            " ", {
+            {
+              "type": "wrapper",
+              "subtype": "usfm:span",
+              "content": [
+                "Mon âme est triste jusqu’à la mort; restez ici, et veillez."
+              ]
+            },
+            " ",
+            {
               "type": "mark",
               "subtype": "verses",
               "atts": {
                 "number": "35"
               }
-            }, {
+            },
+            {
               "type": "graft",
               "subtype": "xref",
               "target": "NmI2N2JlY2Et"
             },
-            "Puis, ayant fait quelques pas en avant, il se jeta contre terre, et pria que, s’il était possible, cette heure s’éloignât de lui. ", {
+            "Puis, ayant fait quelques pas en avant, il se jeta contre terre, et pria que, s’il était possible, cette heure s’éloignât de lui. ",
+            {
               "type": "mark",
               "subtype": "verses",
               "atts": {
                 "number": "36"
               }
             },
-            "Il disait: ", {
+            "Il disait: ",
+            {
               "type": "wrapper",
-              "subtype": "usfm:wj",
-              "content": ["Abba, Père, toutes choses te sont possibles, éloigne de moi cette coupe!"]
-            }, {
+              "subtype": "usfm:span",
+              "content": [
+                "Abba, Père, toutes choses te sont possibles, éloigne de moi cette coupe!"
+              ]
+            },
+            {
               "type": "graft",
               "subtype": "xref",
               "target": "ZTA1NmJkOTMt"
-            }, {
-              "type": "wrapper",
-              "subtype": "usfm:wj",
-              "content": ["Toutefois, non pas ce que je veux, mais ce que tu veux."]
             },
-            " ", {
+            {
+              "type": "wrapper",
+              "subtype": "usfm:span",
+              "content": [
+                "Toutefois, non pas ce que je veux, mais ce que tu veux."
+              ]
+            },
+            " ",
+            {
               "type": "mark",
               "subtype": "verses",
               "atts": {
                 "number": "37"
               }
-            }, {
+            },
+            {
               "type": "graft",
               "subtype": "xref",
               "target": "YWU4MzI3ZDct"
             },
-            "Et il vint vers les disciples, qu’il trouva endormis, et il dit à Pierre: ", {
+            "Et il vint vers les disciples, qu’il trouva endormis, et il dit à Pierre: ",
+            {
               "type": "wrapper",
-              "subtype": "usfm:wj",
-              "content": ["Simon, tu dors! Tu n’as pu veiller une heure!"]
+              "subtype": "usfm:span",
+              "content": [
+                "Simon, tu dors! Tu n’as pu veiller une heure!"
+              ]
             }
           ]
-        }, {
+        },
+        {
           "type": "paragraph",
           "subtype": "usfm:p",
           "content": [
@@ -8729,8 +10136,10 @@
             },
             {
               "type": "wrapper",
-              "subtype": "usfm:wj",
-              "content": ["Veillez et priez, afin que vous ne tombiez pas en tentation;"]
+              "subtype": "usfm:span",
+              "content": [
+                "Veillez et priez, afin que vous ne tombiez pas en tentation;"
+              ]
             },
             {
               "type": "graft",
@@ -8739,65 +10148,76 @@
             },
             {
               "type": "wrapper",
-              "subtype": "usfm:wj",
-              "content": ["l’esprit est bien disposé, mais la chair est faible."]
+              "subtype": "usfm:span",
+              "content": [
+                "l’esprit est bien disposé, mais la chair est faible."
+              ]
             },
-            " ", {
+            " ",
+            {
               "type": "mark",
               "subtype": "verses",
               "atts": {
                 "number": "39"
               }
             },
-            "Il s’éloigna de nouveau, et fit la même prière. ", {
+            "Il s’éloigna de nouveau, et fit la même prière. ",
+            {
               "type": "mark",
               "subtype": "verses",
               "atts": {
                 "number": "40"
               }
             },
-            "Il revint, et les trouva encore endormis; car leurs yeux étaient appesantis. Ils ne surent que lui répondre. ", {
+            "Il revint, et les trouva encore endormis; car leurs yeux étaient appesantis. Ils ne surent que lui répondre. ",
+            {
               "type": "mark",
               "subtype": "verses",
               "atts": {
                 "number": "41"
               }
             },
-            "Il revint pour la troisième fois, et leur dit: ", {
+            "Il revint pour la troisième fois, et leur dit: ",
+            {
               "type": "wrapper",
-              "subtype": "usfm:wj",
-              "content": ["Dormez maintenant, et reposez-vous! C’est assez! L’heure est venue; voici, le Fils de l’homme est livré aux mains des pécheurs."]
+              "subtype": "usfm:span",
+              "content": [
+                "Dormez maintenant, et reposez-vous! C’est assez! L’heure est venue; voici, le Fils de l’homme est livré aux mains des pécheurs."
+              ]
             }
           ]
-        }, {
+        },
+        {
           "type": "paragraph",
           "subtype": "usfm:p",
           "content": [
             {
-              "type": "wrapper",
-              "subtype": "meta_content",
-              "meta_content": ["<== Long verse (30 words)"]
-            }, {
               "type": "mark",
               "subtype": "verses",
               "atts": {
                 "number": "42"
               }
-            }, {
+            },
+            {
               "type": "wrapper",
-              "subtype": "usfm:wj",
-              "content": ["Levez-vous, allons; voici, celui qui me livre s’approche."]
+              "subtype": "usfm:span",
+              "content": [
+                "Levez-vous, allons; voici, celui qui me livre s’approche."
+              ]
             }
           ]
-        }, {
+        },
+        {
           "type": "graft",
           "subtype": "heading",
           "target": "YjM0ODBhMWMt"
-        }, {
+        },
+        {
           "type": "graft",
           "subtype": "heading",
           "target": "NDI1MDg1MmUt"
-        }, {
+        },
+        {
           "type": "paragraph",
           "subtype": "usfm:p",
           "content": [
@@ -8815,56 +10235,61 @@
             },
             "Et aussitôt, comme il parlait encore, arriva Judas l’un des douze, et avec lui une foule armée d’épées et de bâtons, envoyée par les principaux sacrificateurs, par les scribes et par les anciens. ",
             {
-              "type": "wrapper",
-              "subtype": "meta_content",
-              "meta_content": ["<== Long verse (34 words)"]
-            }, {
               "type": "mark",
               "subtype": "verses",
               "atts": {
                 "number": "44"
               }
             },
-            "Celui qui le livrait leur avait donné ce signe: Celui que je baiserai, c’est lui; saisissez-le, et emmenez-le sûrement. ", {
+            "Celui qui le livrait leur avait donné ce signe: Celui que je baiserai, c’est lui; saisissez-le, et emmenez-le sûrement. ",
+            {
               "type": "mark",
               "subtype": "verses",
               "atts": {
                 "number": "45"
               }
             },
-            "Dès qu’il fut arrivé, il s’approcha de Jésus, disant: Rabbi! ", {
+            "Dès qu’il fut arrivé, il s’approcha de Jésus, disant: Rabbi! ",
+            {
               "type": "graft",
               "subtype": "xref",
               "target": "OGVhOTZmYjAt"
             },
-            "Et il le baisa. ", {
+            "Et il le baisa. ",
+            {
               "type": "mark",
               "subtype": "verses",
               "atts": {
                 "number": "46"
               }
             },
-            "Alors ces gens mirent la main sur Jésus, et le saisirent. ", {
+            "Alors ces gens mirent la main sur Jésus, et le saisirent. ",
+            {
               "type": "mark",
               "subtype": "verses",
               "atts": {
                 "number": "47"
               }
             },
-            "Un de ceux qui étaient là, tirant l’épée, frappa le serviteur du souverain sacrificateur, et lui emporta l’oreille. ", {
+            "Un de ceux qui étaient là, tirant l’épée, frappa le serviteur du souverain sacrificateur, et lui emporta l’oreille. ",
+            {
               "type": "mark",
               "subtype": "verses",
               "atts": {
                 "number": "48"
               }
             },
-            "Jésus, prenant la parole, leur dit: ", {
+            "Jésus, prenant la parole, leur dit: ",
+            {
               "type": "wrapper",
-              "subtype": "usfm:wj",
-              "content": ["Vous êtes venus, comme après un brigand, avec des épées et des bâtons, pour vous emparer de moi."]
+              "subtype": "usfm:span",
+              "content": [
+                "Vous êtes venus, comme après un brigand, avec des épées et des bâtons, pour vous emparer de moi."
+              ]
             }
           ]
-        }, {
+        },
+        {
           "type": "paragraph",
           "subtype": "usfm:p",
           "content": [
@@ -8877,8 +10302,10 @@
             },
             {
               "type": "wrapper",
-              "subtype": "usfm:wj",
-              "content": ["J’étais tous les jours parmi vous, enseignant dans le temple, et vous ne m’avez pas saisi."]
+              "subtype": "usfm:span",
+              "content": [
+                "J’étais tous les jours parmi vous, enseignant dans le temple, et vous ne m’avez pas saisi."
+              ]
             },
             {
               "type": "graft",
@@ -8887,28 +10314,34 @@
             },
             {
               "type": "wrapper",
-              "subtype": "usfm:wj",
-              "content": ["Mais c’est afin que les Écritures soient accomplies."]
+              "subtype": "usfm:span",
+              "content": [
+                "Mais c’est afin que les Écritures soient accomplies."
+              ]
             },
-            " ", {
+            " ",
+            {
               "type": "mark",
               "subtype": "verses",
               "atts": {
                 "number": "50"
               }
-            }, {
+            },
+            {
               "type": "graft",
               "subtype": "xref",
               "target": "ZTM2NjhiNzAt"
             },
-            "Alors tous l’abandonnèrent, et prirent la fuite. ", {
+            "Alors tous l’abandonnèrent, et prirent la fuite. ",
+            {
               "type": "mark",
               "subtype": "verses",
               "atts": {
                 "number": "51"
               }
             },
-            "Un jeune homme le suivait, n’ayant sur le corps qu’un drap. On se saisit de lui; ", {
+            "Un jeune homme le suivait, n’ayant sur le corps qu’un drap. On se saisit de lui; ",
+            {
               "type": "mark",
               "subtype": "verses",
               "atts": {
@@ -8917,15 +10350,18 @@
             },
             "mais il lâcha son vêtement, et se sauva tout nu."
           ]
-        }, {
+        },
+        {
           "type": "graft",
           "subtype": "heading",
           "target": "MGIwODE0MGMt"
-        }, {
+        },
+        {
           "type": "graft",
           "subtype": "heading",
           "target": "OWE0ZGJiMTQt"
-        }, {
+        },
+        {
           "type": "paragraph",
           "subtype": "usfm:p",
           "content": [
@@ -8949,145 +10385,158 @@
                 "number": "54"
               }
             },
-            "Pierre le suivit de loin jusque dans l’intérieur de la cour du souverain sacrificateur; il s’assit avec les serviteurs, et il se chauffait près du feu. ", {
+            "Pierre le suivit de loin jusque dans l’intérieur de la cour du souverain sacrificateur; il s’assit avec les serviteurs, et il se chauffait près du feu. ",
+            {
               "type": "mark",
               "subtype": "verses",
               "atts": {
                 "number": "55"
               }
-            }, {
+            },
+            {
               "type": "graft",
               "subtype": "xref",
               "target": "OWM1MTJlMmYt"
             },
-            "Les principaux sacrificateurs et tout le sanhédrin cherchaient un témoignage contre Jésus, pour le faire mourir, et ils n’en trouvaient point; ", {
+            "Les principaux sacrificateurs et tout le sanhédrin cherchaient un témoignage contre Jésus, pour le faire mourir, et ils n’en trouvaient point; ",
+            {
               "type": "mark",
               "subtype": "verses",
               "atts": {
                 "number": "56"
               }
             },
-            "car plusieurs rendaient de faux témoignages contre lui, mais les témoignages ne s’accordaient pas. ", {
+            "car plusieurs rendaient de faux témoignages contre lui, mais les témoignages ne s’accordaient pas. ",
+            {
               "type": "mark",
               "subtype": "verses",
               "atts": {
                 "number": "57"
               }
             },
-            "Quelques-uns se levèrent, et portèrent un faux témoignage contre lui, disant: ", {
+            "Quelques-uns se levèrent, et portèrent un faux témoignage contre lui, disant: ",
+            {
               "type": "mark",
               "subtype": "verses",
               "atts": {
                 "number": "58"
               }
             },
-            "Nous l’avons entendu dire: ", {
+            "Nous l’avons entendu dire: ",
+            {
               "type": "graft",
               "subtype": "xref",
               "target": "YWNiYzQ1OGQt"
             },
-            "Je détruirai ce temple fait de main d’homme, et en trois jours j’en bâtirai un autre qui ne sera pas fait de main d’homme. ", {
-              "type": "wrapper",
-              "subtype": "meta_content",
-              "meta_content": ["<== Long verse (30 words)"]
-            }, {
+            "Je détruirai ce temple fait de main d’homme, et en trois jours j’en bâtirai un autre qui ne sera pas fait de main d’homme. ",
+            {
               "type": "mark",
               "subtype": "verses",
               "atts": {
                 "number": "59"
               }
             },
-            "Même sur ce point-là leur témoignage ne s’accordait pas. ", {
+            "Même sur ce point-là leur témoignage ne s’accordait pas. ",
+            {
               "type": "mark",
               "subtype": "verses",
               "atts": {
                 "number": "60"
               }
-            }, {
+            },
+            {
               "type": "graft",
               "subtype": "xref",
               "target": "ZTI1YTg5NTIt"
             },
-            "Alors le souverain sacrificateur, se levant au milieu de l’assemblée, interrogea Jésus, et dit: Ne réponds-tu rien? Qu’est-ce que ces gens déposent contre toi? ", {
+            "Alors le souverain sacrificateur, se levant au milieu de l’assemblée, interrogea Jésus, et dit: Ne réponds-tu rien? Qu’est-ce que ces gens déposent contre toi? ",
+            {
               "type": "mark",
               "subtype": "verses",
               "atts": {
                 "number": "61"
               }
-            }, {
+            },
+            {
               "type": "graft",
               "subtype": "xref",
               "target": "MTE2MjY2MDUt"
             },
-            "Jésus garda le silence, et ne répondit rien. Le souverain sacrificateur l’interrogea de nouveau, et lui dit: Es-tu le Christ, le Fils du Dieu béni? ", {
+            "Jésus garda le silence, et ne répondit rien. Le souverain sacrificateur l’interrogea de nouveau, et lui dit: Es-tu le Christ, le Fils du Dieu béni? ",
+            {
               "type": "mark",
               "subtype": "verses",
               "atts": {
                 "number": "62"
               }
             },
-            "Jésus répondit: ", {
+            "Jésus répondit: ",
+            {
               "type": "wrapper",
-              "subtype": "usfm:wj",
-              "content": ["Je le suis."]
-            }, {
+              "subtype": "usfm:span",
+              "content": [
+                "Je le suis."
+              ]
+            },
+            {
               "type": "graft",
               "subtype": "xref",
               "target": "ZDJhYjgwZjct"
-            }, {
-              "type": "wrapper",
-              "subtype": "usfm:wj",
-              "content": ["Et vous verrez le Fils de l’homme assis à la droite de la puissance de Dieu, et venant sur les nuées du ciel."]
             },
-            " ", {
+            {
               "type": "wrapper",
-              "subtype": "meta_content",
-              "meta_content": ["<== Long verse (31 words)"]
-            }, {
+              "subtype": "usfm:span",
+              "content": [
+                "Et vous verrez le Fils de l’homme assis à la droite de la puissance de Dieu, et venant sur les nuées du ciel."
+              ]
+            },
+            " ",
+            {
               "type": "mark",
               "subtype": "verses",
               "atts": {
                 "number": "63"
               }
             },
-            "Alors le souverain sacrificateur déchira ses vêtements, et dit: Qu’avons-nous encore besoin de témoins? ", {
+            "Alors le souverain sacrificateur déchira ses vêtements, et dit: Qu’avons-nous encore besoin de témoins? ",
+            {
               "type": "mark",
               "subtype": "verses",
               "atts": {
                 "number": "64"
               }
             },
-            "Vous avez entendu le blasphème. Que vous en semble? Tous le condamnèrent comme méritant la mort. ", {
+            "Vous avez entendu le blasphème. Que vous en semble? Tous le condamnèrent comme méritant la mort. ",
+            {
               "type": "mark",
               "subtype": "verses",
               "atts": {
                 "number": "65"
               }
             },
-            "Et quelques-uns se mirent à cracher sur lui, à lui voiler le visage et ", {
+            "Et quelques-uns se mirent à cracher sur lui, à lui voiler le visage et ",
+            {
               "type": "graft",
               "subtype": "xref",
               "target": "ZGJmZjc4NTkt"
             },
             "à le frapper à coups de poing, en lui disant: Devine! Et les serviteurs le reçurent en lui donnant des soufflets."
           ]
-        }, {
+        },
+        {
           "type": "graft",
           "subtype": "heading",
           "target": "N2Y1M2I1NGYt"
-        }, {
+        },
+        {
           "type": "graft",
           "subtype": "heading",
           "target": "NDNhMTU2ZDgt"
-        }, {
+        },
+        {
           "type": "paragraph",
           "subtype": "usfm:p",
           "content": [
-            {
-              "type": "wrapper",
-              "subtype": "meta_content",
-              "meta_content": ["<== Long verse (36 words)"]
-            },
             {
               "type": "mark",
               "subtype": "verses",
@@ -9100,75 +10549,85 @@
               "subtype": "xref",
               "target": "NjgzMDQ5NmMt"
             },
-            "Pendant que Pierre était en bas dans la cour, il vint une des servantes du souverain sacrificateur. ", {
+            "Pendant que Pierre était en bas dans la cour, il vint une des servantes du souverain sacrificateur. ",
+            {
               "type": "mark",
               "subtype": "verses",
               "atts": {
                 "number": "67"
               }
             },
-            "Voyant Pierre qui se chauffait, elle le regarda, et lui dit: Toi aussi, tu étais avec Jésus de Nazareth. ", {
+            "Voyant Pierre qui se chauffait, elle le regarda, et lui dit: Toi aussi, tu étais avec Jésus de Nazareth. ",
+            {
               "type": "mark",
               "subtype": "verses",
               "atts": {
                 "number": "68"
               }
             },
-            "Il le nia, disant: Je ne sais pas, je ne comprends pas ce que tu veux dire. Puis il sortit pour aller dans le vestibule. Et le coq chanta. ", {
-              "type": "wrapper",
-              "subtype": "meta_content",
-              "meta_content": ["<== Long verse (30 words)"]
-            }, {
+            "Il le nia, disant: Je ne sais pas, je ne comprends pas ce que tu veux dire. Puis il sortit pour aller dans le vestibule. Et le coq chanta. ",
+            {
               "type": "mark",
               "subtype": "verses",
               "atts": {
                 "number": "69"
               }
-            }, {
+            },
+            {
               "type": "graft",
               "subtype": "xref",
               "target": "OWFjZGMwMWIt"
             },
-            "La servante, l’ayant vu, se mit de nouveau à dire à ceux qui étaient présents: Celui-ci est de ces gens-là. Et il le nia de nouveau. ", {
+            "La servante, l’ayant vu, se mit de nouveau à dire à ceux qui étaient présents: Celui-ci est de ces gens-là. Et il le nia de nouveau. ",
+            {
               "type": "mark",
               "subtype": "verses",
               "atts": {
                 "number": "70"
               }
             },
-            "Peu après, ceux qui étaient présents dirent encore à Pierre: Certainement tu es de ces gens-là, car tu es Galiléen. ", {
+            "Peu après, ceux qui étaient présents dirent encore à Pierre: Certainement tu es de ces gens-là, car tu es Galiléen. ",
+            {
               "type": "mark",
               "subtype": "verses",
               "atts": {
                 "number": "71"
               }
             },
-            "Alors il commença à faire des imprécations et à jurer: Je ne connais pas cet homme dont vous parlez. ", {
+            "Alors il commença à faire des imprécations et à jurer: Je ne connais pas cet homme dont vous parlez. ",
+            {
               "type": "mark",
               "subtype": "verses",
               "atts": {
                 "number": "72"
               }
             },
-            "Aussitôt, pour la seconde fois, le coq chanta. Et Pierre se souvint de la parole que Jésus lui avait dite: ", {
+            "Aussitôt, pour la seconde fois, le coq chanta. Et Pierre se souvint de la parole que Jésus lui avait dite: ",
+            {
               "type": "graft",
               "subtype": "xref",
               "target": "NmEzMzMyMmYt"
-            }, {
+            },
+            {
               "type": "wrapper",
-              "subtype": "usfm:wj",
-              "content": ["Avant que le coq chante deux fois, tu me renieras trois fois. Et en y réfléchissant, il pleurait."]
+              "subtype": "usfm:span",
+              "content": [
+                "Avant que le coq chante deux fois, tu me renieras trois fois. Et en y réfléchissant, il pleurait."
+              ]
             }
           ]
-        }, {
+        },
+        {
           "type": "graft",
           "subtype": "heading",
           "target": "Y2U3MTRhZDMt"
-        }, {
+        },
+        {
           "type": "graft",
           "subtype": "heading",
           "target": "YjgzMmYwYTct"
-        }, {
+        },
+        {
           "type": "paragraph",
           "subtype": "usfm:p",
           "content": [
@@ -9178,11 +10637,6 @@
               "atts": {
                 "number": "15"
               }
-            },
-            {
-              "type": "wrapper",
-              "subtype": "meta_content",
-              "meta_content": ["<== Long verse (39 words)"]
             },
             {
               "type": "mark",
@@ -9196,50 +10650,56 @@
               "subtype": "xref",
               "target": "NmJmZGYxNDUt"
             },
-            "Dès le matin, les principaux sacrificateurs tinrent conseil avec les anciens et les scribes, et tout le sanhédrin. Après avoir lié Jésus, ils l’emmenèrent, et le livrèrent ", {
+            "Dès le matin, les principaux sacrificateurs tinrent conseil avec les anciens et les scribes, et tout le sanhédrin. Après avoir lié Jésus, ils l’emmenèrent, et le livrèrent ",
+            {
               "type": "graft",
               "subtype": "xref",
               "target": "MGY1ZDY1NDQt"
             },
-            "à Pilate. ", {
-              "type": "wrapper",
-              "subtype": "meta_content",
-              "meta_content": ["<== Long verse (31 words)"]
-            }, {
+            "à Pilate. ",
+            {
               "type": "mark",
               "subtype": "verses",
               "atts": {
                 "number": "2"
               }
-            }, {
+            },
+            {
               "type": "graft",
               "subtype": "xref",
               "target": "YTk0NTAyNmQt"
             },
-            "Pilate l’interrogea: Es-tu le roi des Juifs? Jésus lui répondit: ", {
+            "Pilate l’interrogea: Es-tu le roi des Juifs? Jésus lui répondit: ",
+            {
               "type": "wrapper",
-              "subtype": "usfm:wj",
-              "content": ["Tu le dis."]
+              "subtype": "usfm:span",
+              "content": [
+                "Tu le dis."
+              ]
             },
-            " ", {
+            " ",
+            {
               "type": "mark",
               "subtype": "verses",
               "atts": {
                 "number": "3"
               }
             },
-            "Les principaux sacrificateurs portaient contre lui plusieurs accusations. ", {
+            "Les principaux sacrificateurs portaient contre lui plusieurs accusations. ",
+            {
               "type": "mark",
               "subtype": "verses",
               "atts": {
                 "number": "4"
               }
-            }, {
+            },
+            {
               "type": "graft",
               "subtype": "xref",
               "target": "MzYyZjBhNDct"
             },
-            "Pilate l’interrogea de nouveau: Ne réponds-tu rien? Vois de combien de choses ils t’accusent. ", {
+            "Pilate l’interrogea de nouveau: Ne réponds-tu rien? Vois de combien de choses ils t’accusent. ",
+            {
               "type": "mark",
               "subtype": "verses",
               "atts": {
@@ -9248,15 +10708,18 @@
             },
             "Et Jésus ne fit plus aucune réponse, ce qui étonna Pilate."
           ]
-        }, {
+        },
+        {
           "type": "graft",
           "subtype": "heading",
           "target": "ZTQzY2U2ZjUt"
-        }, {
+        },
+        {
           "type": "graft",
           "subtype": "heading",
           "target": "MTkwZGE2ZWQt"
-        }, {
+        },
+        {
           "type": "paragraph",
           "subtype": "usfm:p",
           "content": [
@@ -9279,108 +10742,125 @@
               "atts": {
                 "number": "7"
               }
-            }, {
+            },
+            {
               "type": "graft",
               "subtype": "xref",
               "target": "Mzk4ZjYxZTct"
             },
-            "Il y avait en prison un nommé Barabbas avec ses complices, pour un meurtre qu’ils avaient commis dans une sédition. ", {
+            "Il y avait en prison un nommé Barabbas avec ses complices, pour un meurtre qu’ils avaient commis dans une sédition. ",
+            {
               "type": "mark",
               "subtype": "verses",
               "atts": {
                 "number": "8"
               }
             },
-            "La foule, étant montée, se mit à demander ce qu’il avait coutume de leur accorder. ", {
+            "La foule, étant montée, se mit à demander ce qu’il avait coutume de leur accorder. ",
+            {
               "type": "mark",
               "subtype": "verses",
               "atts": {
                 "number": "9"
               }
             },
-            "Pilate leur répondit: Voulez-vous que je vous relâche le roi des Juifs? ", {
+            "Pilate leur répondit: Voulez-vous que je vous relâche le roi des Juifs? ",
+            {
               "type": "mark",
               "subtype": "verses",
               "atts": {
                 "number": "10"
               }
             },
-            "Car il savait que c’était par envie que les principaux sacrificateurs l’avaient livré. ", {
+            "Car il savait que c’était par envie que les principaux sacrificateurs l’avaient livré. ",
+            {
               "type": "mark",
               "subtype": "verses",
               "atts": {
                 "number": "11"
               }
-            }, {
+            },
+            {
               "type": "graft",
               "subtype": "xref",
               "target": "YjA0ZjIwZDQt"
             },
-            "Mais les chefs des sacrificateurs excitèrent la foule, afin que Pilate leur relâchât plutôt Barabbas. ", {
+            "Mais les chefs des sacrificateurs excitèrent la foule, afin que Pilate leur relâchât plutôt Barabbas. ",
+            {
               "type": "mark",
               "subtype": "verses",
               "atts": {
                 "number": "12"
               }
             },
-            "Pilate, reprenant la parole, leur dit: Que voulez-vous donc que je fasse de celui que vous appelez le roi des Juifs? ", {
+            "Pilate, reprenant la parole, leur dit: Que voulez-vous donc que je fasse de celui que vous appelez le roi des Juifs? ",
+            {
               "type": "mark",
               "subtype": "verses",
               "atts": {
                 "number": "13"
               }
             },
-            "Ils crièrent de nouveau: Crucifie-le! ", {
+            "Ils crièrent de nouveau: Crucifie-le! ",
+            {
               "type": "mark",
               "subtype": "verses",
               "atts": {
                 "number": "14"
               }
             },
-            "Pilate leur dit: Quel mal a-t-il fait? Et ils crièrent encore plus fort: Crucifie-le! ", {
+            "Pilate leur dit: Quel mal a-t-il fait? Et ils crièrent encore plus fort: Crucifie-le! ",
+            {
               "type": "mark",
               "subtype": "verses",
               "atts": {
                 "number": "15"
               }
-            }, {
+            },
+            {
               "type": "graft",
               "subtype": "xref",
               "target": "MzMyZmEyOTYt"
             },
-            "Pilate, voulant satisfaire la foule, leur relâcha Barabbas; et, après avoir fait battre de verges Jésus, il le livra pour être crucifié. ", {
+            "Pilate, voulant satisfaire la foule, leur relâcha Barabbas; et, après avoir fait battre de verges Jésus, il le livra pour être crucifié. ",
+            {
               "type": "mark",
               "subtype": "verses",
               "atts": {
                 "number": "16"
               }
-            }, {
+            },
+            {
               "type": "graft",
               "subtype": "xref",
               "target": "NTEzMzFhOWMt"
             },
-            "Les soldats conduisirent Jésus dans l’intérieur de la cour, c’est-à-dire, dans le prétoire, et ils assemblèrent toute la cohorte. ", {
+            "Les soldats conduisirent Jésus dans l’intérieur de la cour, c’est-à-dire, dans le prétoire, et ils assemblèrent toute la cohorte. ",
+            {
               "type": "mark",
               "subtype": "verses",
               "atts": {
                 "number": "17"
               }
             },
-            "Ils le revêtirent de pourpre, et posèrent sur sa tête une couronne d’épines, qu’ils avaient tressée. ", {
+            "Ils le revêtirent de pourpre, et posèrent sur sa tête une couronne d’épines, qu’ils avaient tressée. ",
+            {
               "type": "mark",
               "subtype": "verses",
               "atts": {
                 "number": "18"
               }
             },
-            "Puis ils se mirent à le saluer: Salut, roi des Juifs! ", {
+            "Puis ils se mirent à le saluer: Salut, roi des Juifs! ",
+            {
               "type": "mark",
               "subtype": "verses",
               "atts": {
                 "number": "19"
               }
             },
-            "Et ils lui frappaient la tête avec un roseau, crachaient sur lui, et, fléchissant les genoux, ils se prosternaient devant lui. ", {
+            "Et ils lui frappaient la tête avec un roseau, crachaient sur lui, et, fléchissant les genoux, ils se prosternaient devant lui. ",
+            {
               "type": "mark",
               "subtype": "verses",
               "atts": {
@@ -9389,15 +10869,18 @@
             },
             "Après s’être ainsi moqués de lui, ils lui ôtèrent la pourpre, lui remirent ses vêtements, et l’emmenèrent pour le crucifier."
           ]
-        }, {
+        },
+        {
           "type": "graft",
           "subtype": "heading",
           "target": "NjRlNjE4ZjEt"
-        }, {
+        },
+        {
           "type": "graft",
           "subtype": "heading",
           "target": "ODliMmJkNGUt"
-        }, {
+        },
+        {
           "type": "paragraph",
           "subtype": "usfm:p",
           "content": [
@@ -9420,77 +10903,90 @@
               "atts": {
                 "number": "22"
               }
-            }, {
+            },
+            {
               "type": "graft",
               "subtype": "xref",
               "target": "NzViOTczNDct"
             },
-            "et ils conduisirent Jésus au lieu nommé Golgotha, ce qui signifie lieu du crâne. ", {
+            "et ils conduisirent Jésus au lieu nommé Golgotha, ce qui signifie lieu du crâne. ",
+            {
               "type": "mark",
               "subtype": "verses",
               "atts": {
                 "number": "23"
               }
             },
-            "Ils lui donnèrent à boire du vin mêlé de myrrhe, mais il ne le prit pas. ", {
+            "Ils lui donnèrent à boire du vin mêlé de myrrhe, mais il ne le prit pas. ",
+            {
               "type": "mark",
               "subtype": "verses",
               "atts": {
                 "number": "24"
               }
-            }, {
+            },
+            {
               "type": "graft",
               "subtype": "xref",
               "target": "MjA3ZWRmOTUt"
             },
-            "Ils le crucifièrent, et ", {
+            "Ils le crucifièrent, et ",
+            {
               "type": "graft",
               "subtype": "xref",
               "target": "YTRmMGMxNDct"
             },
-            "se partagèrent ses vêtements, en tirant au sort pour savoir ce que chacun aurait. ", {
+            "se partagèrent ses vêtements, en tirant au sort pour savoir ce que chacun aurait. ",
+            {
               "type": "mark",
               "subtype": "verses",
               "atts": {
                 "number": "25"
               }
             },
-            "C’était la troisième heure, quand ils le crucifièrent. ", {
+            "C’était la troisième heure, quand ils le crucifièrent. ",
+            {
               "type": "mark",
               "subtype": "verses",
               "atts": {
                 "number": "26"
               }
-            }, {
+            },
+            {
               "type": "graft",
               "subtype": "xref",
               "target": "ODQzYjU0ZTAt"
             },
-            "L’inscription indiquant le sujet de sa condamnation portait ces mots: Le roi des Juifs. ", {
+            "L’inscription indiquant le sujet de sa condamnation portait ces mots: Le roi des Juifs. ",
+            {
               "type": "mark",
               "subtype": "verses",
               "atts": {
                 "number": "27"
               }
             },
-            "Ils crucifièrent avec lui deux brigands, l’un à sa droite, et l’autre à sa gauche. ", {
+            "Ils crucifièrent avec lui deux brigands, l’un à sa droite, et l’autre à sa gauche. ",
+            {
               "type": "mark",
               "subtype": "verses",
               "atts": {
                 "number": "28"
               }
-            }, {
+            },
+            {
               "type": "graft",
               "subtype": "xref",
               "target": "YWIxNDE4MWQt"
             },
             "Ainsi fut accompli ce que dit l’Écriture: Il a été mis au nombre des malfaiteurs."
           ]
-        }, {
+        },
+        {
           "type": "graft",
           "subtype": "heading",
           "target": "Y2NhY2QyNGUt"
-        }, {
+        },
+        {
           "type": "paragraph",
           "subtype": "usfm:p",
           "content": [
@@ -9512,21 +11008,24 @@
               "subtype": "xref",
               "target": "MjRmZDcwZjct"
             },
-            "toi qui détruis le temple, et qui le rebâtis en trois jours, ", {
+            "toi qui détruis le temple, et qui le rebâtis en trois jours, ",
+            {
               "type": "mark",
               "subtype": "verses",
               "atts": {
                 "number": "30"
               }
             },
-            "sauve-toi toi-même, en descendant de la croix! ", {
+            "sauve-toi toi-même, en descendant de la croix! ",
+            {
               "type": "mark",
               "subtype": "verses",
               "atts": {
                 "number": "31"
               }
             },
-            "Les principaux sacrificateurs aussi, avec les scribes, se moquaient entre eux, et disaient: Il a sauvé les autres, et il ne peut se sauver lui-même! ", {
+            "Les principaux sacrificateurs aussi, avec les scribes, se moquaient entre eux, et disaient: Il a sauvé les autres, et il ne peut se sauver lui-même! ",
+            {
               "type": "mark",
               "subtype": "verses",
               "atts": {
@@ -9535,11 +11034,13 @@
             },
             "Que le Christ, le roi d’Israël, descende maintenant de la croix, afin que nous voyions et que nous croyions! Ceux qui étaient crucifiés avec lui l’insultaient aussi."
           ]
-        }, {
+        },
+        {
           "type": "graft",
           "subtype": "heading",
           "target": "MThlYTkwMTQt"
-        }, {
+        },
+        {
           "type": "paragraph",
           "subtype": "usfm:p",
           "content": [
@@ -9563,105 +11064,121 @@
                 "number": "34"
               }
             },
-            "Et à la neuvième heure, Jésus s’écria d’une voix forte: ", {
+            "Et à la neuvième heure, Jésus s’écria d’une voix forte: ",
+            {
               "type": "graft",
               "subtype": "xref",
               "target": "ZmU1Y2E0Nzct"
-            }, {
-              "type": "wrapper",
-              "subtype": "usfm:wj",
-              "content": ["Éloï, Éloï, lama sabachthani?"]
             },
-            " ce qui signifie: Mon Dieu, mon Dieu, pourquoi m’as-tu abandonné? ", {
+            {
+              "type": "wrapper",
+              "subtype": "usfm:span",
+              "content": [
+                "Éloï, Éloï, lama sabachthani?"
+              ]
+            },
+            " ce qui signifie: Mon Dieu, mon Dieu, pourquoi m’as-tu abandonné? ",
+            {
               "type": "mark",
               "subtype": "verses",
               "atts": {
                 "number": "35"
               }
             },
-            "Quelques-uns de ceux qui étaient là, l’ayant entendu, dirent: Voici, il appelle Élie. ", {
+            "Quelques-uns de ceux qui étaient là, l’ayant entendu, dirent: Voici, il appelle Élie. ",
+            {
               "type": "mark",
               "subtype": "verses",
               "atts": {
                 "number": "36"
               }
-            }, {
+            },
+            {
               "type": "graft",
               "subtype": "xref",
               "target": "ZDVkNjAxY2It"
             },
-            "Et l’un d’eux courut remplir une éponge de vinaigre, et, l’ayant fixée à un roseau, il lui donna à boire, en disant: Laissez, voyons si Élie viendra le descendre. ", {
-              "type": "wrapper",
-              "subtype": "meta_content",
-              "meta_content": ["<== Long verse (30 words)"]
-            }, {
+            "Et l’un d’eux courut remplir une éponge de vinaigre, et, l’ayant fixée à un roseau, il lui donna à boire, en disant: Laissez, voyons si Élie viendra le descendre. ",
+            {
               "type": "mark",
               "subtype": "verses",
               "atts": {
                 "number": "37"
               }
             },
-            "Mais Jésus, ayant poussé un grand cri, expira. ", {
+            "Mais Jésus, ayant poussé un grand cri, expira. ",
+            {
               "type": "mark",
               "subtype": "verses",
               "atts": {
                 "number": "38"
               }
-            }, {
+            },
+            {
               "type": "graft",
               "subtype": "xref",
               "target": "NzA4YjBmNzgt"
             },
-            "Le voile du temple se déchira en deux, depuis le haut jusqu’en bas. ", {
+            "Le voile du temple se déchira en deux, depuis le haut jusqu’en bas. ",
+            {
               "type": "mark",
               "subtype": "verses",
               "atts": {
                 "number": "39"
               }
-            }, {
+            },
+            {
               "type": "graft",
               "subtype": "xref",
               "target": "NzVlMTg5MjAt"
             },
-            "Le centenier, qui était en face de Jésus, voyant qu’il avait expiré de la sorte, dit: Assurément, cet homme était Fils de Dieu. ", {
+            "Le centenier, qui était en face de Jésus, voyant qu’il avait expiré de la sorte, dit: Assurément, cet homme était Fils de Dieu. ",
+            {
               "type": "mark",
               "subtype": "verses",
               "atts": {
                 "number": "40"
               }
-            }, {
+            },
+            {
               "type": "graft",
               "subtype": "xref",
               "target": "MjY2MzBkZDEt"
             },
-            "Il y avait aussi des femmes ", {
+            "Il y avait aussi des femmes ",
+            {
               "type": "graft",
               "subtype": "xref",
               "target": "MTQ1NTIyOTQt"
             },
-            "qui regardaient de loin. Parmi elles étaient Marie de Magdala, Marie, mère de Jacques le mineur et de Joses, et Salomé, ", {
+            "qui regardaient de loin. Parmi elles étaient Marie de Magdala, Marie, mère de Jacques le mineur et de Joses, et Salomé, ",
+            {
               "type": "mark",
               "subtype": "verses",
               "atts": {
                 "number": "41"
               }
             },
-            "qui le suivaient et ", {
+            "qui le suivaient et ",
+            {
               "type": "graft",
               "subtype": "xref",
               "target": "N2M5Yzg3ODct"
             },
             "le servaient lorsqu’il était en Galilée, et plusieurs autres qui étaient montées avec lui à Jérusalem."
           ]
-        }, {
+        },
+        {
           "type": "graft",
           "subtype": "heading",
           "target": "MjExMDFlZjkt"
-        }, {
+        },
+        {
           "type": "graft",
           "subtype": "heading",
           "target": "N2M2M2ZmN2Mt"
-        }, {
+        },
+        {
           "type": "paragraph",
           "subtype": "usfm:p",
           "content": [
@@ -9685,37 +11202,38 @@
                 "number": "43"
               }
             },
-            "arriva Joseph d’Arimathée, conseiller de distinction, qui lui-même attendait aussi le royaume de Dieu. Il osa se rendre vers Pilate, pour demander le corps de Jésus. ", {
+            "arriva Joseph d’Arimathée, conseiller de distinction, qui lui-même attendait aussi le royaume de Dieu. Il osa se rendre vers Pilate, pour demander le corps de Jésus. ",
+            {
               "type": "mark",
               "subtype": "verses",
               "atts": {
                 "number": "44"
               }
             },
-            "Pilate s’étonna qu’il fût mort si tôt; fit venir le centenier et lui demanda s’il était mort depuis longtemps. ", {
+            "Pilate s’étonna qu’il fût mort si tôt; fit venir le centenier et lui demanda s’il était mort depuis longtemps. ",
+            {
               "type": "mark",
               "subtype": "verses",
               "atts": {
                 "number": "45"
               }
             },
-            "S’en étant assuré par le centenier, il donna le corps à Joseph. ", {
+            "S’en étant assuré par le centenier, il donna le corps à Joseph. ",
+            {
               "type": "mark",
               "subtype": "verses",
               "atts": {
                 "number": "46"
               }
             },
-            "Et Joseph, ayant acheté un linceul, descendit Jésus de la croix, l’enveloppa du linceul, ", {
+            "Et Joseph, ayant acheté un linceul, descendit Jésus de la croix, l’enveloppa du linceul, ",
+            {
               "type": "graft",
               "subtype": "xref",
               "target": "ZTg3ZmI5NzAt"
             },
-            "et le déposa dans un sépulcre taillé dans le roc. Puis il roula une pierre à l’entrée du sépulcre. ", {
-              "type": "wrapper",
-              "subtype": "meta_content",
-              "meta_content": ["<== Long verse (35 words)"]
-            }, {
+            "et le déposa dans un sépulcre taillé dans le roc. Puis il roula une pierre à l’entrée du sépulcre. ",
+            {
               "type": "mark",
               "subtype": "verses",
               "atts": {
@@ -9724,15 +11242,18 @@
             },
             "Marie de Magdala, et Marie, mère de Joses, regardaient où on le mettait."
           ]
-        }, {
+        },
+        {
           "type": "graft",
           "subtype": "heading",
           "target": "ZGRkMDZjMzEt"
-        }, {
+        },
+        {
           "type": "graft",
           "subtype": "heading",
           "target": "YjA1M2RkYTct"
-        }, {
+        },
+        {
           "type": "paragraph",
           "subtype": "usfm:p",
           "content": [
@@ -9755,89 +11276,99 @@
               "subtype": "xref",
               "target": "NTAyN2FlODkt"
             },
-            "Lorsque le sabbat fut passé, Marie de Magdala, Marie, mère de Jacques, et Salomé, achetèrent des aromates, afin d’aller embaumer Jésus. ", {
+            "Lorsque le sabbat fut passé, Marie de Magdala, Marie, mère de Jacques, et Salomé, achetèrent des aromates, afin d’aller embaumer Jésus. ",
+            {
               "type": "mark",
               "subtype": "verses",
               "atts": {
                 "number": "2"
               }
             },
-            "Le premier jour de la semaine, elles se rendirent au sépulcre, de grand matin, comme le soleil venait de se lever. ", {
+            "Le premier jour de la semaine, elles se rendirent au sépulcre, de grand matin, comme le soleil venait de se lever. ",
+            {
               "type": "mark",
               "subtype": "verses",
               "atts": {
                 "number": "3"
               }
             },
-            "Elles disaient entre elles: Qui nous roulera la pierre loin de l’entrée du sépulcre? ", {
+            "Elles disaient entre elles: Qui nous roulera la pierre loin de l’entrée du sépulcre? ",
+            {
               "type": "mark",
               "subtype": "verses",
               "atts": {
                 "number": "4"
               }
             },
-            "Et, levant les yeux, elles aperçurent que la pierre, qui était très grande, avait été roulée. ", {
+            "Et, levant les yeux, elles aperçurent que la pierre, qui était très grande, avait été roulée. ",
+            {
               "type": "mark",
               "subtype": "verses",
               "atts": {
                 "number": "5"
               }
-            }, {
+            },
+            {
               "type": "graft",
               "subtype": "xref",
               "target": "Yzc4ZTI2MmYt"
             },
-            "Elles entrèrent dans le sépulcre, virent un jeune homme assis à droite vêtu d’une robe blanche, et elles furent épouvantées. ", {
+            "Elles entrèrent dans le sépulcre, virent un jeune homme assis à droite vêtu d’une robe blanche, et elles furent épouvantées. ",
+            {
               "type": "mark",
               "subtype": "verses",
               "atts": {
                 "number": "6"
               }
             },
-            "Il leur dit: ", {
+            "Il leur dit: ",
+            {
               "type": "graft",
               "subtype": "xref",
               "target": "MzY4NzliZTMt"
             },
-            "Ne vous épouvantez pas; vous cherchez Jésus de Nazareth, qui a été crucifié; il est ressuscité, il n’est point ici; voici le lieu où on l’avait mis. ", {
-              "type": "wrapper",
-              "subtype": "meta_content",
-              "meta_content": ["<== Long verse (32 words)"]
-            }, {
+            "Ne vous épouvantez pas; vous cherchez Jésus de Nazareth, qui a été crucifié; il est ressuscité, il n’est point ici; voici le lieu où on l’avait mis. ",
+            {
               "type": "mark",
               "subtype": "verses",
               "atts": {
                 "number": "7"
               }
             },
-            "Mais allez dire à ses disciples et à Pierre qu’il vous ", {
+            "Mais allez dire à ses disciples et à Pierre qu’il vous ",
+            {
               "type": "graft",
               "subtype": "xref",
               "target": "NzljZjNmMTYt"
             },
-            "précède en Galilée: c’est là que vous le verrez, ", {
+            "précède en Galilée: c’est là que vous le verrez, ",
+            {
               "type": "graft",
               "subtype": "xref",
               "target": "OWM4ZDE2ODUt"
             },
-            "comme il vous l’a dit. ", {
+            "comme il vous l’a dit. ",
+            {
               "type": "mark",
               "subtype": "verses",
               "atts": {
                 "number": "8"
               }
-            }, {
+            },
+            {
               "type": "graft",
               "subtype": "xref",
               "target": "MWRhYjczYmIt"
             },
             "Elles sortirent du sépulcre et s’enfuirent. La peur et le trouble les avaient saisies; et elles ne dirent rien à personne, à cause de leur effroi."
           ]
-        }, {
+        },
+        {
           "type": "graft",
           "subtype": "heading",
           "target": "ZjQxZWQ1YWUt"
-        }, {
+        },
+        {
           "type": "paragraph",
           "subtype": "usfm:p",
           "content": [
@@ -9854,69 +11385,74 @@
               "subtype": "xref",
               "target": "MDIxM2FjMzEt"
             },
-            "d’abord à Marie de Magdala, ", {
+            "d’abord à Marie de Magdala, ",
+            {
               "type": "graft",
               "subtype": "xref",
               "target": "YjljMzZkOGEt"
             },
-            "de laquelle il avait chassé sept démons. ", {
+            "de laquelle il avait chassé sept démons. ",
+            {
               "type": "mark",
               "subtype": "verses",
               "atts": {
                 "number": "10"
               }
             },
-            "Elle alla en porter la nouvelle à ceux qui avaient été avec lui, et qui s’affligeaient et pleuraient. ", {
+            "Elle alla en porter la nouvelle à ceux qui avaient été avec lui, et qui s’affligeaient et pleuraient. ",
+            {
               "type": "mark",
               "subtype": "verses",
               "atts": {
                 "number": "11"
               }
             },
-            "Quand ils entendirent qu’il vivait, et qu’elle l’avait vu, ils ne le crurent point. ", {
+            "Quand ils entendirent qu’il vivait, et qu’elle l’avait vu, ils ne le crurent point. ",
+            {
               "type": "mark",
               "subtype": "verses",
               "atts": {
                 "number": "12"
               }
-            }, {
+            },
+            {
               "type": "graft",
               "subtype": "xref",
               "target": "ZDdhZWI0YmYt"
             },
-            "Après cela, il apparut, sous une autre forme, à deux d’entre eux qui étaient en chemin pour aller à la campagne. ", {
+            "Après cela, il apparut, sous une autre forme, à deux d’entre eux qui étaient en chemin pour aller à la campagne. ",
+            {
               "type": "mark",
               "subtype": "verses",
               "atts": {
                 "number": "13"
               }
             },
-            "Ils revinrent l’annoncer aux autres, qui ne les crurent pas non plus. ", {
+            "Ils revinrent l’annoncer aux autres, qui ne les crurent pas non plus. ",
+            {
               "type": "mark",
               "subtype": "verses",
               "atts": {
                 "number": "14"
               }
-            }, {
+            },
+            {
               "type": "graft",
               "subtype": "xref",
               "target": "ZDFiODhkNTkt"
             },
             "Enfin, il apparut aux onze, pendant qu’ils étaient à table; et il leur reprocha leur incrédulité et la dureté de leur cœur, parce qu’ils n’avaient pas cru ceux qui l’avaient vu ressuscité."
           ]
-        }, {
+        },
+        {
           "type": "graft",
           "subtype": "heading",
           "target": "NzRlYTA0YTgt"
-        }, {
+        },
+        {
           "type": "paragraph",
           "subtype": "usfm:p",
           "content": [
-            {
-              "type": "wrapper",
-              "subtype": "meta_content",
-              "meta_content": ["<== Long verse (32 words)"]
-            },
             {
               "type": "mark",
               "subtype": "verses",
@@ -9929,13 +11465,17 @@
               "type": "graft",
               "subtype": "xref",
               "target": "OGE0ZTUwZmEt"
-            }, {
+            },
+            {
               "type": "wrapper",
-              "subtype": "usfm:wj",
-              "content": ["Allez par tout le monde, et prêchez la bonne nouvelle à toute la création."]
+              "subtype": "usfm:span",
+              "content": [
+                "Allez par tout le monde, et prêchez la bonne nouvelle à toute la création."
+              ]
             }
           ]
-        }, {
+        },
+        {
           "type": "paragraph",
           "subtype": "usfm:p",
           "content": [
@@ -9948,8 +11488,10 @@
             },
             {
               "type": "wrapper",
-              "subtype": "usfm:wj",
-              "content": ["Celui qui croira et qui sera baptisé sera sauvé,"]
+              "subtype": "usfm:span",
+              "content": [
+                "Celui qui croira et qui sera baptisé sera sauvé,"
+              ]
             },
             {
               "type": "graft",
@@ -9958,84 +11500,112 @@
             },
             {
               "type": "wrapper",
-              "subtype": "usfm:wj",
-              "content": ["mais celui qui ne croira pas sera condamné."]
+              "subtype": "usfm:span",
+              "content": [
+                "mais celui qui ne croira pas sera condamné."
+              ]
             },
-            " ", {
+            " ",
+            {
               "type": "mark",
               "subtype": "verses",
               "atts": {
                 "number": "17"
               }
-            }, {
+            },
+            {
               "type": "wrapper",
-              "subtype": "usfm:wj",
-              "content": ["Voici les miracles qui accompagneront ceux qui auront cru:"]
-            }, {
+              "subtype": "usfm:span",
+              "content": [
+                "Voici les miracles qui accompagneront ceux qui auront cru:"
+              ]
+            },
+            {
               "type": "graft",
               "subtype": "xref",
               "target": "MTM5Njg3M2Qt"
-            }, {
+            },
+            {
               "type": "wrapper",
-              "subtype": "usfm:wj",
-              "content": ["en mon nom, ils chasseront les démons;"]
-            }, {
+              "subtype": "usfm:span",
+              "content": [
+                "en mon nom, ils chasseront les démons;"
+              ]
+            },
+            {
               "type": "graft",
               "subtype": "xref",
               "target": "MmI1ZjkwNTkt"
-            }, {
-              "type": "wrapper",
-              "subtype": "usfm:wj",
-              "content": ["ils parleront de nouvelles langues;"]
             },
-            " ", {
+            {
+              "type": "wrapper",
+              "subtype": "usfm:span",
+              "content": [
+                "ils parleront de nouvelles langues;"
+              ]
+            },
+            " ",
+            {
               "type": "mark",
               "subtype": "verses",
               "atts": {
                 "number": "18"
               }
-            }, {
+            },
+            {
               "type": "graft",
               "subtype": "xref",
               "target": "ZjdhODcxYmYt"
-            }, {
+            },
+            {
               "type": "wrapper",
-              "subtype": "usfm:wj",
-              "content": ["ils saisiront des serpents; s’ils boivent quelque breuvage mortel, il ne leur fera point de mal;"]
-            }, {
+              "subtype": "usfm:span",
+              "content": [
+                "ils saisiront des serpents; s’ils boivent quelque breuvage mortel, il ne leur fera point de mal;"
+              ]
+            },
+            {
               "type": "graft",
               "subtype": "xref",
               "target": "MDYzZGVmM2Mt"
-            }, {
-              "type": "wrapper",
-              "subtype": "usfm:wj",
-              "content": ["ils imposeront les mains aux malades, et les malades, seront guéris."]
             },
-            " ", {
+            {
+              "type": "wrapper",
+              "subtype": "usfm:span",
+              "content": [
+                "ils imposeront les mains aux malades, et les malades, seront guéris."
+              ]
+            },
+            " ",
+            {
               "type": "mark",
               "subtype": "verses",
               "atts": {
                 "number": "19"
               }
             },
-            "Le Seigneur, après leur avoir parlé, ", {
+            "Le Seigneur, après leur avoir parlé, ",
+            {
               "type": "graft",
               "subtype": "xref",
               "target": "ZjE0MmYxOGMt"
             },
-            "fut enlevé au ciel, et il s’assit à la droite de Dieu. ", {
+            "fut enlevé au ciel, et il s’assit à la droite de Dieu. ",
+            {
               "type": "mark",
               "subtype": "verses",
               "atts": {
                 "number": "20"
               }
             },
-            "Et ils ", {
+            "Et ils ",
+            {
               "type": "graft",
               "subtype": "xref",
               "target": "YmYxMjkzMWUt"
             },
-            "s’en allèrent prêcher partout. ", {
+            "s’en allèrent prêcher partout. ",
+            {
               "type": "graft",
               "subtype": "xref",
               "target": "OWJkOWFjNzAt"
@@ -10056,7 +11626,9 @@
         {
           "type": "paragraph",
           "subtype": "usfm:ip",
-          "content": ["L’auteur de l’Évangile selon Marc est le seul qui donne à son livre le titre de: «Évangile de Jésus-Christ, Fils de Dieu» (1:1). Pour cette raison, on peut le considérer comme le créateur de ce genre littéraire. Autrement dit, il serait le premier à mettre par écrit la tradition sur la personne, la vie et l’œuvre de Jésus-Christ qui, jusque-là, circulait sous une forme orale. L’Évangile à ses débuts était prédication, Bonne Nouvelle du salut en Jésus-Christ. Avec la disparition des témoins oculaires de la vie de Jésus, la préservation par écrit de ce qui se disait sur sa personne et son œuvre s’imposa. Marc serait le premier dans cette entreprise. Le canevas de cet évangile est donc le suivant:"]
+          "content": [
+            "L’auteur de l’Évangile selon Marc est le seul qui donne à son livre le titre de: «Évangile de Jésus-Christ, Fils de Dieu» (1:1). Pour cette raison, on peut le considérer comme le créateur de ce genre littéraire. Autrement dit, il serait le premier à mettre par écrit la tradition sur la personne, la vie et l’œuvre de Jésus-Christ qui, jusque-là, circulait sous une forme orale. L’Évangile à ses débuts était prédication, Bonne Nouvelle du salut en Jésus-Christ. Avec la disparition des témoins oculaires de la vie de Jésus, la préservation par écrit de ce qui se disait sur sa personne et son œuvre s’imposa. Marc serait le premier dans cette entreprise. Le canevas de cet évangile est donc le suivant:"
+          ]
         },
         {
           "type": "paragraph",
@@ -10067,213 +11639,354 @@
           "type": "paragraph",
           "subtype": "usfm:io",
           "content": [
-            "1. Prédication de Jean-Baptiste, baptême et tentation de Jésus-Christ ", {
+            "1. Prédication de Jean-Baptiste, baptême et tentation de Jésus-Christ ",
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["1:1-13"]
+              "content": [
+                "1:1-13"
+              ]
             }
           ]
-        }, {
+        },
+        {
           "type": "paragraph",
           "subtype": "usfm:io",
           "content": [
-            "2. Commencement du ministère et ministère de Jésus en Galilée ", {
+            "2. Commencement du ministère et ministère de Jésus en Galilée ",
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["1:14–7:23"]
+              "content": [
+                "1:14–7:23"
+              ]
             }
           ]
-        }, {
+        },
+        {
           "type": "paragraph",
           "subtype": "usfm:io",
           "content": [
-            "3. Jésus dans les territoires de Tyr et de Sidon; ministère de Jésus hors de Galilée et en route vers Jérusalem ", {
+            "3. Jésus dans les territoires de Tyr et de Sidon; ministère de Jésus hors de Galilée et en route vers Jérusalem ",
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["7:24–10:52"]
+              "content": [
+                "7:24–10:52"
+              ]
             }
           ]
-        }, {
+        },
+        {
           "type": "paragraph",
           "subtype": "usfm:io",
           "content": [
-            "4. Entrée de Jésus à Jérusalem et ministère jérusalémite de Jésus avec les événements majeurs que sont sa passion et sa résurrection ", {
+            "4. Entrée de Jésus à Jérusalem et ministère jérusalémite de Jésus avec les événements majeurs que sont sa passion et sa résurrection ",
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["11:1–16:20"]
+              "content": [
+                "11:1–16:20"
+              ]
             }
           ]
-        }, {
+        },
+        {
           "type": "paragraph",
           "subtype": "usfm:ib",
           "content": []
-        }, {
+        },
+        {
           "type": "paragraph",
           "subtype": "usfm:ip",
-          "content": ["Le titre: «Évangile de Jésus-Christ, Fils de Dieu» résume le contenu de Marc. Pour lui, Jésus est le Fils de Dieu, l’homme en qui et par qui Dieu se manifesta au monde. En Jésus et en Jésus seul, Dieu se fait connaître, il s’incarne pour permettre aux hommes de le reconnaître comme Dieu, de croire en lui et de recevoir la vie véritable. De tous les quatre évangiles, celui de Marc est le plus court. Il contient donc l’essentiel de ce que la tradition a voulu préserver au sujet de la vie et de l’œuvre de Jésus-Christ."]
-        }, {
+          "content": [
+            "Le titre: «Évangile de Jésus-Christ, Fils de Dieu» résume le contenu de Marc. Pour lui, Jésus est le Fils de Dieu, l’homme en qui et par qui Dieu se manifesta au monde. En Jésus et en Jésus seul, Dieu se fait connaître, il s’incarne pour permettre aux hommes de le reconnaître comme Dieu, de croire en lui et de recevoir la vie véritable. De tous les quatre évangiles, celui de Marc est le plus court. Il contient donc l’essentiel de ce que la tradition a voulu préserver au sujet de la vie et de l’œuvre de Jésus-Christ."
+          ]
+        },
+        {
           "type": "paragraph",
           "subtype": "usfm:ip",
-          "content": ["Le nom de l’auteur ne se trouve pas dans le texte de l’évangile, toutefois la tradition l’attribue à Marc. Il s’agirait de Jean Marc (Act 12:25; 13:5; 15:37), fils de Marie (Act 12:12) et cousin de Barnabas (Col 4:10), compagnon de Paul (Phm 24, 2 Tim 4:11), disciple de Pierre (1 Pi 5:13). Il s’agirait donc d'un personnage suffisamment renseigné sur Jésus grâce aux apports de Pierre et de Paul, mais aussi à ses connaissances personnelles de chrétien probablement encore très jeune lors des événements de la passion de Jésus. Marc 14:51-52 apparaît comme une signature anonyme de l’auteur qui a voulu laisser une marque de son souvenir personnel."]
-        }, {
+          "content": [
+            "Le nom de l’auteur ne se trouve pas dans le texte de l’évangile, toutefois la tradition l’attribue à Marc. Il s’agirait de Jean Marc (Act 12:25; 13:5; 15:37), fils de Marie (Act 12:12) et cousin de Barnabas (Col 4:10), compagnon de Paul (Phm 24, 2 Tim 4:11), disciple de Pierre (1 Pi 5:13). Il s’agirait donc d'un personnage suffisamment renseigné sur Jésus grâce aux apports de Pierre et de Paul, mais aussi à ses connaissances personnelles de chrétien probablement encore très jeune lors des événements de la passion de Jésus. Marc 14:51-52 apparaît comme une signature anonyme de l’auteur qui a voulu laisser une marque de son souvenir personnel."
+          ]
+        },
+        {
           "type": "paragraph",
           "subtype": "usfm:ip",
-          "content": ["Les destinataires de Marc sont des chrétiens d’origine païenne. En effet, quand on lit Marc, on se rend facilement compte qu’il prend soin, chaque fois que cela s’avère nécessaire, d’expliquer les usages des Juifs. C’est le cas en 7:3: «Or, les pharisiens et tous les Juifs ne mangent pas sans s’être lavé soigneusement les mains, conformément à la tradition des anciens; et, quand ils reviennent de la place publique, ils ne mangent qu’après s’être purifiés» (voir aussi 3:7; 5:4; 7:11; 14:12; 15:42, etc.)."]
-        }, {
+          "content": [
+            "Les destinataires de Marc sont des chrétiens d’origine païenne. En effet, quand on lit Marc, on se rend facilement compte qu’il prend soin, chaque fois que cela s’avère nécessaire, d’expliquer les usages des Juifs. C’est le cas en 7:3: «Or, les pharisiens et tous les Juifs ne mangent pas sans s’être lavé soigneusement les mains, conformément à la tradition des anciens; et, quand ils reviennent de la place publique, ils ne mangent qu’après s’être purifiés» (voir aussi 3:7; 5:4; 7:11; 14:12; 15:42, etc.)."
+          ]
+        },
+        {
           "type": "paragraph",
           "subtype": "usfm:ip",
-          "content": ["L’Évangile de Marc est comme un drame plutôt qu’un enseignement. Il se déroule autour de la personne de Jésus par rapport aux relations qu’il a entretenues avec les hommes, que l’on peut facilement classer en trois catégories: ses propres intimes, ses opposants et, entre ces extrêmes, les foules."]
-        }, {
+          "content": [
+            "L’Évangile de Marc est comme un drame plutôt qu’un enseignement. Il se déroule autour de la personne de Jésus par rapport aux relations qu’il a entretenues avec les hommes, que l’on peut facilement classer en trois catégories: ses propres intimes, ses opposants et, entre ces extrêmes, les foules."
+          ]
+        },
+        {
           "type": "paragraph",
           "subtype": "usfm:ip",
-          "content": ["Le message dramatique de Marc est que Jésus, pendant sa carrière terrestre, est resté incompris et, à la limite, mystérieux pour tous ceux qui l’entouraient, aussi bien ses opposants que ses propres disciples. Malgré ses enseignements en paroles et en actes, ses miracles et ses guérisons spectaculaires, le secret de sa messianité ne sera connu de tous qu’après sa mort et sa résurrection."]
-        }, {
+          "content": [
+            "Le message dramatique de Marc est que Jésus, pendant sa carrière terrestre, est resté incompris et, à la limite, mystérieux pour tous ceux qui l’entouraient, aussi bien ses opposants que ses propres disciples. Malgré ses enseignements en paroles et en actes, ses miracles et ses guérisons spectaculaires, le secret de sa messianité ne sera connu de tous qu’après sa mort et sa résurrection."
+          ]
+        },
+        {
           "type": "paragraph",
           "subtype": "usfm:ip",
           "content": [
             {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["«Ne vous épouvantez pas; vous cherchez Jésus de Nazareth, qui a éte crucifié; il est ressuscité, il n’est point ici… Allez dire à ses disciples et à Pierre qu’il vous précède en Galilée: c’est là que vous le verrez, comme il vous l’a dit"]
+              "content": [
+                "«Ne vous épouvantez pas; vous cherchez Jésus de Nazareth, qui a éte crucifié; il est ressuscité, il n’est point ici… Allez dire à ses disciples et à Pierre qu’il vous précède en Galilée: c’est là que vous le verrez, comme il vous l’a dit"
+              ]
             },
             "» (Mc 16:6-7)."
           ]
-        }, {
+        },
+        {
           "type": "paragraph",
           "subtype": "usfm:ip",
-          "content": ["La pédagogie de Marc consiste à rendre son lecteur participant de l’événement qui survient à l’écoute de la Bonne Nouvelle de Jésus-Christ. Le titre qu’il donne à son livre «l’Évangile de Jésus-Christ, Fils de Dieu» (1:1), comparativement à celui qu’il donne à la prédication de Jésus «la bonne nouvelle» (1:15) interroge le lecteur sur la Bonne Nouvelle annoncée par Jésus et sur celle le concernant. Il ne faudrait donc pas confondre ce que Jésus a été réellement avec ce que les témoins de sa vie rapportent sur lui. Chacun a procédé à une sélection des événements de sa vie. S’agissant de Marc, voici les miracles et paraboles qu’il a trouvé utile de rapporter."]
-        }, {
+          "content": [
+            "La pédagogie de Marc consiste à rendre son lecteur participant de l’événement qui survient à l’écoute de la Bonne Nouvelle de Jésus-Christ. Le titre qu’il donne à son livre «l’Évangile de Jésus-Christ, Fils de Dieu» (1:1), comparativement à celui qu’il donne à la prédication de Jésus «la bonne nouvelle» (1:15) interroge le lecteur sur la Bonne Nouvelle annoncée par Jésus et sur celle le concernant. Il ne faudrait donc pas confondre ce que Jésus a été réellement avec ce que les témoins de sa vie rapportent sur lui. Chacun a procédé à une sélection des événements de sa vie. S’agissant de Marc, voici les miracles et paraboles qu’il a trouvé utile de rapporter."
+          ]
+        },
+        {
           "type": "graft",
           "subtype": "heading",
           "target": "OGRlYzFjZmEt"
-        }, {
-          "type": "paragraph",
-          "subtype": "usfm:tr",
-          "content": ["1. la guérison d’un démoniaque ", "1:23-36"]
-        }, {
-          "type": "paragraph",
-          "subtype": "usfm:tr",
-          "content": ["2. la guérison de la belle-mère de Pierre ", "1:29-31"]
-        }, {
-          "type": "paragraph",
-          "subtype": "usfm:tr",
-          "content": ["3. la guérison d’un lépreux ", "1:40-45"]
-        }, {
-          "type": "paragraph",
-          "subtype": "usfm:tr",
-          "content": ["4. la guérison d’un paralytique ", "2:1-12"]
-        }, {
-          "type": "paragraph",
-          "subtype": "usfm:tr",
-          "content": ["5. la guérison de l’homme à la main sèche ", "3:1-6"]
-        }, {
-          "type": "paragraph",
-          "subtype": "usfm:tr",
-          "content": ["6. la tempête apaisée ", "4:35-41"]
-        }, {
-          "type": "paragraph",
-          "subtype": "usfm:tr",
-          "content": ["7. la guérison d’un démoniaque ", "5:1-20"]
-        }, {
-          "type": "paragraph",
-          "subtype": "usfm:tr",
-          "content": ["8. la résurrection de la fille de Jaïrus ", "5:22-43"]
-        }, {
-          "type": "paragraph",
-          "subtype": "usfm:tr",
-          "content": ["9. la guérison de la femme malade depuis douze ans ", "5:25-34"]
-        }, {
+        },
+        {
           "type": "paragraph",
           "subtype": "usfm:tr",
           "content": [
-            "10. la multiplication des pains (1", {
+            "1. la guérison d’un démoniaque ",
+            "1:23-36"
+          ]
+        },
+        {
+          "type": "paragraph",
+          "subtype": "usfm:tr",
+          "content": [
+            "2. la guérison de la belle-mère de Pierre ",
+            "1:29-31"
+          ]
+        },
+        {
+          "type": "paragraph",
+          "subtype": "usfm:tr",
+          "content": [
+            "3. la guérison d’un lépreux ",
+            "1:40-45"
+          ]
+        },
+        {
+          "type": "paragraph",
+          "subtype": "usfm:tr",
+          "content": [
+            "4. la guérison d’un paralytique ",
+            "2:1-12"
+          ]
+        },
+        {
+          "type": "paragraph",
+          "subtype": "usfm:tr",
+          "content": [
+            "5. la guérison de l’homme à la main sèche ",
+            "3:1-6"
+          ]
+        },
+        {
+          "type": "paragraph",
+          "subtype": "usfm:tr",
+          "content": [
+            "6. la tempête apaisée ",
+            "4:35-41"
+          ]
+        },
+        {
+          "type": "paragraph",
+          "subtype": "usfm:tr",
+          "content": [
+            "7. la guérison d’un démoniaque ",
+            "5:1-20"
+          ]
+        },
+        {
+          "type": "paragraph",
+          "subtype": "usfm:tr",
+          "content": [
+            "8. la résurrection de la fille de Jaïrus ",
+            "5:22-43"
+          ]
+        },
+        {
+          "type": "paragraph",
+          "subtype": "usfm:tr",
+          "content": [
+            "9. la guérison de la femme malade depuis douze ans ",
+            "5:25-34"
+          ]
+        },
+        {
+          "type": "paragraph",
+          "subtype": "usfm:tr",
+          "content": [
+            "10. la multiplication des pains (1",
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["re"]
+              "content": [
+                "re"
+              ]
             },
             " fois) ",
             "6:35-44"
           ]
-        }, {
-          "type": "paragraph",
-          "subtype": "usfm:tr",
-          "content": ["11. la marche sur les eaux ", "6:45-52"]
-        }, {
-          "type": "paragraph",
-          "subtype": "usfm:tr",
-          "content": ["12. la guérison de la fille de la Syro-Phénicienne ", "7:24-30"]
-        }, {
-          "type": "paragraph",
-          "subtype": "usfm:tr",
-          "content": ["13. la guérison d’un sourd-muet ", "7:31-37"]
-        }, {
+        },
+        {
           "type": "paragraph",
           "subtype": "usfm:tr",
           "content": [
-            "14. la 2", {
+            "11. la marche sur les eaux ",
+            "6:45-52"
+          ]
+        },
+        {
+          "type": "paragraph",
+          "subtype": "usfm:tr",
+          "content": [
+            "12. la guérison de la fille de la Syro-Phénicienne ",
+            "7:24-30"
+          ]
+        },
+        {
+          "type": "paragraph",
+          "subtype": "usfm:tr",
+          "content": [
+            "13. la guérison d’un sourd-muet ",
+            "7:31-37"
+          ]
+        },
+        {
+          "type": "paragraph",
+          "subtype": "usfm:tr",
+          "content": [
+            "14. la 2",
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["e"]
+              "content": [
+                "e"
+              ]
             },
             " multiplication des pains ",
             "8:1-9"
           ]
-        }, {
+        },
+        {
           "type": "paragraph",
           "subtype": "usfm:tr",
-          "content": ["15. la guérison d’un aveugle ", "8:22-26"]
-        }, {
+          "content": [
+            "15. la guérison d’un aveugle ",
+            "8:22-26"
+          ]
+        },
+        {
           "type": "paragraph",
           "subtype": "usfm:tr",
-          "content": ["16. la guérison d’un démoniaque ", "9:14-29"]
-        }, {
+          "content": [
+            "16. la guérison d’un démoniaque ",
+            "9:14-29"
+          ]
+        },
+        {
           "type": "paragraph",
           "subtype": "usfm:tr",
-          "content": ["17. la guérison d’un aveugle ", "10:46-52"]
-        }, {
+          "content": [
+            "17. la guérison d’un aveugle ",
+            "10:46-52"
+          ]
+        },
+        {
           "type": "paragraph",
           "subtype": "usfm:tr",
-          "content": ["18. le figuier desséché ", "11:12-24"]
-        }, {
+          "content": [
+            "18. le figuier desséché ",
+            "11:12-24"
+          ]
+        },
+        {
           "type": "graft",
           "subtype": "heading",
           "target": "MWFmNjJmNTQt"
-        }, {
+        },
+        {
           "type": "paragraph",
           "subtype": "usfm:tr",
-          "content": ["1. le semeur ", "4:1-30"]
-        }, {
+          "content": [
+            "1. le semeur ",
+            "4:1-30"
+          ]
+        },
+        {
           "type": "paragraph",
           "subtype": "usfm:tr",
-          "content": ["2. la croissance secrète de la semence ", "4:26-29"]
-        }, {
+          "content": [
+            "2. la croissance secrète de la semence ",
+            "4:26-29"
+          ]
+        },
+        {
           "type": "paragraph",
           "subtype": "usfm:tr",
-          "content": ["3. le grain de sénevé ", "4:30-32"]
-        }, {
+          "content": [
+            "3. le grain de sénevé ",
+            "4:30-32"
+          ]
+        },
+        {
           "type": "paragraph",
           "subtype": "usfm:tr",
-          "content": ["4. les vignerons ", "12:1-9"]
-        }, {
+          "content": [
+            "4. les vignerons ",
+            "12:1-9"
+          ]
+        },
+        {
           "type": "paragraph",
           "subtype": "usfm:tr",
-          "content": ["5. le figuier ", "13:28"]
-        }, {
+          "content": [
+            "5. le figuier ",
+            "13:28"
+          ]
+        },
+        {
           "type": "paragraph",
           "subtype": "usfm:tr",
-          "content": ["6. le maître et ses serviteurs ", "13:34-37"]
-        }, {
+          "content": [
+            "6. le maître et ses serviteurs ",
+            "13:34-37"
+          ]
+        },
+        {
           "type": "paragraph",
           "subtype": "usfm:ip",
-          "content": ["Marc a sélectionné les éléments de la tradition sur Jésus dans le but louable de démontrer ce que signifie «être disciple». Le mystérieux titre du «Fils de l’homme» que Jésus se donne (2:10; 8:29; 14:61, etc.) n’aura pas permis à ses contemporains de reconnaître sa véritable identité. Bien qu’ayant vu en lui le Christ/Messie (8:27-33), ils ne savaient de quel genre de Messie il s’agissait. Alors comment être disciple de Jésus?"]
-        }, {
+          "content": [
+            "Marc a sélectionné les éléments de la tradition sur Jésus dans le but louable de démontrer ce que signifie «être disciple». Le mystérieux titre du «Fils de l’homme» que Jésus se donne (2:10; 8:29; 14:61, etc.) n’aura pas permis à ses contemporains de reconnaître sa véritable identité. Bien qu’ayant vu en lui le Christ/Messie (8:27-33), ils ne savaient de quel genre de Messie il s’agissait. Alors comment être disciple de Jésus?"
+          ]
+        },
+        {
           "type": "paragraph",
           "subtype": "usfm:ip",
           "content": [
             {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["«Si quelqu’un veut venir après moi, qu’il renonce à lui-même, qu’il se charge de sa croix, et qu’il me suive. Car celui qui voudra sauver sa vie la perdra, mais celui qui perdra sa vie à cause de moi et de la Bonne Nouvelle la sauvera» (8:34-35)."]
+              "content": [
+                "«Si quelqu’un veut venir après moi, qu’il renonce à lui-même, qu’il se charge de sa croix, et qu’il me suive. Car celui qui voudra sauver sa vie la perdra, mais celui qui perdra sa vie à cause de moi et de la Bonne Nouvelle la sauvera» (8:34-35)."
+              ]
             }
           ]
         }
@@ -10285,11 +11998,16 @@
         {
           "type": "paragraph",
           "subtype": "usfm:imt",
-          "content": ["INTRODUCTION À L’ÉVANGILE SELON MARC"]
-        }, {
+          "content": [
+            "INTRODUCTION À L’ÉVANGILE SELON MARC"
+          ]
+        },
+        {
           "type": "paragraph",
           "subtype": "usfm:imt3",
-          "content": ["(És 42:1. Ac 10:38. Ph 2:7.)"]
+          "content": [
+            "(És 42:1. Ac 10:38. Ph 2:7.)"
+          ]
         }
       ]
     },
@@ -10299,7 +12017,9 @@
         {
           "type": "paragraph",
           "subtype": "usfm:mt",
-          "content": ["ÉVANGILE SELON MARC"]
+          "content": [
+            "ÉVANGILE SELON MARC"
+          ]
         }
       ]
     },
@@ -10309,7 +12029,9 @@
         {
           "type": "paragraph",
           "subtype": "usfm:s",
-          "content": ["Prédication de Jean-Baptiste"]
+          "content": [
+            "Prédication de Jean-Baptiste"
+          ]
         }
       ]
     },
@@ -10319,7 +12041,9 @@
         {
           "type": "paragraph",
           "subtype": "usfm:r",
-          "content": ["V. 1-8: cf. Mt 3:1-12. Lu 3:1-18."]
+          "content": [
+            "V. 1-8: cf. Mt 3:1-12. Lu 3:1-18."
+          ]
         }
       ]
     },
@@ -10329,7 +12053,9 @@
         {
           "type": "paragraph",
           "subtype": "usfm:s",
-          "content": ["Baptême et tentation de Jésus-Christ"]
+          "content": [
+            "Baptême et tentation de Jésus-Christ"
+          ]
         }
       ]
     },
@@ -10339,7 +12065,9 @@
         {
           "type": "paragraph",
           "subtype": "usfm:r",
-          "content": ["V. 9-13: cf. (Mt 3:13-17; 4:1-11. Lu 3:21-23; 4:1-13.)"]
+          "content": [
+            "V. 9-13: cf. (Mt 3:13-17; 4:1-11. Lu 3:21-23; 4:1-13.)"
+          ]
         }
       ]
     },
@@ -10349,7 +12077,9 @@
         {
           "type": "paragraph",
           "subtype": "usfm:s",
-          "content": ["Commencement du ministère de Jésus-Christ"]
+          "content": [
+            "Commencement du ministère de Jésus-Christ"
+          ]
         }
       ]
     },
@@ -10359,7 +12089,9 @@
         {
           "type": "paragraph",
           "subtype": "usfm:r",
-          "content": ["V. 14-15: cf. (Mt 4:12-17. Lu 4:14, 15.)"]
+          "content": [
+            "V. 14-15: cf. (Mt 4:12-17. Lu 4:14, 15.)"
+          ]
         }
       ]
     },
@@ -10369,7 +12101,9 @@
         {
           "type": "paragraph",
           "subtype": "usfm:s",
-          "content": ["Vocation de quatre disciples"]
+          "content": [
+            "Vocation de quatre disciples"
+          ]
         }
       ]
     },
@@ -10379,7 +12113,9 @@
         {
           "type": "paragraph",
           "subtype": "usfm:r",
-          "content": ["V. 16-20: cf. (Mt 4:18-22. Lu 5:1-11.) Jn 1:35-43."]
+          "content": [
+            "V. 16-20: cf. (Mt 4:18-22. Lu 5:1-11.) Jn 1:35-43."
+          ]
         }
       ]
     },
@@ -10389,7 +12125,9 @@
         {
           "type": "paragraph",
           "subtype": "usfm:s",
-          "content": ["Jésus à Capernaüm. Enseignement dans la synagogue. Guérison d’un démoniaque"]
+          "content": [
+            "Jésus à Capernaüm. Enseignement dans la synagogue. Guérison d’un démoniaque"
+          ]
         }
       ]
     },
@@ -10399,7 +12137,9 @@
         {
           "type": "paragraph",
           "subtype": "usfm:r",
-          "content": ["V. 21-28: cf. Lu 4:31-37. (Mc 5:1-17. Ac 10:38.)"]
+          "content": [
+            "V. 21-28: cf. Lu 4:31-37. (Mc 5:1-17. Ac 10:38.)"
+          ]
         }
       ]
     },
@@ -10409,7 +12149,9 @@
         {
           "type": "paragraph",
           "subtype": "usfm:s",
-          "content": ["Guérison de la belle-mère de Pierre et de plusieurs malades. — Jésus en divers lieux de la Galilée"]
+          "content": [
+            "Guérison de la belle-mère de Pierre et de plusieurs malades. — Jésus en divers lieux de la Galilée"
+          ]
         }
       ]
     },
@@ -10419,7 +12161,9 @@
         {
           "type": "paragraph",
           "subtype": "usfm:r",
-          "content": ["V. 29-31: cf. (Mt 8:14, 15. Lu 4:38, 39.)"]
+          "content": [
+            "V. 29-31: cf. (Mt 8:14, 15. Lu 4:38, 39.)"
+          ]
         }
       ]
     },
@@ -10429,7 +12173,9 @@
         {
           "type": "paragraph",
           "subtype": "usfm:r",
-          "content": ["V. 32-39: cf. (Mt 8:16, 17; 4:23-25. Lu 4:40-44.)"]
+          "content": [
+            "V. 32-39: cf. (Mt 8:16, 17; 4:23-25. Lu 4:40-44.)"
+          ]
         }
       ]
     },
@@ -10439,7 +12185,9 @@
         {
           "type": "paragraph",
           "subtype": "usfm:s",
-          "content": ["Guérison d’un lépreux"]
+          "content": [
+            "Guérison d’un lépreux"
+          ]
         }
       ]
     },
@@ -10449,7 +12197,9 @@
         {
           "type": "paragraph",
           "subtype": "usfm:r",
-          "content": ["V. 40-45: cf. (Mt 8:2-4. Lu 5:12-16.) Lu 17:12-19."]
+          "content": [
+            "V. 40-45: cf. (Mt 8:2-4. Lu 5:12-16.) Lu 17:12-19."
+          ]
         }
       ]
     },
@@ -10459,7 +12209,9 @@
         {
           "type": "paragraph",
           "subtype": "usfm:s",
-          "content": ["Jésus de retour à Capernaüm. Guérison d’un paralytique"]
+          "content": [
+            "Jésus de retour à Capernaüm. Guérison d’un paralytique"
+          ]
         }
       ]
     },
@@ -10469,7 +12221,9 @@
         {
           "type": "paragraph",
           "subtype": "usfm:r",
-          "content": ["V. 1-12: cf. (Mt 9:1-8. Lu 5:17-26.) Jn 10:36-38."]
+          "content": [
+            "V. 1-12: cf. (Mt 9:1-8. Lu 5:17-26.) Jn 10:36-38."
+          ]
         }
       ]
     },
@@ -10479,7 +12233,9 @@
         {
           "type": "paragraph",
           "subtype": "usfm:s",
-          "content": ["Vocation de Lévi (Matthieu)"]
+          "content": [
+            "Vocation de Lévi (Matthieu)"
+          ]
         }
       ]
     },
@@ -10489,7 +12245,9 @@
         {
           "type": "paragraph",
           "subtype": "usfm:r",
-          "content": ["V. 13-14: cf. (Mt 9:9. Lu 5:27, 28.) Mt 4:18-22."]
+          "content": [
+            "V. 13-14: cf. (Mt 9:9. Lu 5:27, 28.) Mt 4:18-22."
+          ]
         }
       ]
     },
@@ -10499,7 +12257,9 @@
         {
           "type": "paragraph",
           "subtype": "usfm:r",
-          "content": ["V. 15-17: cf. (Mt 9:10-13. Lu 5:29-32.) Lu 15:1-10. Ps 25:8, 9."]
+          "content": [
+            "V. 15-17: cf. (Mt 9:10-13. Lu 5:29-32.) Lu 15:1-10. Ps 25:8, 9."
+          ]
         }
       ]
     },
@@ -10509,7 +12269,9 @@
         {
           "type": "paragraph",
           "subtype": "usfm:s",
-          "content": ["Question des disciples de Jean-Baptiste sur le jeûne"]
+          "content": [
+            "Question des disciples de Jean-Baptiste sur le jeûne"
+          ]
         }
       ]
     },
@@ -10519,7 +12281,9 @@
         {
           "type": "paragraph",
           "subtype": "usfm:r",
-          "content": ["V. 18-22: cf. (Mt 9:14-17. Lu 5:33-39.)"]
+          "content": [
+            "V. 18-22: cf. (Mt 9:14-17. Lu 5:33-39.)"
+          ]
         }
       ]
     },
@@ -10529,7 +12293,9 @@
         {
           "type": "paragraph",
           "subtype": "usfm:s",
-          "content": ["Les épis de blé et le sabbat"]
+          "content": [
+            "Les épis de blé et le sabbat"
+          ]
         }
       ]
     },
@@ -10539,7 +12305,9 @@
         {
           "type": "paragraph",
           "subtype": "usfm:r",
-          "content": ["V. 23-28: cf. (Mt 12:1-8. Lu 6:1-5.)"]
+          "content": [
+            "V. 23-28: cf. (Mt 12:1-8. Lu 6:1-5.)"
+          ]
         }
       ]
     },
@@ -10549,7 +12317,9 @@
         {
           "type": "paragraph",
           "subtype": "usfm:s",
-          "content": ["L’homme à la main sèche"]
+          "content": [
+            "L’homme à la main sèche"
+          ]
         }
       ]
     },
@@ -10559,7 +12329,9 @@
         {
           "type": "paragraph",
           "subtype": "usfm:r",
-          "content": ["V. 1-6: cf. (Mt 12:9-14. Lu 6:6-11.)"]
+          "content": [
+            "V. 1-6: cf. (Mt 12:9-14. Lu 6:6-11.)"
+          ]
         }
       ]
     },
@@ -10569,7 +12341,9 @@
         {
           "type": "paragraph",
           "subtype": "usfm:r",
-          "content": ["V. 7-12: cf. Mt 12:15-21. És 42:1-4."]
+          "content": [
+            "V. 7-12: cf. Mt 12:15-21. És 42:1-4."
+          ]
         }
       ]
     },
@@ -10579,7 +12353,9 @@
         {
           "type": "paragraph",
           "subtype": "usfm:s",
-          "content": ["Choix des douze apôtres"]
+          "content": [
+            "Choix des douze apôtres"
+          ]
         }
       ]
     },
@@ -10589,7 +12365,9 @@
         {
           "type": "paragraph",
           "subtype": "usfm:r",
-          "content": ["V. 13-19: cf. Lu 6:12-19. (Mt 10:1-15. Ac 1:13.)"]
+          "content": [
+            "V. 13-19: cf. Lu 6:12-19. (Mt 10:1-15. Ac 1:13.)"
+          ]
         }
       ]
     },
@@ -10599,7 +12377,9 @@
         {
           "type": "paragraph",
           "subtype": "usfm:s",
-          "content": ["Attaque des scribes et réponse de Jésus. Le péché contre le Saint-Esprit"]
+          "content": [
+            "Attaque des scribes et réponse de Jésus. Le péché contre le Saint-Esprit"
+          ]
         }
       ]
     },
@@ -10609,7 +12389,9 @@
         {
           "type": "paragraph",
           "subtype": "usfm:r",
-          "content": ["V. 20-30: cf. (Mt 12:22-37. Lu 11:14-23.)"]
+          "content": [
+            "V. 20-30: cf. (Mt 12:22-37. Lu 11:14-23.)"
+          ]
         }
       ]
     },
@@ -10619,7 +12401,9 @@
         {
           "type": "paragraph",
           "subtype": "usfm:s",
-          "content": ["La mère et les frères de Jésus"]
+          "content": [
+            "La mère et les frères de Jésus"
+          ]
         }
       ]
     },
@@ -10629,7 +12413,9 @@
         {
           "type": "paragraph",
           "subtype": "usfm:r",
-          "content": ["V. 31-35: cf. (Mt 12:46-50. Lu 8:19-21.)"]
+          "content": [
+            "V. 31-35: cf. (Mt 12:46-50. Lu 8:19-21.)"
+          ]
         }
       ]
     },
@@ -10639,7 +12425,9 @@
         {
           "type": "paragraph",
           "subtype": "usfm:s",
-          "content": ["Paraboles du semeur, de la semence, du grain de sénevé"]
+          "content": [
+            "Paraboles du semeur, de la semence, du grain de sénevé"
+          ]
         }
       ]
     },
@@ -10649,7 +12437,9 @@
         {
           "type": "paragraph",
           "subtype": "usfm:r",
-          "content": ["V. 1-20: cf. (Mt 13:1-23. Lu 8:1-15.)"]
+          "content": [
+            "V. 1-20: cf. (Mt 13:1-23. Lu 8:1-15.)"
+          ]
         }
       ]
     },
@@ -10659,7 +12449,9 @@
         {
           "type": "paragraph",
           "subtype": "usfm:r",
-          "content": ["V. 21-25: cf. Lu 8:16-18."]
+          "content": [
+            "V. 21-25: cf. Lu 8:16-18."
+          ]
         }
       ]
     },
@@ -10669,7 +12461,9 @@
         {
           "type": "paragraph",
           "subtype": "usfm:r",
-          "content": ["V. 26-29: cf. És 55:10, 11. 1 Co 3:6, 7. Ph 1:6."]
+          "content": [
+            "V. 26-29: cf. És 55:10, 11. 1 Co 3:6, 7. Ph 1:6."
+          ]
         }
       ]
     },
@@ -10679,7 +12473,9 @@
         {
           "type": "paragraph",
           "subtype": "usfm:r",
-          "content": ["V. 30-34: cf. (Mt 13:31-35. Lu 13:18, 19.) Da 2:34, 35."]
+          "content": [
+            "V. 30-34: cf. (Mt 13:31-35. Lu 13:18, 19.) Da 2:34, 35."
+          ]
         }
       ]
     },
@@ -10689,7 +12485,9 @@
         {
           "type": "paragraph",
           "subtype": "usfm:s",
-          "content": ["La tempête apaisée"]
+          "content": [
+            "La tempête apaisée"
+          ]
         }
       ]
     },
@@ -10699,7 +12497,9 @@
         {
           "type": "paragraph",
           "subtype": "usfm:r",
-          "content": ["V. 35-41: cf. (Mt 8:18-27. Lu 8:22-25.)"]
+          "content": [
+            "V. 35-41: cf. (Mt 8:18-27. Lu 8:22-25.)"
+          ]
         }
       ]
     },
@@ -10709,7 +12509,9 @@
         {
           "type": "paragraph",
           "subtype": "usfm:s",
-          "content": ["Jésus sur le territoire des Gadaréniens. Guérison d’un démoniaque"]
+          "content": [
+            "Jésus sur le territoire des Gadaréniens. Guérison d’un démoniaque"
+          ]
         }
       ]
     },
@@ -10719,7 +12521,9 @@
         {
           "type": "paragraph",
           "subtype": "usfm:r",
-          "content": ["V. 1-20: cf. (Mt 8:28-34. Lu 8:26-39.) Mc 1:23-28. Ps 106:11. És 49:24, 25."]
+          "content": [
+            "V. 1-20: cf. (Mt 8:28-34. Lu 8:26-39.) Mc 1:23-28. Ps 106:11. És 49:24, 25."
+          ]
         }
       ]
     },
@@ -10729,7 +12533,9 @@
         {
           "type": "paragraph",
           "subtype": "usfm:s",
-          "content": ["Résurrection de la fille de Jaïrus, et guérison d’une femme malade depuis douze ans"]
+          "content": [
+            "Résurrection de la fille de Jaïrus, et guérison d’une femme malade depuis douze ans"
+          ]
         }
       ]
     },
@@ -10739,7 +12545,9 @@
         {
           "type": "paragraph",
           "subtype": "usfm:r",
-          "content": ["V. 21-43: cf. (Mt 9:18-26. Lu 8:40-56.)"]
+          "content": [
+            "V. 21-43: cf. (Mt 9:18-26. Lu 8:40-56.)"
+          ]
         }
       ]
     },
@@ -10749,7 +12557,9 @@
         {
           "type": "paragraph",
           "subtype": "usfm:s",
-          "content": ["Jésus à Nazareth. Incrédulité des habitants"]
+          "content": [
+            "Jésus à Nazareth. Incrédulité des habitants"
+          ]
         }
       ]
     },
@@ -10759,7 +12569,9 @@
         {
           "type": "paragraph",
           "subtype": "usfm:r",
-          "content": ["V. 1-6: cf. (Mt 13:54-58.) Lu 4:16-30. Ro 10:21."]
+          "content": [
+            "V. 1-6: cf. (Mt 13:54-58.) Lu 4:16-30. Ro 10:21."
+          ]
         }
       ]
     },
@@ -10769,7 +12581,9 @@
         {
           "type": "paragraph",
           "subtype": "usfm:s",
-          "content": ["Mission des douze apôtres"]
+          "content": [
+            "Mission des douze apôtres"
+          ]
         }
       ]
     },
@@ -10779,7 +12593,9 @@
         {
           "type": "paragraph",
           "subtype": "usfm:r",
-          "content": ["V. 7-13: cf. (Mt 10; 11:1. Lu 9:1-6.) Lu 10:1-20."]
+          "content": [
+            "V. 7-13: cf. (Mt 10; 11:1. Lu 9:1-6.) Lu 10:1-20."
+          ]
         }
       ]
     },
@@ -10789,7 +12605,9 @@
         {
           "type": "paragraph",
           "subtype": "usfm:s",
-          "content": ["Mort de Jean-Baptiste"]
+          "content": [
+            "Mort de Jean-Baptiste"
+          ]
         }
       ]
     },
@@ -10799,7 +12617,9 @@
         {
           "type": "paragraph",
           "subtype": "usfm:r",
-          "content": ["V. 14-29: cf. (Mt 14:1-12.) Lu 9:7-9; 3:19, 20."]
+          "content": [
+            "V. 14-29: cf. (Mt 14:1-12.) Lu 9:7-9; 3:19, 20."
+          ]
         }
       ]
     },
@@ -10809,7 +12629,9 @@
         {
           "type": "paragraph",
           "subtype": "usfm:s",
-          "content": ["Multiplication des pains"]
+          "content": [
+            "Multiplication des pains"
+          ]
         }
       ]
     },
@@ -10819,7 +12641,9 @@
         {
           "type": "paragraph",
           "subtype": "usfm:r",
-          "content": ["V. 30-44: cf. (Mt 14:13-21. Lu 9:10-17. Jn 6:1-14.) Mc 8:1-9."]
+          "content": [
+            "V. 30-44: cf. (Mt 14:13-21. Lu 9:10-17. Jn 6:1-14.) Mc 8:1-9."
+          ]
         }
       ]
     },
@@ -10829,7 +12653,9 @@
         {
           "type": "paragraph",
           "subtype": "usfm:s",
-          "content": ["Jésus marche sur les eaux"]
+          "content": [
+            "Jésus marche sur les eaux"
+          ]
         }
       ]
     },
@@ -10839,7 +12665,9 @@
         {
           "type": "paragraph",
           "subtype": "usfm:r",
-          "content": ["V. 45-52: cf. (Mt 14:22-33. Jn 6:15-21.)"]
+          "content": [
+            "V. 45-52: cf. (Mt 14:22-33. Jn 6:15-21.)"
+          ]
         }
       ]
     },
@@ -10849,7 +12677,9 @@
         {
           "type": "paragraph",
           "subtype": "usfm:s",
-          "content": ["Guérisons à Génésareth"]
+          "content": [
+            "Guérisons à Génésareth"
+          ]
         }
       ]
     },
@@ -10859,7 +12689,9 @@
         {
           "type": "paragraph",
           "subtype": "usfm:r",
-          "content": ["V. 53-56: cf. Mt 14:34-36. Jn 6:22, etc."]
+          "content": [
+            "V. 53-56: cf. Mt 14:34-36. Jn 6:22, etc."
+          ]
         }
       ]
     },
@@ -10869,7 +12701,9 @@
         {
           "type": "paragraph",
           "subtype": "usfm:s",
-          "content": ["Les pharisiens et la tradition"]
+          "content": [
+            "Les pharisiens et la tradition"
+          ]
         }
       ]
     },
@@ -10879,7 +12713,9 @@
         {
           "type": "paragraph",
           "subtype": "usfm:r",
-          "content": ["V. 1-13: cf. (Mt 15:1-9.) Lu 11:37-41."]
+          "content": [
+            "V. 1-13: cf. (Mt 15:1-9.) Lu 11:37-41."
+          ]
         }
       ]
     },
@@ -10889,7 +12725,9 @@
         {
           "type": "paragraph",
           "subtype": "usfm:r",
-          "content": ["V. 14-23: cf. Mt 15:10-20. (Ga 5:19-21. Jé 4:14. Ps 51:12.)"]
+          "content": [
+            "V. 14-23: cf. Mt 15:10-20. (Ga 5:19-21. Jé 4:14. Ps 51:12.)"
+          ]
         }
       ]
     },
@@ -10899,7 +12737,9 @@
         {
           "type": "paragraph",
           "subtype": "usfm:s",
-          "content": ["Jésus sur le territoire de Tyr et de Sidon. La femme cananéenne"]
+          "content": [
+            "Jésus sur le territoire de Tyr et de Sidon. La femme cananéenne"
+          ]
         }
       ]
     },
@@ -10909,7 +12749,9 @@
         {
           "type": "paragraph",
           "subtype": "usfm:r",
-          "content": ["V. 24-30: cf. Mt 15:21-28. (Ge 32:24-29.)"]
+          "content": [
+            "V. 24-30: cf. Mt 15:21-28. (Ge 32:24-29.)"
+          ]
         }
       ]
     },
@@ -10919,7 +12761,9 @@
         {
           "type": "paragraph",
           "subtype": "usfm:s",
-          "content": ["Jésus de retour vers la mer de Galilée. Guérison d’un sourd-muet"]
+          "content": [
+            "Jésus de retour vers la mer de Galilée. Guérison d’un sourd-muet"
+          ]
         }
       ]
     },
@@ -10929,7 +12773,9 @@
         {
           "type": "paragraph",
           "subtype": "usfm:r",
-          "content": ["V. 31-37: cf. Mt 15:29-31. És 35:4-6."]
+          "content": [
+            "V. 31-37: cf. Mt 15:29-31. És 35:4-6."
+          ]
         }
       ]
     },
@@ -10939,7 +12785,9 @@
         {
           "type": "paragraph",
           "subtype": "usfm:s",
-          "content": ["Seconde multiplication des pains"]
+          "content": [
+            "Seconde multiplication des pains"
+          ]
         }
       ]
     },
@@ -10949,7 +12797,9 @@
         {
           "type": "paragraph",
           "subtype": "usfm:r",
-          "content": ["V. 1-9: cf. Mt 15:32-39. (Mc 6:35-44. 2 R 4:42-44.) Ps 146:7."]
+          "content": [
+            "V. 1-9: cf. Mt 15:32-39. (Mc 6:35-44. 2 R 4:42-44.) Ps 146:7."
+          ]
         }
       ]
     },
@@ -10959,7 +12809,9 @@
         {
           "type": "paragraph",
           "subtype": "usfm:s",
-          "content": ["Un signe du ciel demandé par les pharisiens. Le levain des pharisiens"]
+          "content": [
+            "Un signe du ciel demandé par les pharisiens. Le levain des pharisiens"
+          ]
         }
       ]
     },
@@ -10969,7 +12821,9 @@
         {
           "type": "paragraph",
           "subtype": "usfm:r",
-          "content": ["V. 10-21: cf. Mt 15:39; 16:1-12."]
+          "content": [
+            "V. 10-21: cf. Mt 15:39; 16:1-12."
+          ]
         }
       ]
     },
@@ -10979,7 +12833,9 @@
         {
           "type": "paragraph",
           "subtype": "usfm:s",
-          "content": ["Guérison d’un aveugle à Bethsaïda"]
+          "content": [
+            "Guérison d’un aveugle à Bethsaïda"
+          ]
         }
       ]
     },
@@ -10989,7 +12845,9 @@
         {
           "type": "paragraph",
           "subtype": "usfm:r",
-          "content": ["V. 22-26: cf. Mc 10:46-53. Jn 9:1-11."]
+          "content": [
+            "V. 22-26: cf. Mc 10:46-53. Jn 9:1-11."
+          ]
         }
       ]
     },
@@ -10999,7 +12857,9 @@
         {
           "type": "paragraph",
           "subtype": "usfm:s",
-          "content": ["Jésus sur le territoire de Césarée de Philippe. Opinions diverses sur le Christ. Confession de Pierre"]
+          "content": [
+            "Jésus sur le territoire de Césarée de Philippe. Opinions diverses sur le Christ. Confession de Pierre"
+          ]
         }
       ]
     },
@@ -11009,7 +12869,9 @@
         {
           "type": "paragraph",
           "subtype": "usfm:r",
-          "content": ["V. 27-30: cf. (Mt 16:13-20. Lu 9:18-21.)"]
+          "content": [
+            "V. 27-30: cf. (Mt 16:13-20. Lu 9:18-21.)"
+          ]
         }
       ]
     },
@@ -11019,7 +12881,9 @@
         {
           "type": "paragraph",
           "subtype": "usfm:s",
-          "content": ["Jésus annonce ses souffrances et sa mort. Comment suivre Jésus"]
+          "content": [
+            "Jésus annonce ses souffrances et sa mort. Comment suivre Jésus"
+          ]
         }
       ]
     },
@@ -11029,7 +12893,9 @@
         {
           "type": "paragraph",
           "subtype": "usfm:r",
-          "content": ["8 v. 31 à 9 v. 1: cf. (Mt 16:21-28. Lu 9:22-27.)"]
+          "content": [
+            "8 v. 31 à 9 v. 1: cf. (Mt 16:21-28. Lu 9:22-27.)"
+          ]
         }
       ]
     },
@@ -11039,7 +12905,9 @@
         {
           "type": "paragraph",
           "subtype": "usfm:s",
-          "content": ["Jésus sur une haute montagne. La transfiguration"]
+          "content": [
+            "Jésus sur une haute montagne. La transfiguration"
+          ]
         }
       ]
     },
@@ -11049,7 +12917,9 @@
         {
           "type": "paragraph",
           "subtype": "usfm:r",
-          "content": ["V. 2-13: cf. (Mt 17:1-13. Lu 9:28-36.) 2 Pi 1:16-18."]
+          "content": [
+            "V. 2-13: cf. (Mt 17:1-13. Lu 9:28-36.) 2 Pi 1:16-18."
+          ]
         }
       ]
     },
@@ -11059,7 +12929,9 @@
         {
           "type": "paragraph",
           "subtype": "usfm:s",
-          "content": ["Guérison d’un démoniaque"]
+          "content": [
+            "Guérison d’un démoniaque"
+          ]
         }
       ]
     },
@@ -11069,7 +12941,9 @@
         {
           "type": "paragraph",
           "subtype": "usfm:r",
-          "content": ["V. 14-29: cf. (Mt 17:14-21. Lu 9:37-43.)"]
+          "content": [
+            "V. 14-29: cf. (Mt 17:14-21. Lu 9:37-43.)"
+          ]
         }
       ]
     },
@@ -11079,7 +12953,9 @@
         {
           "type": "paragraph",
           "subtype": "usfm:s",
-          "content": ["Jésus annonce sa mort et sa résurrection"]
+          "content": [
+            "Jésus annonce sa mort et sa résurrection"
+          ]
         }
       ]
     },
@@ -11089,7 +12965,9 @@
         {
           "type": "paragraph",
           "subtype": "usfm:r",
-          "content": ["V. 30-32: cf. (Mt 17:22, 23. Lu 9:43-46.) Mc 8:31-33."]
+          "content": [
+            "V. 30-32: cf. (Mt 17:22, 23. Lu 9:43-46.) Mc 8:31-33."
+          ]
         }
       ]
     },
@@ -11099,7 +12977,9 @@
         {
           "type": "paragraph",
           "subtype": "usfm:s",
-          "content": ["Jésus de retour à Capernaüm. Qui est le plus grand?"]
+          "content": [
+            "Jésus de retour à Capernaüm. Qui est le plus grand?"
+          ]
         }
       ]
     },
@@ -11109,7 +12989,9 @@
         {
           "type": "paragraph",
           "subtype": "usfm:r",
-          "content": ["V. 33-37: cf. (Mt 18:1-5. Lu 9:46-48.) Mc 10:35-45. Ph 2:5-11."]
+          "content": [
+            "V. 33-37: cf. (Mt 18:1-5. Lu 9:46-48.) Mc 10:35-45. Ph 2:5-11."
+          ]
         }
       ]
     },
@@ -11119,7 +13001,9 @@
         {
           "type": "paragraph",
           "subtype": "usfm:s",
-          "content": ["Les scandales"]
+          "content": [
+            "Les scandales"
+          ]
         }
       ]
     },
@@ -11129,7 +13013,9 @@
         {
           "type": "paragraph",
           "subtype": "usfm:r",
-          "content": ["V. 38-51: cf. (Mt 18:5-9. Lu 9:49, 50.) 1 Co 8:9-13; 9:24-27."]
+          "content": [
+            "V. 38-51: cf. (Mt 18:5-9. Lu 9:49, 50.) 1 Co 8:9-13; 9:24-27."
+          ]
         }
       ]
     },
@@ -11139,7 +13025,9 @@
         {
           "type": "paragraph",
           "subtype": "usfm:s",
-          "content": ["Jésus en Pérée. Le divorce"]
+          "content": [
+            "Jésus en Pérée. Le divorce"
+          ]
         }
       ]
     },
@@ -11149,7 +13037,9 @@
         {
           "type": "paragraph",
           "subtype": "usfm:r",
-          "content": ["V. 1-12: cf. Mt 19:1-12. (De 24:1-4. Mt 5:31, 32.)"]
+          "content": [
+            "V. 1-12: cf. Mt 19:1-12. (De 24:1-4. Mt 5:31, 32.)"
+          ]
         }
       ]
     },
@@ -11159,7 +13049,9 @@
         {
           "type": "paragraph",
           "subtype": "usfm:s",
-          "content": ["Les petits enfants"]
+          "content": [
+            "Les petits enfants"
+          ]
         }
       ]
     },
@@ -11169,7 +13061,9 @@
         {
           "type": "paragraph",
           "subtype": "usfm:r",
-          "content": ["V. 13-16: cf. (Mt 19:13-15. Lu 18:15-17.)"]
+          "content": [
+            "V. 13-16: cf. (Mt 19:13-15. Lu 18:15-17.)"
+          ]
         }
       ]
     },
@@ -11179,7 +13073,9 @@
         {
           "type": "paragraph",
           "subtype": "usfm:s",
-          "content": ["Le jeune homme riche"]
+          "content": [
+            "Le jeune homme riche"
+          ]
         }
       ]
     },
@@ -11189,7 +13085,9 @@
         {
           "type": "paragraph",
           "subtype": "usfm:r",
-          "content": ["V. 17-27: cf. (Mt 19:16-26. Lu 18:18-27.) Mt 6:19-21, 24. Mc 9:43, etc. Ro 10:3."]
+          "content": [
+            "V. 17-27: cf. (Mt 19:16-26. Lu 18:18-27.) Mt 6:19-21, 24. Mc 9:43, etc. Ro 10:3."
+          ]
         }
       ]
     },
@@ -11199,7 +13097,9 @@
         {
           "type": "paragraph",
           "subtype": "usfm:s",
-          "content": ["L’héritage de la vie éternelle"]
+          "content": [
+            "L’héritage de la vie éternelle"
+          ]
         }
       ]
     },
@@ -11209,7 +13109,9 @@
         {
           "type": "paragraph",
           "subtype": "usfm:r",
-          "content": ["V. 28-31: cf. (Mt 19:27-30. Lu 18:28-30.)"]
+          "content": [
+            "V. 28-31: cf. (Mt 19:27-30. Lu 18:28-30.)"
+          ]
         }
       ]
     },
@@ -11219,7 +13121,9 @@
         {
           "type": "paragraph",
           "subtype": "usfm:s",
-          "content": ["Jésus annonce sa mort et sa résurrection"]
+          "content": [
+            "Jésus annonce sa mort et sa résurrection"
+          ]
         }
       ]
     },
@@ -11229,7 +13133,9 @@
         {
           "type": "paragraph",
           "subtype": "usfm:r",
-          "content": ["V. 32-34: cf. (Mt 20:17-19. Lu 18:31-34.) Mc 8:31-33."]
+          "content": [
+            "V. 32-34: cf. (Mt 20:17-19. Lu 18:31-34.) Mc 8:31-33."
+          ]
         }
       ]
     },
@@ -11239,7 +13145,9 @@
         {
           "type": "paragraph",
           "subtype": "usfm:s",
-          "content": ["Demande des fils de Zébédée"]
+          "content": [
+            "Demande des fils de Zébédée"
+          ]
         }
       ]
     },
@@ -11249,7 +13157,9 @@
         {
           "type": "paragraph",
           "subtype": "usfm:r",
-          "content": ["V. 35-45: cf. Mt 20:20-28. (Lu 22:24-27. Jn 13:3-17.)"]
+          "content": [
+            "V. 35-45: cf. Mt 20:20-28. (Lu 22:24-27. Jn 13:3-17.)"
+          ]
         }
       ]
     },
@@ -11259,7 +13169,9 @@
         {
           "type": "paragraph",
           "subtype": "usfm:s",
-          "content": ["L’aveugle Bartimée guéri à Jéricho"]
+          "content": [
+            "L’aveugle Bartimée guéri à Jéricho"
+          ]
         }
       ]
     },
@@ -11269,7 +13181,9 @@
         {
           "type": "paragraph",
           "subtype": "usfm:r",
-          "content": ["V. 46-53: cf. (Mt 20:29-34. Lu 18:35-43.) Ps 146:8."]
+          "content": [
+            "V. 46-53: cf. (Mt 20:29-34. Lu 18:35-43.) Ps 146:8."
+          ]
         }
       ]
     },
@@ -11279,7 +13193,9 @@
         {
           "type": "paragraph",
           "subtype": "usfm:s",
-          "content": ["Entrée de Jésus à Jérusalem"]
+          "content": [
+            "Entrée de Jésus à Jérusalem"
+          ]
         }
       ]
     },
@@ -11289,7 +13205,9 @@
         {
           "type": "paragraph",
           "subtype": "usfm:r",
-          "content": ["V. 1-11: cf. (Mt 21:1-11, 14-17. Lu 19:29-44. Jn 12:12-19.)"]
+          "content": [
+            "V. 1-11: cf. (Mt 21:1-11, 14-17. Lu 19:29-44. Jn 12:12-19.)"
+          ]
         }
       ]
     },
@@ -11299,7 +13217,9 @@
         {
           "type": "paragraph",
           "subtype": "usfm:s",
-          "content": ["Le figuier maudit. Les vendeurs chassés du temple. Irritation des sacrificateurs"]
+          "content": [
+            "Le figuier maudit. Les vendeurs chassés du temple. Irritation des sacrificateurs"
+          ]
         }
       ]
     },
@@ -11309,7 +13229,9 @@
         {
           "type": "paragraph",
           "subtype": "usfm:r",
-          "content": ["V. 12-19: cf. (Mt 21:18, 19, 12, 13. Lu 19:45-48.) Jn 2:13-17. Lu 13:6-9."]
+          "content": [
+            "V. 12-19: cf. (Mt 21:18, 19, 12, 13. Lu 19:45-48.) Jn 2:13-17. Lu 13:6-9."
+          ]
         }
       ]
     },
@@ -11319,7 +13241,9 @@
         {
           "type": "paragraph",
           "subtype": "usfm:s",
-          "content": ["La puissance de la foi"]
+          "content": [
+            "La puissance de la foi"
+          ]
         }
       ]
     },
@@ -11329,7 +13253,9 @@
         {
           "type": "paragraph",
           "subtype": "usfm:r",
-          "content": ["V. 20-26: cf. Mt 21:20-22. (Ja 5:16-18. Mt 18:19-22.)"]
+          "content": [
+            "V. 20-26: cf. Mt 21:20-22. (Ja 5:16-18. Mt 18:19-22.)"
+          ]
         }
       ]
     },
@@ -11339,7 +13265,9 @@
         {
           "type": "paragraph",
           "subtype": "usfm:s",
-          "content": ["L’autorité de Jésus"]
+          "content": [
+            "L’autorité de Jésus"
+          ]
         }
       ]
     },
@@ -11349,7 +13277,9 @@
         {
           "type": "paragraph",
           "subtype": "usfm:r",
-          "content": ["V. 27-33: cf. (Mt 21:23-27. Lu 20:1-8.) Jn 2:18-21."]
+          "content": [
+            "V. 27-33: cf. (Mt 21:23-27. Lu 20:1-8.) Jn 2:18-21."
+          ]
         }
       ]
     },
@@ -11359,7 +13289,9 @@
         {
           "type": "paragraph",
           "subtype": "usfm:s",
-          "content": ["Parabole des vignerons. La pierre de l’angle"]
+          "content": [
+            "Parabole des vignerons. La pierre de l’angle"
+          ]
         }
       ]
     },
@@ -11369,7 +13301,9 @@
         {
           "type": "paragraph",
           "subtype": "usfm:r",
-          "content": ["V. 1-12: cf. (Mt 21:33-46. Lu 20:9-19.) És 5:1-7."]
+          "content": [
+            "V. 1-12: cf. (Mt 21:33-46. Lu 20:9-19.) És 5:1-7."
+          ]
         }
       ]
     },
@@ -11379,7 +13313,9 @@
         {
           "type": "paragraph",
           "subtype": "usfm:s",
-          "content": ["Questions captieuses proposées à Jésus sur le tribut à César, la résurrection, le plus grand commandement"]
+          "content": [
+            "Questions captieuses proposées à Jésus sur le tribut à César, la résurrection, le plus grand commandement"
+          ]
         }
       ]
     },
@@ -11389,7 +13325,9 @@
         {
           "type": "paragraph",
           "subtype": "usfm:r",
-          "content": ["V. 13-17: cf. Mt 22:15-22. Lu 20:20-26."]
+          "content": [
+            "V. 13-17: cf. Mt 22:15-22. Lu 20:20-26."
+          ]
         }
       ]
     },
@@ -11399,7 +13337,9 @@
         {
           "type": "paragraph",
           "subtype": "usfm:r",
-          "content": ["V. 18-27: cf. (Mt 22:23-33. Lu 20:27-40.) 2 Ti 3:8, 9."]
+          "content": [
+            "V. 18-27: cf. (Mt 22:23-33. Lu 20:27-40.) 2 Ti 3:8, 9."
+          ]
         }
       ]
     },
@@ -11409,7 +13349,9 @@
         {
           "type": "paragraph",
           "subtype": "usfm:r",
-          "content": ["V. 28-34: cf. Mt 22:34-40. (Lu 10:25-37. Ro 13:8-10.)"]
+          "content": [
+            "V. 28-34: cf. Mt 22:34-40. (Lu 10:25-37. Ro 13:8-10.)"
+          ]
         }
       ]
     },
@@ -11419,7 +13361,9 @@
         {
           "type": "paragraph",
           "subtype": "usfm:s",
-          "content": ["De qui le Christ est-il fils?"]
+          "content": [
+            "De qui le Christ est-il fils?"
+          ]
         }
       ]
     },
@@ -11429,7 +13373,9 @@
         {
           "type": "paragraph",
           "subtype": "usfm:r",
-          "content": ["V. 35-37: cf. (Mt 22:41-45. Lu 20:41-44.)"]
+          "content": [
+            "V. 35-37: cf. (Mt 22:41-45. Lu 20:41-44.)"
+          ]
         }
       ]
     },
@@ -11439,7 +13385,9 @@
         {
           "type": "paragraph",
           "subtype": "usfm:s",
-          "content": ["Les scribes censurés par Jésus"]
+          "content": [
+            "Les scribes censurés par Jésus"
+          ]
         }
       ]
     },
@@ -11449,7 +13397,9 @@
         {
           "type": "paragraph",
           "subtype": "usfm:r",
-          "content": ["V. 38-40: cf. (Mt 23:1-14. Lu 20:45-47.)"]
+          "content": [
+            "V. 38-40: cf. (Mt 23:1-14. Lu 20:45-47.)"
+          ]
         }
       ]
     },
@@ -11459,7 +13409,9 @@
         {
           "type": "paragraph",
           "subtype": "usfm:s",
-          "content": ["La pauvre veuve"]
+          "content": [
+            "La pauvre veuve"
+          ]
         }
       ]
     },
@@ -11469,7 +13421,9 @@
         {
           "type": "paragraph",
           "subtype": "usfm:r",
-          "content": ["V. 41-44: cf. Lu 21:1-4. (2 Co 8:1-5, 12.) 2 S 24:24. Mc 14:9."]
+          "content": [
+            "V. 41-44: cf. Lu 21:1-4. (2 Co 8:1-5, 12.) 2 S 24:24. Mc 14:9."
+          ]
         }
       ]
     },
@@ -11479,7 +13433,9 @@
         {
           "type": "paragraph",
           "subtype": "usfm:s",
-          "content": ["La destruction de Jérusalem et l’avènement du Fils de l’homme"]
+          "content": [
+            "La destruction de Jérusalem et l’avènement du Fils de l’homme"
+          ]
         }
       ]
     },
@@ -11489,7 +13445,9 @@
         {
           "type": "paragraph",
           "subtype": "usfm:r",
-          "content": ["V. 1-13: cf. (Mt 24:1-14. Lu 21:5-19.) Mt 10:16-23."]
+          "content": [
+            "V. 1-13: cf. (Mt 24:1-14. Lu 21:5-19.) Mt 10:16-23."
+          ]
         }
       ]
     },
@@ -11499,7 +13457,9 @@
         {
           "type": "paragraph",
           "subtype": "usfm:s",
-          "content": ["Exhortation à la vigilance"]
+          "content": [
+            "Exhortation à la vigilance"
+          ]
         }
       ]
     },
@@ -11509,7 +13469,9 @@
         {
           "type": "paragraph",
           "subtype": "usfm:r",
-          "content": ["V. 14-37: cf. (Mt 24:15-51. Lu 21:20-36.) Lu 17:22-37."]
+          "content": [
+            "V. 14-37: cf. (Mt 24:15-51. Lu 21:20-36.) Lu 17:22-37."
+          ]
         }
       ]
     },
@@ -11519,7 +13481,9 @@
         {
           "type": "paragraph",
           "subtype": "usfm:s",
-          "content": ["Histoire de la passion. Complot contre Jésus"]
+          "content": [
+            "Histoire de la passion. Complot contre Jésus"
+          ]
         }
       ]
     },
@@ -11529,7 +13493,9 @@
         {
           "type": "paragraph",
           "subtype": "usfm:r",
-          "content": ["V. 1-2: cf. (Mt 26:1-5. Lu 22:1, 2.)"]
+          "content": [
+            "V. 1-2: cf. (Mt 26:1-5. Lu 22:1, 2.)"
+          ]
         }
       ]
     },
@@ -11539,7 +13505,9 @@
         {
           "type": "paragraph",
           "subtype": "usfm:s",
-          "content": ["Parfum répandu sur la tête de Jésus à Béthanie. Trahison de Judas"]
+          "content": [
+            "Parfum répandu sur la tête de Jésus à Béthanie. Trahison de Judas"
+          ]
         }
       ]
     },
@@ -11549,7 +13517,9 @@
         {
           "type": "paragraph",
           "subtype": "usfm:r",
-          "content": ["V. 3-11: cf. (Mt 26:6-16. Jn 12:1-8. Lu 22:3-6). Lu 7:36-50."]
+          "content": [
+            "V. 3-11: cf. (Mt 26:6-16. Jn 12:1-8. Lu 22:3-6). Lu 7:36-50."
+          ]
         }
       ]
     },
@@ -11559,7 +13529,9 @@
         {
           "type": "paragraph",
           "subtype": "usfm:s",
-          "content": ["Célébration de la Pâque et institution de la sainte cène"]
+          "content": [
+            "Célébration de la Pâque et institution de la sainte cène"
+          ]
         }
       ]
     },
@@ -11569,7 +13541,9 @@
         {
           "type": "paragraph",
           "subtype": "usfm:r",
-          "content": ["V. 12-21: cf. (Mt 26:17-25. Lu 22:7-18, 21-30.) Jn 13:1-30."]
+          "content": [
+            "V. 12-21: cf. (Mt 26:17-25. Lu 22:7-18, 21-30.) Jn 13:1-30."
+          ]
         }
       ]
     },
@@ -11579,7 +13553,9 @@
         {
           "type": "paragraph",
           "subtype": "usfm:r",
-          "content": ["V. 22-25: cf. (Mt 26:26-29. Lu 22:19, 20. 1 Co 11:23-25.) 1 Co 10:16, 17."]
+          "content": [
+            "V. 22-25: cf. (Mt 26:26-29. Lu 22:19, 20. 1 Co 11:23-25.) 1 Co 10:16, 17."
+          ]
         }
       ]
     },
@@ -11589,7 +13565,9 @@
         {
           "type": "paragraph",
           "subtype": "usfm:r",
-          "content": ["V. 26-31: cf. (Mt 26:30-35. Lu 22:39. Jn 18:1.) (Lu 22:31-38. Jn 13:36-38.)"]
+          "content": [
+            "V. 26-31: cf. (Mt 26:30-35. Lu 22:39. Jn 18:1.) (Lu 22:31-38. Jn 13:36-38.)"
+          ]
         }
       ]
     },
@@ -11599,7 +13577,9 @@
         {
           "type": "paragraph",
           "subtype": "usfm:s",
-          "content": ["Gethsémané"]
+          "content": [
+            "Gethsémané"
+          ]
         }
       ]
     },
@@ -11609,7 +13589,9 @@
         {
           "type": "paragraph",
           "subtype": "usfm:r",
-          "content": ["V. 32-42: cf. (Mt 26:36-46. Lu 22:40-46.)"]
+          "content": [
+            "V. 32-42: cf. (Mt 26:36-46. Lu 22:40-46.)"
+          ]
         }
       ]
     },
@@ -11619,7 +13601,9 @@
         {
           "type": "paragraph",
           "subtype": "usfm:s",
-          "content": ["Arrestation de Jésus"]
+          "content": [
+            "Arrestation de Jésus"
+          ]
         }
       ]
     },
@@ -11629,7 +13613,9 @@
         {
           "type": "paragraph",
           "subtype": "usfm:r",
-          "content": ["V. 43-52: cf. (Mt 26:47-56. Lu 22:47-53. Jn 18:2-12.)"]
+          "content": [
+            "V. 43-52: cf. (Mt 26:47-56. Lu 22:47-53. Jn 18:2-12.)"
+          ]
         }
       ]
     },
@@ -11639,7 +13625,9 @@
         {
           "type": "paragraph",
           "subtype": "usfm:s",
-          "content": ["Jésus devant le sanhédrin présidé par Caïphe. Condamnation"]
+          "content": [
+            "Jésus devant le sanhédrin présidé par Caïphe. Condamnation"
+          ]
         }
       ]
     },
@@ -11649,7 +13637,9 @@
         {
           "type": "paragraph",
           "subtype": "usfm:r",
-          "content": ["V. 53-65: cf. (Mt 26:57-68. Lu 22:54, 63-65. Jn 18:13-15, 19-24.)"]
+          "content": [
+            "V. 53-65: cf. (Mt 26:57-68. Lu 22:54, 63-65. Jn 18:13-15, 19-24.)"
+          ]
         }
       ]
     },
@@ -11659,7 +13649,9 @@
         {
           "type": "paragraph",
           "subtype": "usfm:s",
-          "content": ["Reniement de Pierre"]
+          "content": [
+            "Reniement de Pierre"
+          ]
         }
       ]
     },
@@ -11669,7 +13661,9 @@
         {
           "type": "paragraph",
           "subtype": "usfm:r",
-          "content": ["V. 66-72: cf. (Mt 26:69-75. Lu 22:55-62. Jn 18:15-18, 25-27.)"]
+          "content": [
+            "V. 66-72: cf. (Mt 26:69-75. Lu 22:55-62. Jn 18:15-18, 25-27.)"
+          ]
         }
       ]
     },
@@ -11679,7 +13673,9 @@
         {
           "type": "paragraph",
           "subtype": "usfm:s",
-          "content": ["Jésus devant Pilate, gouverneur romain"]
+          "content": [
+            "Jésus devant Pilate, gouverneur romain"
+          ]
         }
       ]
     },
@@ -11689,7 +13685,9 @@
         {
           "type": "paragraph",
           "subtype": "usfm:r",
-          "content": ["V. 1-5: cf. (Mt 27:1, 2, 11-14. Lu 22:66-71; 23:1-4. Jn 18:28-38.)"]
+          "content": [
+            "V. 1-5: cf. (Mt 27:1, 2, 11-14. Lu 22:66-71; 23:1-4. Jn 18:28-38.)"
+          ]
         }
       ]
     },
@@ -11699,7 +13697,9 @@
         {
           "type": "paragraph",
           "subtype": "usfm:s",
-          "content": ["Sentence de mort confirmée. Outrages des soldats"]
+          "content": [
+            "Sentence de mort confirmée. Outrages des soldats"
+          ]
         }
       ]
     },
@@ -11709,7 +13709,9 @@
         {
           "type": "paragraph",
           "subtype": "usfm:r",
-          "content": ["V. 6-20: cf. (Mt 27:15-31. Lu 23:13-25. Jn 18:39, 40; 19:1-16.)"]
+          "content": [
+            "V. 6-20: cf. (Mt 27:15-31. Lu 23:13-25. Jn 18:39, 40; 19:1-16.)"
+          ]
         }
       ]
     },
@@ -11719,7 +13721,9 @@
         {
           "type": "paragraph",
           "subtype": "usfm:s",
-          "content": ["Jésus crucifié"]
+          "content": [
+            "Jésus crucifié"
+          ]
         }
       ]
     },
@@ -11729,7 +13733,9 @@
         {
           "type": "paragraph",
           "subtype": "usfm:r",
-          "content": ["V. 21-28: cf. (Mt 27:32-38. Lu 23:26-34, 38. Jn 19:17-24.) Ga 3:13. Jn 3:14, 15."]
+          "content": [
+            "V. 21-28: cf. (Mt 27:32-38. Lu 23:26-34, 38. Jn 19:17-24.) Ga 3:13. Jn 3:14, 15."
+          ]
         }
       ]
     },
@@ -11739,7 +13745,9 @@
         {
           "type": "paragraph",
           "subtype": "usfm:r",
-          "content": ["V. 29-32: cf. (Mt 27:39-44. Lu 23:35-43. Jn 19:25-27.)"]
+          "content": [
+            "V. 29-32: cf. (Mt 27:39-44. Lu 23:35-43. Jn 19:25-27.)"
+          ]
         }
       ]
     },
@@ -11749,7 +13757,9 @@
         {
           "type": "paragraph",
           "subtype": "usfm:r",
-          "content": ["V. 33-41: cf. (Mt 27:45-56. Lu 23:44-49. Jn 19:28-37.) (Ps 22. És 53:5, etc.) Jn 1:29; 10:11; 12:32, 33. Ro 5:6-8. 2 Co 5:14, 15, 21."]
+          "content": [
+            "V. 33-41: cf. (Mt 27:45-56. Lu 23:44-49. Jn 19:28-37.) (Ps 22. És 53:5, etc.) Jn 1:29; 10:11; 12:32, 33. Ro 5:6-8. 2 Co 5:14, 15, 21."
+          ]
         }
       ]
     },
@@ -11759,7 +13769,9 @@
         {
           "type": "paragraph",
           "subtype": "usfm:s",
-          "content": ["Le corps de Jésus mis dans un sépulcre"]
+          "content": [
+            "Le corps de Jésus mis dans un sépulcre"
+          ]
         }
       ]
     },
@@ -11769,7 +13781,9 @@
         {
           "type": "paragraph",
           "subtype": "usfm:r",
-          "content": ["V. 42-47: cf. (Mt 27:57-61. Lu 23:50-56. Jn 19:38-42.)"]
+          "content": [
+            "V. 42-47: cf. (Mt 27:57-61. Lu 23:50-56. Jn 19:38-42.)"
+          ]
         }
       ]
     },
@@ -11779,7 +13793,9 @@
         {
           "type": "paragraph",
           "subtype": "usfm:s",
-          "content": ["Résurrection et ascension de Jésus-Christ"]
+          "content": [
+            "Résurrection et ascension de Jésus-Christ"
+          ]
         }
       ]
     },
@@ -11789,7 +13805,9 @@
         {
           "type": "paragraph",
           "subtype": "usfm:r",
-          "content": ["V. 1-8: cf. (Mt 28:1-8. Lu 24:1-8. Jn 20:1, 2.) (Ps 16:8-10. Ac 2:23-32). 1 Co 15:1-28. Ac 26:8."]
+          "content": [
+            "V. 1-8: cf. (Mt 28:1-8. Lu 24:1-8. Jn 20:1, 2.) (Ps 16:8-10. Ac 2:23-32). 1 Co 15:1-28. Ac 26:8."
+          ]
         }
       ]
     },
@@ -11799,7 +13817,9 @@
         {
           "type": "paragraph",
           "subtype": "usfm:r",
-          "content": ["V. 9-14: cf. (Mt 28:8-10. Lu 24:9-45. Jn 20:11-23)."]
+          "content": [
+            "V. 9-14: cf. (Mt 28:8-10. Lu 24:9-45. Jn 20:11-23)."
+          ]
         }
       ]
     },
@@ -11809,7 +13829,9 @@
         {
           "type": "paragraph",
           "subtype": "usfm:r",
-          "content": ["V. 15-20: cf. (Mt 28:16-20. Lu 24:46-49, 50-53. Ac 1:1-12.) Jn 21:1-24. 1 Co 15:6, 7."]
+          "content": [
+            "V. 15-20: cf. (Mt 28:16-20. Lu 24:46-49, 50-53. Ac 1:1-12.) Jn 21:1-24. 1 Co 15:6, 7."
+          ]
         }
       ]
     },
@@ -11819,7 +13841,9 @@
         {
           "type": "paragraph",
           "subtype": "usfm:is",
-          "content": ["Les paraboles de Jésus"]
+          "content": [
+            "Les paraboles de Jésus"
+          ]
         }
       ]
     },
@@ -11829,7 +13853,9 @@
         {
           "type": "paragraph",
           "subtype": "usfm:is",
-          "content": ["Les miracles de Jésus"]
+          "content": [
+            "Les miracles de Jésus"
+          ]
         }
       ]
     },
@@ -11839,7 +13865,9 @@
         {
           "type": "paragraph",
           "subtype": "usfm:x",
-          "content": ["a"]
+          "content": [
+            "a"
+          ]
         }
       ]
     },
@@ -11849,7 +13877,9 @@
         {
           "type": "paragraph",
           "subtype": "usfm:x",
-          "content": ["b"]
+          "content": [
+            "b"
+          ]
         }
       ]
     },
@@ -11859,7 +13889,9 @@
         {
           "type": "paragraph",
           "subtype": "usfm:x",
-          "content": ["c"]
+          "content": [
+            "c"
+          ]
         }
       ]
     },
@@ -11869,7 +13901,9 @@
         {
           "type": "paragraph",
           "subtype": "usfm:x",
-          "content": ["d"]
+          "content": [
+            "d"
+          ]
         }
       ]
     },
@@ -11879,7 +13913,9 @@
         {
           "type": "paragraph",
           "subtype": "usfm:x",
-          "content": ["e"]
+          "content": [
+            "e"
+          ]
         }
       ]
     },
@@ -11889,7 +13925,9 @@
         {
           "type": "paragraph",
           "subtype": "usfm:x",
-          "content": ["f"]
+          "content": [
+            "f"
+          ]
         }
       ]
     },
@@ -11899,7 +13937,9 @@
         {
           "type": "paragraph",
           "subtype": "usfm:x",
-          "content": ["g"]
+          "content": [
+            "g"
+          ]
         }
       ]
     },
@@ -11909,7 +13949,9 @@
         {
           "type": "paragraph",
           "subtype": "usfm:x",
-          "content": ["h"]
+          "content": [
+            "h"
+          ]
         }
       ]
     },
@@ -11919,7 +13961,9 @@
         {
           "type": "paragraph",
           "subtype": "usfm:x",
-          "content": ["i"]
+          "content": [
+            "i"
+          ]
         }
       ]
     },
@@ -11929,7 +13973,9 @@
         {
           "type": "paragraph",
           "subtype": "usfm:x",
-          "content": ["j"]
+          "content": [
+            "j"
+          ]
         }
       ]
     },
@@ -11939,7 +13985,9 @@
         {
           "type": "paragraph",
           "subtype": "usfm:x",
-          "content": ["k"]
+          "content": [
+            "k"
+          ]
         }
       ]
     },
@@ -11949,7 +13997,9 @@
         {
           "type": "paragraph",
           "subtype": "usfm:x",
-          "content": ["l"]
+          "content": [
+            "l"
+          ]
         }
       ]
     },
@@ -11959,7 +14009,9 @@
         {
           "type": "paragraph",
           "subtype": "usfm:x",
-          "content": ["m"]
+          "content": [
+            "m"
+          ]
         }
       ]
     },
@@ -11969,7 +14021,9 @@
         {
           "type": "paragraph",
           "subtype": "usfm:x",
-          "content": ["n"]
+          "content": [
+            "n"
+          ]
         }
       ]
     },
@@ -11979,7 +14033,9 @@
         {
           "type": "paragraph",
           "subtype": "usfm:x",
-          "content": ["o"]
+          "content": [
+            "o"
+          ]
         }
       ]
     },
@@ -11989,7 +14045,9 @@
         {
           "type": "paragraph",
           "subtype": "usfm:x",
-          "content": ["p"]
+          "content": [
+            "p"
+          ]
         }
       ]
     },
@@ -11999,7 +14057,9 @@
         {
           "type": "paragraph",
           "subtype": "usfm:x",
-          "content": ["q"]
+          "content": [
+            "q"
+          ]
         }
       ]
     },
@@ -12009,7 +14069,9 @@
         {
           "type": "paragraph",
           "subtype": "usfm:x",
-          "content": ["r"]
+          "content": [
+            "r"
+          ]
         }
       ]
     },
@@ -12019,7 +14081,9 @@
         {
           "type": "paragraph",
           "subtype": "usfm:x",
-          "content": ["s"]
+          "content": [
+            "s"
+          ]
         }
       ]
     },
@@ -12029,7 +14093,9 @@
         {
           "type": "paragraph",
           "subtype": "usfm:x",
-          "content": ["t"]
+          "content": [
+            "t"
+          ]
         }
       ]
     },
@@ -12039,7 +14105,9 @@
         {
           "type": "paragraph",
           "subtype": "usfm:x",
-          "content": ["u"]
+          "content": [
+            "u"
+          ]
         }
       ]
     },
@@ -12049,7 +14117,9 @@
         {
           "type": "paragraph",
           "subtype": "usfm:x",
-          "content": ["v"]
+          "content": [
+            "v"
+          ]
         }
       ]
     },
@@ -12059,7 +14129,9 @@
         {
           "type": "paragraph",
           "subtype": "usfm:x",
-          "content": ["w"]
+          "content": [
+            "w"
+          ]
         }
       ]
     },
@@ -12069,7 +14141,9 @@
         {
           "type": "paragraph",
           "subtype": "usfm:x",
-          "content": ["x"]
+          "content": [
+            "x"
+          ]
         }
       ]
     },
@@ -12079,7 +14153,9 @@
         {
           "type": "paragraph",
           "subtype": "usfm:x",
-          "content": ["y"]
+          "content": [
+            "y"
+          ]
         }
       ]
     },
@@ -12089,7 +14165,9 @@
         {
           "type": "paragraph",
           "subtype": "usfm:x",
-          "content": ["z"]
+          "content": [
+            "z"
+          ]
         }
       ]
     },
@@ -12099,7 +14177,9 @@
         {
           "type": "paragraph",
           "subtype": "usfm:x",
-          "content": ["a"]
+          "content": [
+            "a"
+          ]
         }
       ]
     },
@@ -12109,7 +14189,9 @@
         {
           "type": "paragraph",
           "subtype": "usfm:x",
-          "content": ["b"]
+          "content": [
+            "b"
+          ]
         }
       ]
     },
@@ -12119,7 +14201,9 @@
         {
           "type": "paragraph",
           "subtype": "usfm:x",
-          "content": ["c"]
+          "content": [
+            "c"
+          ]
         }
       ]
     },
@@ -12129,7 +14213,9 @@
         {
           "type": "paragraph",
           "subtype": "usfm:x",
-          "content": ["a"]
+          "content": [
+            "a"
+          ]
         }
       ]
     },
@@ -12139,7 +14225,9 @@
         {
           "type": "paragraph",
           "subtype": "usfm:x",
-          "content": ["b"]
+          "content": [
+            "b"
+          ]
         }
       ]
     },
@@ -12149,7 +14237,9 @@
         {
           "type": "paragraph",
           "subtype": "usfm:x",
-          "content": ["c"]
+          "content": [
+            "c"
+          ]
         }
       ]
     },
@@ -12159,7 +14249,9 @@
         {
           "type": "paragraph",
           "subtype": "usfm:x",
-          "content": ["d"]
+          "content": [
+            "d"
+          ]
         }
       ]
     },
@@ -12169,7 +14261,9 @@
         {
           "type": "paragraph",
           "subtype": "usfm:x",
-          "content": ["e"]
+          "content": [
+            "e"
+          ]
         }
       ]
     },
@@ -12179,7 +14273,9 @@
         {
           "type": "paragraph",
           "subtype": "usfm:x",
-          "content": ["f"]
+          "content": [
+            "f"
+          ]
         }
       ]
     },
@@ -12189,7 +14285,9 @@
         {
           "type": "paragraph",
           "subtype": "usfm:x",
-          "content": ["g"]
+          "content": [
+            "g"
+          ]
         }
       ]
     },
@@ -12199,7 +14297,9 @@
         {
           "type": "paragraph",
           "subtype": "usfm:x",
-          "content": ["h"]
+          "content": [
+            "h"
+          ]
         }
       ]
     },
@@ -12209,7 +14309,9 @@
         {
           "type": "paragraph",
           "subtype": "usfm:x",
-          "content": ["i"]
+          "content": [
+            "i"
+          ]
         }
       ]
     },
@@ -12219,7 +14321,9 @@
         {
           "type": "paragraph",
           "subtype": "usfm:x",
-          "content": ["j"]
+          "content": [
+            "j"
+          ]
         }
       ]
     },
@@ -12229,7 +14333,9 @@
         {
           "type": "paragraph",
           "subtype": "usfm:x",
-          "content": ["k"]
+          "content": [
+            "k"
+          ]
         }
       ]
     },
@@ -12239,7 +14345,9 @@
         {
           "type": "paragraph",
           "subtype": "usfm:x",
-          "content": ["l"]
+          "content": [
+            "l"
+          ]
         }
       ]
     },
@@ -12249,7 +14357,9 @@
         {
           "type": "paragraph",
           "subtype": "usfm:x",
-          "content": ["m"]
+          "content": [
+            "m"
+          ]
         }
       ]
     },
@@ -12259,7 +14369,9 @@
         {
           "type": "paragraph",
           "subtype": "usfm:x",
-          "content": ["a"]
+          "content": [
+            "a"
+          ]
         }
       ]
     },
@@ -12269,7 +14381,9 @@
         {
           "type": "paragraph",
           "subtype": "usfm:x",
-          "content": ["b"]
+          "content": [
+            "b"
+          ]
         }
       ]
     },
@@ -12279,7 +14393,9 @@
         {
           "type": "paragraph",
           "subtype": "usfm:x",
-          "content": ["c"]
+          "content": [
+            "c"
+          ]
         }
       ]
     },
@@ -12289,7 +14405,9 @@
         {
           "type": "paragraph",
           "subtype": "usfm:x",
-          "content": ["d"]
+          "content": [
+            "d"
+          ]
         }
       ]
     },
@@ -12299,7 +14417,9 @@
         {
           "type": "paragraph",
           "subtype": "usfm:x",
-          "content": ["e"]
+          "content": [
+            "e"
+          ]
         }
       ]
     },
@@ -12309,7 +14429,9 @@
         {
           "type": "paragraph",
           "subtype": "usfm:x",
-          "content": ["f"]
+          "content": [
+            "f"
+          ]
         }
       ]
     },
@@ -12319,7 +14441,9 @@
         {
           "type": "paragraph",
           "subtype": "usfm:x",
-          "content": ["g"]
+          "content": [
+            "g"
+          ]
         }
       ]
     },
@@ -12329,7 +14453,9 @@
         {
           "type": "paragraph",
           "subtype": "usfm:x",
-          "content": ["h"]
+          "content": [
+            "h"
+          ]
         }
       ]
     },
@@ -12339,7 +14465,9 @@
         {
           "type": "paragraph",
           "subtype": "usfm:x",
-          "content": ["i"]
+          "content": [
+            "i"
+          ]
         }
       ]
     },
@@ -12349,7 +14477,9 @@
         {
           "type": "paragraph",
           "subtype": "usfm:x",
-          "content": ["j"]
+          "content": [
+            "j"
+          ]
         }
       ]
     },
@@ -12359,7 +14489,9 @@
         {
           "type": "paragraph",
           "subtype": "usfm:x",
-          "content": ["k"]
+          "content": [
+            "k"
+          ]
         }
       ]
     },
@@ -12369,7 +14501,9 @@
         {
           "type": "paragraph",
           "subtype": "usfm:x",
-          "content": ["l"]
+          "content": [
+            "l"
+          ]
         }
       ]
     },
@@ -12379,7 +14513,9 @@
         {
           "type": "paragraph",
           "subtype": "usfm:x",
-          "content": ["m"]
+          "content": [
+            "m"
+          ]
         }
       ]
     },
@@ -12389,7 +14525,9 @@
         {
           "type": "paragraph",
           "subtype": "usfm:x",
-          "content": ["n"]
+          "content": [
+            "n"
+          ]
         }
       ]
     },
@@ -12399,7 +14537,9 @@
         {
           "type": "paragraph",
           "subtype": "usfm:x",
-          "content": ["a"]
+          "content": [
+            "a"
+          ]
         }
       ]
     },
@@ -12409,7 +14549,9 @@
         {
           "type": "paragraph",
           "subtype": "usfm:x",
-          "content": ["b"]
+          "content": [
+            "b"
+          ]
         }
       ]
     },
@@ -12419,7 +14561,9 @@
         {
           "type": "paragraph",
           "subtype": "usfm:x",
-          "content": ["c"]
+          "content": [
+            "c"
+          ]
         }
       ]
     },
@@ -12429,7 +14573,9 @@
         {
           "type": "paragraph",
           "subtype": "usfm:x",
-          "content": ["d"]
+          "content": [
+            "d"
+          ]
         }
       ]
     },
@@ -12439,7 +14585,9 @@
         {
           "type": "paragraph",
           "subtype": "usfm:x",
-          "content": ["e"]
+          "content": [
+            "e"
+          ]
         }
       ]
     },
@@ -12449,7 +14597,9 @@
         {
           "type": "paragraph",
           "subtype": "usfm:x",
-          "content": ["f"]
+          "content": [
+            "f"
+          ]
         }
       ]
     },
@@ -12459,7 +14609,9 @@
         {
           "type": "paragraph",
           "subtype": "usfm:x",
-          "content": ["g"]
+          "content": [
+            "g"
+          ]
         }
       ]
     },
@@ -12469,7 +14621,9 @@
         {
           "type": "paragraph",
           "subtype": "usfm:x",
-          "content": ["h"]
+          "content": [
+            "h"
+          ]
         }
       ]
     },
@@ -12479,7 +14633,9 @@
         {
           "type": "paragraph",
           "subtype": "usfm:x",
-          "content": ["i"]
+          "content": [
+            "i"
+          ]
         }
       ]
     },
@@ -12489,7 +14645,9 @@
         {
           "type": "paragraph",
           "subtype": "usfm:x",
-          "content": ["j"]
+          "content": [
+            "j"
+          ]
         }
       ]
     },
@@ -12499,7 +14657,9 @@
         {
           "type": "paragraph",
           "subtype": "usfm:x",
-          "content": ["k"]
+          "content": [
+            "k"
+          ]
         }
       ]
     },
@@ -12509,7 +14669,9 @@
         {
           "type": "paragraph",
           "subtype": "usfm:x",
-          "content": ["l"]
+          "content": [
+            "l"
+          ]
         }
       ]
     },
@@ -12519,7 +14681,9 @@
         {
           "type": "paragraph",
           "subtype": "usfm:x",
-          "content": ["m"]
+          "content": [
+            "m"
+          ]
         }
       ]
     },
@@ -12529,7 +14693,9 @@
         {
           "type": "paragraph",
           "subtype": "usfm:x",
-          "content": ["n"]
+          "content": [
+            "n"
+          ]
         }
       ]
     },
@@ -12539,7 +14705,9 @@
         {
           "type": "paragraph",
           "subtype": "usfm:x",
-          "content": ["o"]
+          "content": [
+            "o"
+          ]
         }
       ]
     },
@@ -12549,7 +14717,9 @@
         {
           "type": "paragraph",
           "subtype": "usfm:x",
-          "content": ["a"]
+          "content": [
+            "a"
+          ]
         }
       ]
     },
@@ -12559,7 +14729,9 @@
         {
           "type": "paragraph",
           "subtype": "usfm:x",
-          "content": ["b"]
+          "content": [
+            "b"
+          ]
         }
       ]
     },
@@ -12569,7 +14741,9 @@
         {
           "type": "paragraph",
           "subtype": "usfm:x",
-          "content": ["c"]
+          "content": [
+            "c"
+          ]
         }
       ]
     },
@@ -12579,7 +14753,9 @@
         {
           "type": "paragraph",
           "subtype": "usfm:x",
-          "content": ["d"]
+          "content": [
+            "d"
+          ]
         }
       ]
     },
@@ -12589,7 +14765,9 @@
         {
           "type": "paragraph",
           "subtype": "usfm:x",
-          "content": ["e"]
+          "content": [
+            "e"
+          ]
         }
       ]
     },
@@ -12599,7 +14777,9 @@
         {
           "type": "paragraph",
           "subtype": "usfm:x",
-          "content": ["f"]
+          "content": [
+            "f"
+          ]
         }
       ]
     },
@@ -12609,7 +14789,9 @@
         {
           "type": "paragraph",
           "subtype": "usfm:x",
-          "content": ["g"]
+          "content": [
+            "g"
+          ]
         }
       ]
     },
@@ -12619,7 +14801,9 @@
         {
           "type": "paragraph",
           "subtype": "usfm:x",
-          "content": ["h"]
+          "content": [
+            "h"
+          ]
         }
       ]
     },
@@ -12629,7 +14813,9 @@
         {
           "type": "paragraph",
           "subtype": "usfm:x",
-          "content": ["i"]
+          "content": [
+            "i"
+          ]
         }
       ]
     },
@@ -12639,7 +14825,9 @@
         {
           "type": "paragraph",
           "subtype": "usfm:x",
-          "content": ["a"]
+          "content": [
+            "a"
+          ]
         }
       ]
     },
@@ -12649,7 +14837,9 @@
         {
           "type": "paragraph",
           "subtype": "usfm:x",
-          "content": ["b"]
+          "content": [
+            "b"
+          ]
         }
       ]
     },
@@ -12659,7 +14849,9 @@
         {
           "type": "paragraph",
           "subtype": "usfm:x",
-          "content": ["c"]
+          "content": [
+            "c"
+          ]
         }
       ]
     },
@@ -12669,7 +14861,9 @@
         {
           "type": "paragraph",
           "subtype": "usfm:x",
-          "content": ["d"]
+          "content": [
+            "d"
+          ]
         }
       ]
     },
@@ -12679,7 +14873,9 @@
         {
           "type": "paragraph",
           "subtype": "usfm:x",
-          "content": ["e"]
+          "content": [
+            "e"
+          ]
         }
       ]
     },
@@ -12689,7 +14885,9 @@
         {
           "type": "paragraph",
           "subtype": "usfm:x",
-          "content": ["f"]
+          "content": [
+            "f"
+          ]
         }
       ]
     },
@@ -12699,7 +14897,9 @@
         {
           "type": "paragraph",
           "subtype": "usfm:x",
-          "content": ["g"]
+          "content": [
+            "g"
+          ]
         }
       ]
     },
@@ -12709,7 +14909,9 @@
         {
           "type": "paragraph",
           "subtype": "usfm:x",
-          "content": ["h"]
+          "content": [
+            "h"
+          ]
         }
       ]
     },
@@ -12719,7 +14921,9 @@
         {
           "type": "paragraph",
           "subtype": "usfm:x",
-          "content": ["i"]
+          "content": [
+            "i"
+          ]
         }
       ]
     },
@@ -12729,7 +14933,9 @@
         {
           "type": "paragraph",
           "subtype": "usfm:x",
-          "content": ["j"]
+          "content": [
+            "j"
+          ]
         }
       ]
     },
@@ -12739,7 +14945,9 @@
         {
           "type": "paragraph",
           "subtype": "usfm:x",
-          "content": ["k"]
+          "content": [
+            "k"
+          ]
         }
       ]
     },
@@ -12749,7 +14957,9 @@
         {
           "type": "paragraph",
           "subtype": "usfm:x",
-          "content": ["l"]
+          "content": [
+            "l"
+          ]
         }
       ]
     },
@@ -12759,7 +14969,9 @@
         {
           "type": "paragraph",
           "subtype": "usfm:x",
-          "content": ["m"]
+          "content": [
+            "m"
+          ]
         }
       ]
     },
@@ -12769,7 +14981,9 @@
         {
           "type": "paragraph",
           "subtype": "usfm:x",
-          "content": ["n"]
+          "content": [
+            "n"
+          ]
         }
       ]
     },
@@ -12779,7 +14993,9 @@
         {
           "type": "paragraph",
           "subtype": "usfm:x",
-          "content": ["o"]
+          "content": [
+            "o"
+          ]
         }
       ]
     },
@@ -12789,7 +15005,9 @@
         {
           "type": "paragraph",
           "subtype": "usfm:x",
-          "content": ["p"]
+          "content": [
+            "p"
+          ]
         }
       ]
     },
@@ -12799,7 +15017,9 @@
         {
           "type": "paragraph",
           "subtype": "usfm:x",
-          "content": ["q"]
+          "content": [
+            "q"
+          ]
         }
       ]
     },
@@ -12809,7 +15029,9 @@
         {
           "type": "paragraph",
           "subtype": "usfm:x",
-          "content": ["r"]
+          "content": [
+            "r"
+          ]
         }
       ]
     },
@@ -12819,7 +15041,9 @@
         {
           "type": "paragraph",
           "subtype": "usfm:x",
-          "content": ["s"]
+          "content": [
+            "s"
+          ]
         }
       ]
     },
@@ -12829,7 +15053,9 @@
         {
           "type": "paragraph",
           "subtype": "usfm:x",
-          "content": ["t"]
+          "content": [
+            "t"
+          ]
         }
       ]
     },
@@ -12839,7 +15065,9 @@
         {
           "type": "paragraph",
           "subtype": "usfm:x",
-          "content": ["u"]
+          "content": [
+            "u"
+          ]
         }
       ]
     },
@@ -12849,7 +15077,9 @@
         {
           "type": "paragraph",
           "subtype": "usfm:x",
-          "content": ["v"]
+          "content": [
+            "v"
+          ]
         }
       ]
     },
@@ -12859,7 +15089,9 @@
         {
           "type": "paragraph",
           "subtype": "usfm:x",
-          "content": ["w"]
+          "content": [
+            "w"
+          ]
         }
       ]
     },
@@ -12869,7 +15101,9 @@
         {
           "type": "paragraph",
           "subtype": "usfm:x",
-          "content": ["x"]
+          "content": [
+            "x"
+          ]
         }
       ]
     },
@@ -12879,7 +15113,9 @@
         {
           "type": "paragraph",
           "subtype": "usfm:x",
-          "content": ["y"]
+          "content": [
+            "y"
+          ]
         }
       ]
     },
@@ -12889,7 +15125,9 @@
         {
           "type": "paragraph",
           "subtype": "usfm:x",
-          "content": ["z"]
+          "content": [
+            "z"
+          ]
         }
       ]
     },
@@ -12899,7 +15137,9 @@
         {
           "type": "paragraph",
           "subtype": "usfm:x",
-          "content": ["a"]
+          "content": [
+            "a"
+          ]
         }
       ]
     },
@@ -12909,7 +15149,9 @@
         {
           "type": "paragraph",
           "subtype": "usfm:x",
-          "content": ["b"]
+          "content": [
+            "b"
+          ]
         }
       ]
     },
@@ -12919,7 +15161,9 @@
         {
           "type": "paragraph",
           "subtype": "usfm:x",
-          "content": ["c"]
+          "content": [
+            "c"
+          ]
         }
       ]
     },
@@ -12929,7 +15173,9 @@
         {
           "type": "paragraph",
           "subtype": "usfm:x",
-          "content": ["d"]
+          "content": [
+            "d"
+          ]
         }
       ]
     },
@@ -12939,7 +15185,9 @@
         {
           "type": "paragraph",
           "subtype": "usfm:x",
-          "content": ["e"]
+          "content": [
+            "e"
+          ]
         }
       ]
     },
@@ -12949,7 +15197,9 @@
         {
           "type": "paragraph",
           "subtype": "usfm:x",
-          "content": ["a"]
+          "content": [
+            "a"
+          ]
         }
       ]
     },
@@ -12959,7 +15209,9 @@
         {
           "type": "paragraph",
           "subtype": "usfm:x",
-          "content": ["b"]
+          "content": [
+            "b"
+          ]
         }
       ]
     },
@@ -12969,7 +15221,9 @@
         {
           "type": "paragraph",
           "subtype": "usfm:x",
-          "content": ["c"]
+          "content": [
+            "c"
+          ]
         }
       ]
     },
@@ -12979,7 +15233,9 @@
         {
           "type": "paragraph",
           "subtype": "usfm:x",
-          "content": ["d"]
+          "content": [
+            "d"
+          ]
         }
       ]
     },
@@ -12989,7 +15245,9 @@
         {
           "type": "paragraph",
           "subtype": "usfm:x",
-          "content": ["e"]
+          "content": [
+            "e"
+          ]
         }
       ]
     },
@@ -12999,7 +15257,9 @@
         {
           "type": "paragraph",
           "subtype": "usfm:x",
-          "content": ["f"]
+          "content": [
+            "f"
+          ]
         }
       ]
     },
@@ -13009,7 +15269,9 @@
         {
           "type": "paragraph",
           "subtype": "usfm:x",
-          "content": ["g"]
+          "content": [
+            "g"
+          ]
         }
       ]
     },
@@ -13019,7 +15281,9 @@
         {
           "type": "paragraph",
           "subtype": "usfm:x",
-          "content": ["h"]
+          "content": [
+            "h"
+          ]
         }
       ]
     },
@@ -13029,7 +15293,9 @@
         {
           "type": "paragraph",
           "subtype": "usfm:x",
-          "content": ["i"]
+          "content": [
+            "i"
+          ]
         }
       ]
     },
@@ -13039,7 +15305,9 @@
         {
           "type": "paragraph",
           "subtype": "usfm:x",
-          "content": ["j"]
+          "content": [
+            "j"
+          ]
         }
       ]
     },
@@ -13049,7 +15317,9 @@
         {
           "type": "paragraph",
           "subtype": "usfm:x",
-          "content": ["k"]
+          "content": [
+            "k"
+          ]
         }
       ]
     },
@@ -13059,7 +15329,9 @@
         {
           "type": "paragraph",
           "subtype": "usfm:x",
-          "content": ["l"]
+          "content": [
+            "l"
+          ]
         }
       ]
     },
@@ -13069,7 +15341,9 @@
         {
           "type": "paragraph",
           "subtype": "usfm:x",
-          "content": ["m"]
+          "content": [
+            "m"
+          ]
         }
       ]
     },
@@ -13079,7 +15353,9 @@
         {
           "type": "paragraph",
           "subtype": "usfm:x",
-          "content": ["n"]
+          "content": [
+            "n"
+          ]
         }
       ]
     },
@@ -13089,7 +15365,9 @@
         {
           "type": "paragraph",
           "subtype": "usfm:x",
-          "content": ["a"]
+          "content": [
+            "a"
+          ]
         }
       ]
     },
@@ -13099,7 +15377,9 @@
         {
           "type": "paragraph",
           "subtype": "usfm:x",
-          "content": ["b"]
+          "content": [
+            "b"
+          ]
         }
       ]
     },
@@ -13109,7 +15389,9 @@
         {
           "type": "paragraph",
           "subtype": "usfm:x",
-          "content": ["c"]
+          "content": [
+            "c"
+          ]
         }
       ]
     },
@@ -13119,7 +15401,9 @@
         {
           "type": "paragraph",
           "subtype": "usfm:x",
-          "content": ["d"]
+          "content": [
+            "d"
+          ]
         }
       ]
     },
@@ -13129,7 +15413,9 @@
         {
           "type": "paragraph",
           "subtype": "usfm:x",
-          "content": ["e"]
+          "content": [
+            "e"
+          ]
         }
       ]
     },
@@ -13139,7 +15425,9 @@
         {
           "type": "paragraph",
           "subtype": "usfm:x",
-          "content": ["f"]
+          "content": [
+            "f"
+          ]
         }
       ]
     },
@@ -13149,7 +15437,9 @@
         {
           "type": "paragraph",
           "subtype": "usfm:x",
-          "content": ["g"]
+          "content": [
+            "g"
+          ]
         }
       ]
     },
@@ -13159,7 +15449,9 @@
         {
           "type": "paragraph",
           "subtype": "usfm:x",
-          "content": ["h"]
+          "content": [
+            "h"
+          ]
         }
       ]
     },
@@ -13169,7 +15461,9 @@
         {
           "type": "paragraph",
           "subtype": "usfm:x",
-          "content": ["i"]
+          "content": [
+            "i"
+          ]
         }
       ]
     },
@@ -13179,7 +15473,9 @@
         {
           "type": "paragraph",
           "subtype": "usfm:x",
-          "content": ["j"]
+          "content": [
+            "j"
+          ]
         }
       ]
     },
@@ -13189,7 +15485,9 @@
         {
           "type": "paragraph",
           "subtype": "usfm:x",
-          "content": ["k"]
+          "content": [
+            "k"
+          ]
         }
       ]
     },
@@ -13199,7 +15497,9 @@
         {
           "type": "paragraph",
           "subtype": "usfm:x",
-          "content": ["l"]
+          "content": [
+            "l"
+          ]
         }
       ]
     },
@@ -13209,7 +15509,9 @@
         {
           "type": "paragraph",
           "subtype": "usfm:x",
-          "content": ["m"]
+          "content": [
+            "m"
+          ]
         }
       ]
     },
@@ -13219,7 +15521,9 @@
         {
           "type": "paragraph",
           "subtype": "usfm:x",
-          "content": ["n"]
+          "content": [
+            "n"
+          ]
         }
       ]
     },
@@ -13229,7 +15533,9 @@
         {
           "type": "paragraph",
           "subtype": "usfm:x",
-          "content": ["o"]
+          "content": [
+            "o"
+          ]
         }
       ]
     },
@@ -13239,7 +15545,9 @@
         {
           "type": "paragraph",
           "subtype": "usfm:x",
-          "content": ["p"]
+          "content": [
+            "p"
+          ]
         }
       ]
     },
@@ -13249,7 +15557,9 @@
         {
           "type": "paragraph",
           "subtype": "usfm:x",
-          "content": ["q"]
+          "content": [
+            "q"
+          ]
         }
       ]
     },
@@ -13259,7 +15569,9 @@
         {
           "type": "paragraph",
           "subtype": "usfm:x",
-          "content": ["r"]
+          "content": [
+            "r"
+          ]
         }
       ]
     },
@@ -13269,7 +15581,9 @@
         {
           "type": "paragraph",
           "subtype": "usfm:x",
-          "content": ["s"]
+          "content": [
+            "s"
+          ]
         }
       ]
     },
@@ -13279,7 +15593,9 @@
         {
           "type": "paragraph",
           "subtype": "usfm:x",
-          "content": ["a"]
+          "content": [
+            "a"
+          ]
         }
       ]
     },
@@ -13289,7 +15605,9 @@
         {
           "type": "paragraph",
           "subtype": "usfm:x",
-          "content": ["b"]
+          "content": [
+            "b"
+          ]
         }
       ]
     },
@@ -13299,7 +15617,9 @@
         {
           "type": "paragraph",
           "subtype": "usfm:x",
-          "content": ["c"]
+          "content": [
+            "c"
+          ]
         }
       ]
     },
@@ -13309,7 +15629,9 @@
         {
           "type": "paragraph",
           "subtype": "usfm:x",
-          "content": ["d"]
+          "content": [
+            "d"
+          ]
         }
       ]
     },
@@ -13319,7 +15641,9 @@
         {
           "type": "paragraph",
           "subtype": "usfm:x",
-          "content": ["e"]
+          "content": [
+            "e"
+          ]
         }
       ]
     },
@@ -13329,7 +15653,9 @@
         {
           "type": "paragraph",
           "subtype": "usfm:x",
-          "content": ["f"]
+          "content": [
+            "f"
+          ]
         }
       ]
     },
@@ -13339,7 +15665,9 @@
         {
           "type": "paragraph",
           "subtype": "usfm:x",
-          "content": ["g"]
+          "content": [
+            "g"
+          ]
         }
       ]
     },
@@ -13349,7 +15677,9 @@
         {
           "type": "paragraph",
           "subtype": "usfm:x",
-          "content": ["h"]
+          "content": [
+            "h"
+          ]
         }
       ]
     },
@@ -13359,7 +15689,9 @@
         {
           "type": "paragraph",
           "subtype": "usfm:x",
-          "content": ["i"]
+          "content": [
+            "i"
+          ]
         }
       ]
     },
@@ -13369,7 +15701,9 @@
         {
           "type": "paragraph",
           "subtype": "usfm:x",
-          "content": ["j"]
+          "content": [
+            "j"
+          ]
         }
       ]
     },
@@ -13379,7 +15713,9 @@
         {
           "type": "paragraph",
           "subtype": "usfm:x",
-          "content": ["k"]
+          "content": [
+            "k"
+          ]
         }
       ]
     },
@@ -13389,7 +15725,9 @@
         {
           "type": "paragraph",
           "subtype": "usfm:x",
-          "content": ["l"]
+          "content": [
+            "l"
+          ]
         }
       ]
     },
@@ -13399,7 +15737,9 @@
         {
           "type": "paragraph",
           "subtype": "usfm:x",
-          "content": ["m"]
+          "content": [
+            "m"
+          ]
         }
       ]
     },
@@ -13409,7 +15749,9 @@
         {
           "type": "paragraph",
           "subtype": "usfm:x",
-          "content": ["n"]
+          "content": [
+            "n"
+          ]
         }
       ]
     },
@@ -13419,7 +15761,9 @@
         {
           "type": "paragraph",
           "subtype": "usfm:x",
-          "content": ["o"]
+          "content": [
+            "o"
+          ]
         }
       ]
     },
@@ -13429,7 +15773,9 @@
         {
           "type": "paragraph",
           "subtype": "usfm:x",
-          "content": ["p"]
+          "content": [
+            "p"
+          ]
         }
       ]
     },
@@ -13439,7 +15785,9 @@
         {
           "type": "paragraph",
           "subtype": "usfm:x",
-          "content": ["q"]
+          "content": [
+            "q"
+          ]
         }
       ]
     },
@@ -13449,7 +15797,9 @@
         {
           "type": "paragraph",
           "subtype": "usfm:x",
-          "content": ["r"]
+          "content": [
+            "r"
+          ]
         }
       ]
     },
@@ -13459,7 +15809,9 @@
         {
           "type": "paragraph",
           "subtype": "usfm:x",
-          "content": ["s"]
+          "content": [
+            "s"
+          ]
         }
       ]
     },
@@ -13469,7 +15821,9 @@
         {
           "type": "paragraph",
           "subtype": "usfm:x",
-          "content": ["t"]
+          "content": [
+            "t"
+          ]
         }
       ]
     },
@@ -13479,7 +15833,9 @@
         {
           "type": "paragraph",
           "subtype": "usfm:x",
-          "content": ["u"]
+          "content": [
+            "u"
+          ]
         }
       ]
     },
@@ -13489,7 +15845,9 @@
         {
           "type": "paragraph",
           "subtype": "usfm:x",
-          "content": ["v"]
+          "content": [
+            "v"
+          ]
         }
       ]
     },
@@ -13499,7 +15857,9 @@
         {
           "type": "paragraph",
           "subtype": "usfm:x",
-          "content": ["w"]
+          "content": [
+            "w"
+          ]
         }
       ]
     },
@@ -13509,7 +15869,9 @@
         {
           "type": "paragraph",
           "subtype": "usfm:x",
-          "content": ["x"]
+          "content": [
+            "x"
+          ]
         }
       ]
     },
@@ -13519,7 +15881,9 @@
         {
           "type": "paragraph",
           "subtype": "usfm:x",
-          "content": ["y"]
+          "content": [
+            "y"
+          ]
         }
       ]
     },
@@ -13529,7 +15893,9 @@
         {
           "type": "paragraph",
           "subtype": "usfm:x",
-          "content": ["a"]
+          "content": [
+            "a"
+          ]
         }
       ]
     },
@@ -13539,7 +15905,9 @@
         {
           "type": "paragraph",
           "subtype": "usfm:x",
-          "content": ["b"]
+          "content": [
+            "b"
+          ]
         }
       ]
     },
@@ -13549,7 +15917,9 @@
         {
           "type": "paragraph",
           "subtype": "usfm:x",
-          "content": ["c"]
+          "content": [
+            "c"
+          ]
         }
       ]
     },
@@ -13559,7 +15929,9 @@
         {
           "type": "paragraph",
           "subtype": "usfm:x",
-          "content": ["d"]
+          "content": [
+            "d"
+          ]
         }
       ]
     },
@@ -13569,7 +15941,9 @@
         {
           "type": "paragraph",
           "subtype": "usfm:x",
-          "content": ["e"]
+          "content": [
+            "e"
+          ]
         }
       ]
     },
@@ -13579,7 +15953,9 @@
         {
           "type": "paragraph",
           "subtype": "usfm:x",
-          "content": ["f"]
+          "content": [
+            "f"
+          ]
         }
       ]
     },
@@ -13589,7 +15965,9 @@
         {
           "type": "paragraph",
           "subtype": "usfm:x",
-          "content": ["g"]
+          "content": [
+            "g"
+          ]
         }
       ]
     },
@@ -13599,7 +15977,9 @@
         {
           "type": "paragraph",
           "subtype": "usfm:x",
-          "content": ["h"]
+          "content": [
+            "h"
+          ]
         }
       ]
     },
@@ -13609,7 +15989,9 @@
         {
           "type": "paragraph",
           "subtype": "usfm:x",
-          "content": ["i"]
+          "content": [
+            "i"
+          ]
         }
       ]
     },
@@ -13619,7 +16001,9 @@
         {
           "type": "paragraph",
           "subtype": "usfm:x",
-          "content": ["j"]
+          "content": [
+            "j"
+          ]
         }
       ]
     },
@@ -13629,7 +16013,9 @@
         {
           "type": "paragraph",
           "subtype": "usfm:x",
-          "content": ["k"]
+          "content": [
+            "k"
+          ]
         }
       ]
     },
@@ -13639,7 +16025,9 @@
         {
           "type": "paragraph",
           "subtype": "usfm:x",
-          "content": ["l"]
+          "content": [
+            "l"
+          ]
         }
       ]
     },
@@ -13649,7 +16037,9 @@
         {
           "type": "paragraph",
           "subtype": "usfm:x",
-          "content": ["m"]
+          "content": [
+            "m"
+          ]
         }
       ]
     },
@@ -13659,7 +16049,9 @@
         {
           "type": "paragraph",
           "subtype": "usfm:x",
-          "content": ["n"]
+          "content": [
+            "n"
+          ]
         }
       ]
     },
@@ -13669,7 +16061,9 @@
         {
           "type": "paragraph",
           "subtype": "usfm:x",
-          "content": ["o"]
+          "content": [
+            "o"
+          ]
         }
       ]
     },
@@ -13679,7 +16073,9 @@
         {
           "type": "paragraph",
           "subtype": "usfm:x",
-          "content": ["p"]
+          "content": [
+            "p"
+          ]
         }
       ]
     },
@@ -13689,7 +16085,9 @@
         {
           "type": "paragraph",
           "subtype": "usfm:x",
-          "content": ["q"]
+          "content": [
+            "q"
+          ]
         }
       ]
     },
@@ -13699,7 +16097,9 @@
         {
           "type": "paragraph",
           "subtype": "usfm:x",
-          "content": ["r"]
+          "content": [
+            "r"
+          ]
         }
       ]
     },
@@ -13709,7 +16109,9 @@
         {
           "type": "paragraph",
           "subtype": "usfm:x",
-          "content": ["s"]
+          "content": [
+            "s"
+          ]
         }
       ]
     },
@@ -13719,7 +16121,9 @@
         {
           "type": "paragraph",
           "subtype": "usfm:x",
-          "content": ["t"]
+          "content": [
+            "t"
+          ]
         }
       ]
     },
@@ -13729,7 +16133,9 @@
         {
           "type": "paragraph",
           "subtype": "usfm:x",
-          "content": ["u"]
+          "content": [
+            "u"
+          ]
         }
       ]
     },
@@ -13739,7 +16145,9 @@
         {
           "type": "paragraph",
           "subtype": "usfm:x",
-          "content": ["v"]
+          "content": [
+            "v"
+          ]
         }
       ]
     },
@@ -13749,7 +16157,9 @@
         {
           "type": "paragraph",
           "subtype": "usfm:x",
-          "content": ["w"]
+          "content": [
+            "w"
+          ]
         }
       ]
     },
@@ -13759,7 +16169,9 @@
         {
           "type": "paragraph",
           "subtype": "usfm:x",
-          "content": ["x"]
+          "content": [
+            "x"
+          ]
         }
       ]
     },
@@ -13769,7 +16181,9 @@
         {
           "type": "paragraph",
           "subtype": "usfm:x",
-          "content": ["y"]
+          "content": [
+            "y"
+          ]
         }
       ]
     },
@@ -13779,7 +16193,9 @@
         {
           "type": "paragraph",
           "subtype": "usfm:x",
-          "content": ["z"]
+          "content": [
+            "z"
+          ]
         }
       ]
     },
@@ -13789,7 +16205,9 @@
         {
           "type": "paragraph",
           "subtype": "usfm:x",
-          "content": ["a"]
+          "content": [
+            "a"
+          ]
         }
       ]
     },
@@ -13799,7 +16217,9 @@
         {
           "type": "paragraph",
           "subtype": "usfm:x",
-          "content": ["a"]
+          "content": [
+            "a"
+          ]
         }
       ]
     },
@@ -13809,7 +16229,9 @@
         {
           "type": "paragraph",
           "subtype": "usfm:x",
-          "content": ["b"]
+          "content": [
+            "b"
+          ]
         }
       ]
     },
@@ -13819,7 +16241,9 @@
         {
           "type": "paragraph",
           "subtype": "usfm:x",
-          "content": ["c"]
+          "content": [
+            "c"
+          ]
         }
       ]
     },
@@ -13829,7 +16253,9 @@
         {
           "type": "paragraph",
           "subtype": "usfm:x",
-          "content": ["d"]
+          "content": [
+            "d"
+          ]
         }
       ]
     },
@@ -13839,7 +16265,9 @@
         {
           "type": "paragraph",
           "subtype": "usfm:x",
-          "content": ["e"]
+          "content": [
+            "e"
+          ]
         }
       ]
     },
@@ -13849,7 +16277,9 @@
         {
           "type": "paragraph",
           "subtype": "usfm:x",
-          "content": ["f"]
+          "content": [
+            "f"
+          ]
         }
       ]
     },
@@ -13859,7 +16289,9 @@
         {
           "type": "paragraph",
           "subtype": "usfm:x",
-          "content": ["g"]
+          "content": [
+            "g"
+          ]
         }
       ]
     },
@@ -13869,7 +16301,9 @@
         {
           "type": "paragraph",
           "subtype": "usfm:x",
-          "content": ["h"]
+          "content": [
+            "h"
+          ]
         }
       ]
     },
@@ -13879,7 +16313,9 @@
         {
           "type": "paragraph",
           "subtype": "usfm:x",
-          "content": ["i"]
+          "content": [
+            "i"
+          ]
         }
       ]
     },
@@ -13889,7 +16325,9 @@
         {
           "type": "paragraph",
           "subtype": "usfm:x",
-          "content": ["j"]
+          "content": [
+            "j"
+          ]
         }
       ]
     },
@@ -13899,7 +16337,9 @@
         {
           "type": "paragraph",
           "subtype": "usfm:x",
-          "content": ["k"]
+          "content": [
+            "k"
+          ]
         }
       ]
     },
@@ -13909,7 +16349,9 @@
         {
           "type": "paragraph",
           "subtype": "usfm:x",
-          "content": ["l"]
+          "content": [
+            "l"
+          ]
         }
       ]
     },
@@ -13919,7 +16361,9 @@
         {
           "type": "paragraph",
           "subtype": "usfm:x",
-          "content": ["m"]
+          "content": [
+            "m"
+          ]
         }
       ]
     },
@@ -13929,7 +16373,9 @@
         {
           "type": "paragraph",
           "subtype": "usfm:x",
-          "content": ["n"]
+          "content": [
+            "n"
+          ]
         }
       ]
     },
@@ -13939,7 +16385,9 @@
         {
           "type": "paragraph",
           "subtype": "usfm:x",
-          "content": ["o"]
+          "content": [
+            "o"
+          ]
         }
       ]
     },
@@ -13949,7 +16397,9 @@
         {
           "type": "paragraph",
           "subtype": "usfm:x",
-          "content": ["p"]
+          "content": [
+            "p"
+          ]
         }
       ]
     },
@@ -13959,7 +16409,9 @@
         {
           "type": "paragraph",
           "subtype": "usfm:x",
-          "content": ["q"]
+          "content": [
+            "q"
+          ]
         }
       ]
     },
@@ -13969,7 +16421,9 @@
         {
           "type": "paragraph",
           "subtype": "usfm:x",
-          "content": ["r"]
+          "content": [
+            "r"
+          ]
         }
       ]
     },
@@ -13979,7 +16433,9 @@
         {
           "type": "paragraph",
           "subtype": "usfm:x",
-          "content": ["a"]
+          "content": [
+            "a"
+          ]
         }
       ]
     },
@@ -13989,7 +16445,9 @@
         {
           "type": "paragraph",
           "subtype": "usfm:x",
-          "content": ["b"]
+          "content": [
+            "b"
+          ]
         }
       ]
     },
@@ -13999,7 +16457,9 @@
         {
           "type": "paragraph",
           "subtype": "usfm:x",
-          "content": ["c"]
+          "content": [
+            "c"
+          ]
         }
       ]
     },
@@ -14009,7 +16469,9 @@
         {
           "type": "paragraph",
           "subtype": "usfm:x",
-          "content": ["d"]
+          "content": [
+            "d"
+          ]
         }
       ]
     },
@@ -14019,7 +16481,9 @@
         {
           "type": "paragraph",
           "subtype": "usfm:x",
-          "content": ["e"]
+          "content": [
+            "e"
+          ]
         }
       ]
     },
@@ -14029,7 +16493,9 @@
         {
           "type": "paragraph",
           "subtype": "usfm:x",
-          "content": ["f"]
+          "content": [
+            "f"
+          ]
         }
       ]
     },
@@ -14039,7 +16505,9 @@
         {
           "type": "paragraph",
           "subtype": "usfm:x",
-          "content": ["g"]
+          "content": [
+            "g"
+          ]
         }
       ]
     },
@@ -14049,7 +16517,9 @@
         {
           "type": "paragraph",
           "subtype": "usfm:x",
-          "content": ["h"]
+          "content": [
+            "h"
+          ]
         }
       ]
     },
@@ -14059,7 +16529,9 @@
         {
           "type": "paragraph",
           "subtype": "usfm:x",
-          "content": ["i"]
+          "content": [
+            "i"
+          ]
         }
       ]
     },
@@ -14069,7 +16541,9 @@
         {
           "type": "paragraph",
           "subtype": "usfm:x",
-          "content": ["j"]
+          "content": [
+            "j"
+          ]
         }
       ]
     },
@@ -14079,7 +16553,9 @@
         {
           "type": "paragraph",
           "subtype": "usfm:x",
-          "content": ["k"]
+          "content": [
+            "k"
+          ]
         }
       ]
     },
@@ -14089,7 +16565,9 @@
         {
           "type": "paragraph",
           "subtype": "usfm:x",
-          "content": ["l"]
+          "content": [
+            "l"
+          ]
         }
       ]
     },
@@ -14099,7 +16577,9 @@
         {
           "type": "paragraph",
           "subtype": "usfm:x",
-          "content": ["m"]
+          "content": [
+            "m"
+          ]
         }
       ]
     },
@@ -14109,7 +16589,9 @@
         {
           "type": "paragraph",
           "subtype": "usfm:x",
-          "content": ["n"]
+          "content": [
+            "n"
+          ]
         }
       ]
     },
@@ -14119,7 +16601,9 @@
         {
           "type": "paragraph",
           "subtype": "usfm:x",
-          "content": ["o"]
+          "content": [
+            "o"
+          ]
         }
       ]
     },
@@ -14129,7 +16613,9 @@
         {
           "type": "paragraph",
           "subtype": "usfm:x",
-          "content": ["p"]
+          "content": [
+            "p"
+          ]
         }
       ]
     },
@@ -14139,7 +16625,9 @@
         {
           "type": "paragraph",
           "subtype": "usfm:x",
-          "content": ["q"]
+          "content": [
+            "q"
+          ]
         }
       ]
     },
@@ -14149,7 +16637,9 @@
         {
           "type": "paragraph",
           "subtype": "usfm:x",
-          "content": ["r"]
+          "content": [
+            "r"
+          ]
         }
       ]
     },
@@ -14159,7 +16649,9 @@
         {
           "type": "paragraph",
           "subtype": "usfm:x",
-          "content": ["s"]
+          "content": [
+            "s"
+          ]
         }
       ]
     },
@@ -14169,7 +16661,9 @@
         {
           "type": "paragraph",
           "subtype": "usfm:x",
-          "content": ["t"]
+          "content": [
+            "t"
+          ]
         }
       ]
     },
@@ -14179,7 +16673,9 @@
         {
           "type": "paragraph",
           "subtype": "usfm:x",
-          "content": ["u"]
+          "content": [
+            "u"
+          ]
         }
       ]
     },
@@ -14189,7 +16685,9 @@
         {
           "type": "paragraph",
           "subtype": "usfm:x",
-          "content": ["a"]
+          "content": [
+            "a"
+          ]
         }
       ]
     },
@@ -14199,7 +16697,9 @@
         {
           "type": "paragraph",
           "subtype": "usfm:x",
-          "content": ["b"]
+          "content": [
+            "b"
+          ]
         }
       ]
     },
@@ -14209,7 +16709,9 @@
         {
           "type": "paragraph",
           "subtype": "usfm:x",
-          "content": ["c"]
+          "content": [
+            "c"
+          ]
         }
       ]
     },
@@ -14219,7 +16721,9 @@
         {
           "type": "paragraph",
           "subtype": "usfm:x",
-          "content": ["d"]
+          "content": [
+            "d"
+          ]
         }
       ]
     },
@@ -14229,7 +16733,9 @@
         {
           "type": "paragraph",
           "subtype": "usfm:x",
-          "content": ["e"]
+          "content": [
+            "e"
+          ]
         }
       ]
     },
@@ -14239,7 +16745,9 @@
         {
           "type": "paragraph",
           "subtype": "usfm:x",
-          "content": ["f"]
+          "content": [
+            "f"
+          ]
         }
       ]
     },
@@ -14249,7 +16757,9 @@
         {
           "type": "paragraph",
           "subtype": "usfm:x",
-          "content": ["g"]
+          "content": [
+            "g"
+          ]
         }
       ]
     },
@@ -14259,7 +16769,9 @@
         {
           "type": "paragraph",
           "subtype": "usfm:x",
-          "content": ["h"]
+          "content": [
+            "h"
+          ]
         }
       ]
     },
@@ -14269,7 +16781,9 @@
         {
           "type": "paragraph",
           "subtype": "usfm:x",
-          "content": ["i"]
+          "content": [
+            "i"
+          ]
         }
       ]
     },
@@ -14279,7 +16793,9 @@
         {
           "type": "paragraph",
           "subtype": "usfm:x",
-          "content": ["j"]
+          "content": [
+            "j"
+          ]
         }
       ]
     },
@@ -14289,7 +16805,9 @@
         {
           "type": "paragraph",
           "subtype": "usfm:x",
-          "content": ["k"]
+          "content": [
+            "k"
+          ]
         }
       ]
     },
@@ -14299,7 +16817,9 @@
         {
           "type": "paragraph",
           "subtype": "usfm:x",
-          "content": ["l"]
+          "content": [
+            "l"
+          ]
         }
       ]
     },
@@ -14309,7 +16829,9 @@
         {
           "type": "paragraph",
           "subtype": "usfm:x",
-          "content": ["m"]
+          "content": [
+            "m"
+          ]
         }
       ]
     },
@@ -14319,7 +16841,9 @@
         {
           "type": "paragraph",
           "subtype": "usfm:x",
-          "content": ["n"]
+          "content": [
+            "n"
+          ]
         }
       ]
     },
@@ -14329,7 +16853,9 @@
         {
           "type": "paragraph",
           "subtype": "usfm:x",
-          "content": ["o"]
+          "content": [
+            "o"
+          ]
         }
       ]
     },
@@ -14339,7 +16865,9 @@
         {
           "type": "paragraph",
           "subtype": "usfm:x",
-          "content": ["p"]
+          "content": [
+            "p"
+          ]
         }
       ]
     },
@@ -14349,7 +16877,9 @@
         {
           "type": "paragraph",
           "subtype": "usfm:x",
-          "content": ["q"]
+          "content": [
+            "q"
+          ]
         }
       ]
     },
@@ -14359,7 +16889,9 @@
         {
           "type": "paragraph",
           "subtype": "usfm:x",
-          "content": ["r"]
+          "content": [
+            "r"
+          ]
         }
       ]
     },
@@ -14369,7 +16901,9 @@
         {
           "type": "paragraph",
           "subtype": "usfm:x",
-          "content": ["s"]
+          "content": [
+            "s"
+          ]
         }
       ]
     },
@@ -14379,7 +16913,9 @@
         {
           "type": "paragraph",
           "subtype": "usfm:x",
-          "content": ["t"]
+          "content": [
+            "t"
+          ]
         }
       ]
     },
@@ -14389,7 +16925,9 @@
         {
           "type": "paragraph",
           "subtype": "usfm:x",
-          "content": ["u"]
+          "content": [
+            "u"
+          ]
         }
       ]
     },
@@ -14399,7 +16937,9 @@
         {
           "type": "paragraph",
           "subtype": "usfm:x",
-          "content": ["a"]
+          "content": [
+            "a"
+          ]
         }
       ]
     },
@@ -14409,7 +16949,9 @@
         {
           "type": "paragraph",
           "subtype": "usfm:x",
-          "content": ["b"]
+          "content": [
+            "b"
+          ]
         }
       ]
     },
@@ -14419,7 +16961,9 @@
         {
           "type": "paragraph",
           "subtype": "usfm:x",
-          "content": ["c"]
+          "content": [
+            "c"
+          ]
         }
       ]
     },
@@ -14429,7 +16973,9 @@
         {
           "type": "paragraph",
           "subtype": "usfm:x",
-          "content": ["d"]
+          "content": [
+            "d"
+          ]
         }
       ]
     },
@@ -14439,7 +16985,9 @@
         {
           "type": "paragraph",
           "subtype": "usfm:x",
-          "content": ["e"]
+          "content": [
+            "e"
+          ]
         }
       ]
     },
@@ -14449,7 +16997,9 @@
         {
           "type": "paragraph",
           "subtype": "usfm:x",
-          "content": ["f"]
+          "content": [
+            "f"
+          ]
         }
       ]
     },
@@ -14459,7 +17009,9 @@
         {
           "type": "paragraph",
           "subtype": "usfm:x",
-          "content": ["g"]
+          "content": [
+            "g"
+          ]
         }
       ]
     },
@@ -14469,7 +17021,9 @@
         {
           "type": "paragraph",
           "subtype": "usfm:x",
-          "content": ["h"]
+          "content": [
+            "h"
+          ]
         }
       ]
     },
@@ -14479,7 +17033,9 @@
         {
           "type": "paragraph",
           "subtype": "usfm:x",
-          "content": ["i"]
+          "content": [
+            "i"
+          ]
         }
       ]
     },
@@ -14489,7 +17045,9 @@
         {
           "type": "paragraph",
           "subtype": "usfm:x",
-          "content": ["j"]
+          "content": [
+            "j"
+          ]
         }
       ]
     },
@@ -14499,7 +17057,9 @@
         {
           "type": "paragraph",
           "subtype": "usfm:x",
-          "content": ["k"]
+          "content": [
+            "k"
+          ]
         }
       ]
     },
@@ -14509,7 +17069,9 @@
         {
           "type": "paragraph",
           "subtype": "usfm:x",
-          "content": ["l"]
+          "content": [
+            "l"
+          ]
         }
       ]
     },
@@ -14519,7 +17081,9 @@
         {
           "type": "paragraph",
           "subtype": "usfm:x",
-          "content": ["m"]
+          "content": [
+            "m"
+          ]
         }
       ]
     },
@@ -14529,7 +17093,9 @@
         {
           "type": "paragraph",
           "subtype": "usfm:x",
-          "content": ["n"]
+          "content": [
+            "n"
+          ]
         }
       ]
     },
@@ -14539,7 +17105,9 @@
         {
           "type": "paragraph",
           "subtype": "usfm:x",
-          "content": ["o"]
+          "content": [
+            "o"
+          ]
         }
       ]
     },
@@ -14549,7 +17117,9 @@
         {
           "type": "paragraph",
           "subtype": "usfm:x",
-          "content": ["p"]
+          "content": [
+            "p"
+          ]
         }
       ]
     },
@@ -14559,7 +17129,9 @@
         {
           "type": "paragraph",
           "subtype": "usfm:x",
-          "content": ["q"]
+          "content": [
+            "q"
+          ]
         }
       ]
     },
@@ -14569,7 +17141,9 @@
         {
           "type": "paragraph",
           "subtype": "usfm:x",
-          "content": ["r"]
+          "content": [
+            "r"
+          ]
         }
       ]
     },
@@ -14579,7 +17153,9 @@
         {
           "type": "paragraph",
           "subtype": "usfm:x",
-          "content": ["s"]
+          "content": [
+            "s"
+          ]
         }
       ]
     },
@@ -14589,7 +17165,9 @@
         {
           "type": "paragraph",
           "subtype": "usfm:x",
-          "content": ["t"]
+          "content": [
+            "t"
+          ]
         }
       ]
     },
@@ -14599,7 +17177,9 @@
         {
           "type": "paragraph",
           "subtype": "usfm:x",
-          "content": ["u"]
+          "content": [
+            "u"
+          ]
         }
       ]
     },
@@ -14609,7 +17189,9 @@
         {
           "type": "paragraph",
           "subtype": "usfm:x",
-          "content": ["v"]
+          "content": [
+            "v"
+          ]
         }
       ]
     },
@@ -14619,7 +17201,9 @@
         {
           "type": "paragraph",
           "subtype": "usfm:x",
-          "content": ["w"]
+          "content": [
+            "w"
+          ]
         }
       ]
     },
@@ -14629,7 +17213,9 @@
         {
           "type": "paragraph",
           "subtype": "usfm:x",
-          "content": ["x"]
+          "content": [
+            "x"
+          ]
         }
       ]
     },
@@ -14639,7 +17225,9 @@
         {
           "type": "paragraph",
           "subtype": "usfm:x",
-          "content": ["y"]
+          "content": [
+            "y"
+          ]
         }
       ]
     },
@@ -14649,7 +17237,9 @@
         {
           "type": "paragraph",
           "subtype": "usfm:x",
-          "content": ["z"]
+          "content": [
+            "z"
+          ]
         }
       ]
     },
@@ -14659,7 +17249,9 @@
         {
           "type": "paragraph",
           "subtype": "usfm:x",
-          "content": ["a"]
+          "content": [
+            "a"
+          ]
         }
       ]
     },
@@ -14669,7 +17261,9 @@
         {
           "type": "paragraph",
           "subtype": "usfm:x",
-          "content": ["b"]
+          "content": [
+            "b"
+          ]
         }
       ]
     },
@@ -14679,7 +17273,9 @@
         {
           "type": "paragraph",
           "subtype": "usfm:x",
-          "content": ["c"]
+          "content": [
+            "c"
+          ]
         }
       ]
     },
@@ -14689,7 +17285,9 @@
         {
           "type": "paragraph",
           "subtype": "usfm:x",
-          "content": ["d"]
+          "content": [
+            "d"
+          ]
         }
       ]
     },
@@ -14699,7 +17297,9 @@
         {
           "type": "paragraph",
           "subtype": "usfm:x",
-          "content": ["e"]
+          "content": [
+            "e"
+          ]
         }
       ]
     },
@@ -14709,7 +17309,9 @@
         {
           "type": "paragraph",
           "subtype": "usfm:x",
-          "content": ["f"]
+          "content": [
+            "f"
+          ]
         }
       ]
     },
@@ -14719,7 +17321,9 @@
         {
           "type": "paragraph",
           "subtype": "usfm:x",
-          "content": ["g"]
+          "content": [
+            "g"
+          ]
         }
       ]
     },
@@ -14729,7 +17333,9 @@
         {
           "type": "paragraph",
           "subtype": "usfm:x",
-          "content": ["h"]
+          "content": [
+            "h"
+          ]
         }
       ]
     },
@@ -14739,7 +17345,9 @@
         {
           "type": "paragraph",
           "subtype": "usfm:x",
-          "content": ["a"]
+          "content": [
+            "a"
+          ]
         }
       ]
     },
@@ -14749,7 +17357,9 @@
         {
           "type": "paragraph",
           "subtype": "usfm:x",
-          "content": ["b"]
+          "content": [
+            "b"
+          ]
         }
       ]
     },
@@ -14759,7 +17369,9 @@
         {
           "type": "paragraph",
           "subtype": "usfm:x",
-          "content": ["c"]
+          "content": [
+            "c"
+          ]
         }
       ]
     },
@@ -14769,7 +17381,9 @@
         {
           "type": "paragraph",
           "subtype": "usfm:x",
-          "content": ["d"]
+          "content": [
+            "d"
+          ]
         }
       ]
     },
@@ -14779,7 +17393,9 @@
         {
           "type": "paragraph",
           "subtype": "usfm:x",
-          "content": ["e"]
+          "content": [
+            "e"
+          ]
         }
       ]
     },
@@ -14789,7 +17405,9 @@
         {
           "type": "paragraph",
           "subtype": "usfm:x",
-          "content": ["f"]
+          "content": [
+            "f"
+          ]
         }
       ]
     },
@@ -14799,7 +17417,9 @@
         {
           "type": "paragraph",
           "subtype": "usfm:x",
-          "content": ["g"]
+          "content": [
+            "g"
+          ]
         }
       ]
     },
@@ -14809,7 +17429,9 @@
         {
           "type": "paragraph",
           "subtype": "usfm:x",
-          "content": ["h"]
+          "content": [
+            "h"
+          ]
         }
       ]
     },
@@ -14819,7 +17441,9 @@
         {
           "type": "paragraph",
           "subtype": "usfm:x",
-          "content": ["i"]
+          "content": [
+            "i"
+          ]
         }
       ]
     },
@@ -14829,7 +17453,9 @@
         {
           "type": "paragraph",
           "subtype": "usfm:x",
-          "content": ["j"]
+          "content": [
+            "j"
+          ]
         }
       ]
     },
@@ -14839,7 +17465,9 @@
         {
           "type": "paragraph",
           "subtype": "usfm:x",
-          "content": ["k"]
+          "content": [
+            "k"
+          ]
         }
       ]
     },
@@ -14849,7 +17477,9 @@
         {
           "type": "paragraph",
           "subtype": "usfm:x",
-          "content": ["l"]
+          "content": [
+            "l"
+          ]
         }
       ]
     },
@@ -14859,7 +17489,9 @@
         {
           "type": "paragraph",
           "subtype": "usfm:x",
-          "content": ["m"]
+          "content": [
+            "m"
+          ]
         }
       ]
     },
@@ -14869,7 +17501,9 @@
         {
           "type": "paragraph",
           "subtype": "usfm:x",
-          "content": ["n"]
+          "content": [
+            "n"
+          ]
         }
       ]
     },
@@ -14879,7 +17513,9 @@
         {
           "type": "paragraph",
           "subtype": "usfm:x",
-          "content": ["o"]
+          "content": [
+            "o"
+          ]
         }
       ]
     },
@@ -14889,7 +17525,9 @@
         {
           "type": "paragraph",
           "subtype": "usfm:x",
-          "content": ["p"]
+          "content": [
+            "p"
+          ]
         }
       ]
     },
@@ -14899,7 +17537,9 @@
         {
           "type": "paragraph",
           "subtype": "usfm:x",
-          "content": ["q"]
+          "content": [
+            "q"
+          ]
         }
       ]
     },
@@ -14909,7 +17549,9 @@
         {
           "type": "paragraph",
           "subtype": "usfm:x",
-          "content": ["r"]
+          "content": [
+            "r"
+          ]
         }
       ]
     },
@@ -14919,7 +17561,9 @@
         {
           "type": "paragraph",
           "subtype": "usfm:x",
-          "content": ["s"]
+          "content": [
+            "s"
+          ]
         }
       ]
     },
@@ -14929,7 +17573,9 @@
         {
           "type": "paragraph",
           "subtype": "usfm:x",
-          "content": ["t"]
+          "content": [
+            "t"
+          ]
         }
       ]
     },
@@ -14939,7 +17585,9 @@
         {
           "type": "paragraph",
           "subtype": "usfm:x",
-          "content": ["u"]
+          "content": [
+            "u"
+          ]
         }
       ]
     },
@@ -14949,7 +17597,9 @@
         {
           "type": "paragraph",
           "subtype": "usfm:x",
-          "content": ["v"]
+          "content": [
+            "v"
+          ]
         }
       ]
     },
@@ -14959,7 +17609,9 @@
         {
           "type": "paragraph",
           "subtype": "usfm:x",
-          "content": ["w"]
+          "content": [
+            "w"
+          ]
         }
       ]
     },
@@ -14969,7 +17621,9 @@
         {
           "type": "paragraph",
           "subtype": "usfm:x",
-          "content": ["x"]
+          "content": [
+            "x"
+          ]
         }
       ]
     },
@@ -14979,7 +17633,9 @@
         {
           "type": "paragraph",
           "subtype": "usfm:x",
-          "content": ["y"]
+          "content": [
+            "y"
+          ]
         }
       ]
     },
@@ -14989,7 +17645,9 @@
         {
           "type": "paragraph",
           "subtype": "usfm:x",
-          "content": ["z"]
+          "content": [
+            "z"
+          ]
         }
       ]
     },
@@ -14999,7 +17657,9 @@
         {
           "type": "paragraph",
           "subtype": "usfm:x",
-          "content": ["a"]
+          "content": [
+            "a"
+          ]
         }
       ]
     },
@@ -15009,7 +17669,9 @@
         {
           "type": "paragraph",
           "subtype": "usfm:x",
-          "content": ["a"]
+          "content": [
+            "a"
+          ]
         }
       ]
     },
@@ -15019,7 +17681,9 @@
         {
           "type": "paragraph",
           "subtype": "usfm:x",
-          "content": ["b"]
+          "content": [
+            "b"
+          ]
         }
       ]
     },
@@ -15029,7 +17693,9 @@
         {
           "type": "paragraph",
           "subtype": "usfm:x",
-          "content": ["c"]
+          "content": [
+            "c"
+          ]
         }
       ]
     },
@@ -15039,7 +17705,9 @@
         {
           "type": "paragraph",
           "subtype": "usfm:x",
-          "content": ["d"]
+          "content": [
+            "d"
+          ]
         }
       ]
     },
@@ -15049,7 +17717,9 @@
         {
           "type": "paragraph",
           "subtype": "usfm:x",
-          "content": ["e"]
+          "content": [
+            "e"
+          ]
         }
       ]
     },
@@ -15059,7 +17729,9 @@
         {
           "type": "paragraph",
           "subtype": "usfm:x",
-          "content": ["f"]
+          "content": [
+            "f"
+          ]
         }
       ]
     },
@@ -15069,7 +17741,9 @@
         {
           "type": "paragraph",
           "subtype": "usfm:x",
-          "content": ["g"]
+          "content": [
+            "g"
+          ]
         }
       ]
     },
@@ -15079,7 +17753,9 @@
         {
           "type": "paragraph",
           "subtype": "usfm:x",
-          "content": ["h"]
+          "content": [
+            "h"
+          ]
         }
       ]
     },
@@ -15089,7 +17765,9 @@
         {
           "type": "paragraph",
           "subtype": "usfm:x",
-          "content": ["i"]
+          "content": [
+            "i"
+          ]
         }
       ]
     },
@@ -15099,7 +17777,9 @@
         {
           "type": "paragraph",
           "subtype": "usfm:x",
-          "content": ["j"]
+          "content": [
+            "j"
+          ]
         }
       ]
     },
@@ -15109,7 +17789,9 @@
         {
           "type": "paragraph",
           "subtype": "usfm:x",
-          "content": ["k"]
+          "content": [
+            "k"
+          ]
         }
       ]
     },
@@ -15119,7 +17801,9 @@
         {
           "type": "paragraph",
           "subtype": "usfm:x",
-          "content": ["l"]
+          "content": [
+            "l"
+          ]
         }
       ]
     },
@@ -15129,7 +17813,9 @@
         {
           "type": "paragraph",
           "subtype": "usfm:x",
-          "content": ["m"]
+          "content": [
+            "m"
+          ]
         }
       ]
     },
@@ -15139,7 +17825,9 @@
         {
           "type": "paragraph",
           "subtype": "usfm:x",
-          "content": ["n"]
+          "content": [
+            "n"
+          ]
         }
       ]
     },
@@ -15149,7 +17837,9 @@
         {
           "type": "paragraph",
           "subtype": "usfm:x",
-          "content": ["o"]
+          "content": [
+            "o"
+          ]
         }
       ]
     },
@@ -15159,7 +17849,9 @@
         {
           "type": "paragraph",
           "subtype": "usfm:x",
-          "content": ["p"]
+          "content": [
+            "p"
+          ]
         }
       ]
     },
@@ -15169,7 +17861,9 @@
         {
           "type": "paragraph",
           "subtype": "usfm:x",
-          "content": ["q"]
+          "content": [
+            "q"
+          ]
         }
       ]
     },
@@ -15179,7 +17873,9 @@
         {
           "type": "paragraph",
           "subtype": "usfm:x",
-          "content": ["r"]
+          "content": [
+            "r"
+          ]
         }
       ]
     },
@@ -15189,7 +17885,9 @@
         {
           "type": "paragraph",
           "subtype": "usfm:x",
-          "content": ["s"]
+          "content": [
+            "s"
+          ]
         }
       ]
     },
@@ -15205,14 +17903,20 @@
               "subtype": "note_caller",
               "target": "ZDYxOWQ3Mjgt"
             },
-            " ", {
+            " ",
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["1.2 "]
-            }, {
+              "content": [
+                "1.2 "
+              ]
+            },
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["Mal 3:1. Mt 11:10. Lu 7:27."]
+              "content": [
+                "Mal 3:1. Mt 11:10. Lu 7:27."
+              ]
             }
           ]
         }
@@ -15230,14 +17934,20 @@
               "subtype": "note_caller",
               "target": "ZTkyMWIzMzEt"
             },
-            " ", {
+            " ",
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["1.3 "]
-            }, {
+              "content": [
+                "1.3 "
+              ]
+            },
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["És 40:3. Mt 3:3. Lu 3:4. Jn 1:23."]
+              "content": [
+                "És 40:3. Mt 3:3. Lu 3:4. Jn 1:23."
+              ]
             }
           ]
         }
@@ -15255,14 +17965,20 @@
               "subtype": "note_caller",
               "target": "NTQ5MTQ2ZjQt"
             },
-            " ", {
+            " ",
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["1.4 "]
-            }, {
+              "content": [
+                "1.4 "
+              ]
+            },
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["Mt 3:1. Lu 3:3. Jn 3:23."]
+              "content": [
+                "Mt 3:1. Lu 3:3. Jn 3:23."
+              ]
             }
           ]
         }
@@ -15280,14 +17996,20 @@
               "subtype": "note_caller",
               "target": "ZTU1ZWM2NWIt"
             },
-            " ", {
+            " ",
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["1.5 "]
-            }, {
+              "content": [
+                "1.5 "
+              ]
+            },
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["Mt 3:5. Lu 3:7."]
+              "content": [
+                "Mt 3:5. Lu 3:7."
+              ]
             }
           ]
         }
@@ -15305,14 +18027,20 @@
               "subtype": "note_caller",
               "target": "YTU5OWVlNjIt"
             },
-            " ", {
+            " ",
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["1.6 "]
-            }, {
+              "content": [
+                "1.6 "
+              ]
+            },
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["2 R 1:8. Mt 3:4."]
+              "content": [
+                "2 R 1:8. Mt 3:4."
+              ]
             }
           ]
         }
@@ -15330,14 +18058,20 @@
               "subtype": "note_caller",
               "target": "NzcwODA3ZTct"
             },
-            " ", {
+            " ",
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["1.6 "]
-            }, {
+              "content": [
+                "1.6 "
+              ]
+            },
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["Lé 11:22."]
+              "content": [
+                "Lé 11:22."
+              ]
             }
           ]
         }
@@ -15355,14 +18089,20 @@
               "subtype": "note_caller",
               "target": "YWZmZjQ3MmYt"
             },
-            " ", {
+            " ",
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["1.7 "]
-            }, {
+              "content": [
+                "1.7 "
+              ]
+            },
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["Mt 3:11. Lu 3:16. Jn 1:27."]
+              "content": [
+                "Mt 3:11. Lu 3:16. Jn 1:27."
+              ]
             }
           ]
         }
@@ -15380,14 +18120,20 @@
               "subtype": "note_caller",
               "target": "N2JmZDRhNjEt"
             },
-            " ", {
+            " ",
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["1.8 "]
-            }, {
+              "content": [
+                "1.8 "
+              ]
+            },
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["Mt 3:11. Ac 1:5; 11:16; 19:4."]
+              "content": [
+                "Mt 3:11. Ac 1:5; 11:16; 19:4."
+              ]
             }
           ]
         }
@@ -15405,14 +18151,20 @@
               "subtype": "note_caller",
               "target": "MTdiZmQ4NmEt"
             },
-            " ", {
+            " ",
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["1.8 "]
-            }, {
+              "content": [
+                "1.8 "
+              ]
+            },
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["És 44:3. Joë 2:28. Ac 2:4; 11:15."]
+              "content": [
+                "És 44:3. Joë 2:28. Ac 2:4; 11:15."
+              ]
             }
           ]
         }
@@ -15430,14 +18182,20 @@
               "subtype": "note_caller",
               "target": "OTVmMGIzNGIt"
             },
-            " ", {
+            " ",
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["1.10 "]
-            }, {
+              "content": [
+                "1.10 "
+              ]
+            },
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["Mt 3:16. Lu 3:21. Jn 1:32."]
+              "content": [
+                "Mt 3:16. Lu 3:21. Jn 1:32."
+              ]
             }
           ]
         }
@@ -15455,14 +18213,20 @@
               "subtype": "note_caller",
               "target": "NjJkYzg0ZDQt"
             },
-            " ", {
+            " ",
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["1.11 "]
-            }, {
+              "content": [
+                "1.11 "
+              ]
+            },
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["Ps 2:7. És 42:1. Mt 3:17; 17:5. Mc 9:7. Lu 3:22; 9:35. Col 1:13. 2 Pi 1:17."]
+              "content": [
+                "Ps 2:7. És 42:1. Mt 3:17; 17:5. Mc 9:7. Lu 3:22; 9:35. Col 1:13. 2 Pi 1:17."
+              ]
             }
           ]
         }
@@ -15480,14 +18244,20 @@
               "subtype": "note_caller",
               "target": "Y2I4ZTEwYWMt"
             },
-            " ", {
+            " ",
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["1.12 "]
-            }, {
+              "content": [
+                "1.12 "
+              ]
+            },
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["Mt 4:1. Lu 4:1."]
+              "content": [
+                "Mt 4:1. Lu 4:1."
+              ]
             }
           ]
         }
@@ -15505,14 +18275,20 @@
               "subtype": "note_caller",
               "target": "OTM3NjA4MmQt"
             },
-            " ", {
+            " ",
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["1.14 "]
-            }, {
+              "content": [
+                "1.14 "
+              ]
+            },
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["Mt 4:12. Lu 4:14. Jn 4:43."]
+              "content": [
+                "Mt 4:12. Lu 4:14. Jn 4:43."
+              ]
             }
           ]
         }
@@ -15530,14 +18306,20 @@
               "subtype": "note_caller",
               "target": "NDRhYmQ0NGEt"
             },
-            " ", {
+            " ",
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["1.15 "]
-            }, {
+              "content": [
+                "1.15 "
+              ]
+            },
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["És 56:1."]
+              "content": [
+                "És 56:1."
+              ]
             }
           ]
         }
@@ -15555,14 +18337,20 @@
               "subtype": "note_caller",
               "target": "MmQ3NDI0NWUt"
             },
-            " ", {
+            " ",
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["1.16 "]
-            }, {
+              "content": [
+                "1.16 "
+              ]
+            },
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["Mt 4:18."]
+              "content": [
+                "Mt 4:18."
+              ]
             }
           ]
         }
@@ -15580,14 +18368,20 @@
               "subtype": "note_caller",
               "target": "NTYyZWQ2NjUt"
             },
-            " ", {
+            " ",
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["1.17 "]
-            }, {
+              "content": [
+                "1.17 "
+              ]
+            },
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["És 16:16. Éz 47:10."]
+              "content": [
+                "És 16:16. Éz 47:10."
+              ]
             }
           ]
         }
@@ -15605,14 +18399,20 @@
               "subtype": "note_caller",
               "target": "N2UwYTYyNDUt"
             },
-            " ", {
+            " ",
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["1.18 "]
-            }, {
+              "content": [
+                "1.18 "
+              ]
+            },
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["Mt 19:27. Mc 10:28. Lu 5:11; 18:28."]
+              "content": [
+                "Mt 19:27. Mc 10:28. Lu 5:11; 18:28."
+              ]
             }
           ]
         }
@@ -15630,14 +18430,20 @@
               "subtype": "note_caller",
               "target": "MDdlNjM1NGQt"
             },
-            " ", {
+            " ",
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["1.19 "]
-            }, {
+              "content": [
+                "1.19 "
+              ]
+            },
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["Mt 4:21."]
+              "content": [
+                "Mt 4:21."
+              ]
             }
           ]
         }
@@ -15655,14 +18461,20 @@
               "subtype": "note_caller",
               "target": "YTA4NjgyNmEt"
             },
-            " ", {
+            " ",
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["1.21 "]
-            }, {
+              "content": [
+                "1.21 "
+              ]
+            },
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["Mt 4:13. Lu 4:31."]
+              "content": [
+                "Mt 4:13. Lu 4:31."
+              ]
             }
           ]
         }
@@ -15680,14 +18492,20 @@
               "subtype": "note_caller",
               "target": "MzEyYjBiMDAt"
             },
-            " ", {
+            " ",
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["1.22 "]
-            }, {
+              "content": [
+                "1.22 "
+              ]
+            },
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["Mt 7:28. Lu 4:32."]
+              "content": [
+                "Mt 7:28. Lu 4:32."
+              ]
             }
           ]
         }
@@ -15705,14 +18523,20 @@
               "subtype": "note_caller",
               "target": "YjA0NThhNWIt"
             },
-            " ", {
+            " ",
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["1.23 "]
-            }, {
+              "content": [
+                "1.23 "
+              ]
+            },
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["Lu 4:33."]
+              "content": [
+                "Lu 4:33."
+              ]
             }
           ]
         }
@@ -15730,14 +18554,20 @@
               "subtype": "note_caller",
               "target": "NjYzMDVhZGEt"
             },
-            " ", {
+            " ",
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["1.29 "]
-            }, {
+              "content": [
+                "1.29 "
+              ]
+            },
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["Mt 8:14. Lu 4:38."]
+              "content": [
+                "Mt 8:14. Lu 4:38."
+              ]
             }
           ]
         }
@@ -15755,14 +18585,20 @@
               "subtype": "note_caller",
               "target": "YjFmOWRhN2It"
             },
-            " ", {
+            " ",
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["1.32 "]
-            }, {
+              "content": [
+                "1.32 "
+              ]
+            },
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["Mt 8:16. Lu 4:40."]
+              "content": [
+                "Mt 8:16. Lu 4:40."
+              ]
             }
           ]
         }
@@ -15780,14 +18616,20 @@
               "subtype": "note_caller",
               "target": "NTZhZGVkYTAt"
             },
-            " ", {
+            " ",
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["1.35 "]
-            }, {
+              "content": [
+                "1.35 "
+              ]
+            },
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["Lu 4:12."]
+              "content": [
+                "Lu 4:12."
+              ]
             }
           ]
         }
@@ -15805,14 +18647,20 @@
               "subtype": "note_caller",
               "target": "ZWEzNjQ0NzIt"
             },
-            " ", {
+            " ",
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["1.35 "]
-            }, {
+              "content": [
+                "1.35 "
+              ]
+            },
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["Mt 14:23."]
+              "content": [
+                "Mt 14:23."
+              ]
             }
           ]
         }
@@ -15830,14 +18678,20 @@
               "subtype": "note_caller",
               "target": "YzQ2NGFkMTUt"
             },
-            " ", {
+            " ",
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["1.38 "]
-            }, {
+              "content": [
+                "1.38 "
+              ]
+            },
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["Lu 4:43."]
+              "content": [
+                "Lu 4:43."
+              ]
             }
           ]
         }
@@ -15855,14 +18709,20 @@
               "subtype": "note_caller",
               "target": "NjY2Y2I5OWIt"
             },
-            " ", {
+            " ",
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["1.38 "]
-            }, {
+              "content": [
+                "1.38 "
+              ]
+            },
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["És 61:1. Lu 4:18."]
+              "content": [
+                "És 61:1. Lu 4:18."
+              ]
             }
           ]
         }
@@ -15880,14 +18740,20 @@
               "subtype": "note_caller",
               "target": "MDg4MmFlZjAt"
             },
-            " ", {
+            " ",
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["1.40 "]
-            }, {
+              "content": [
+                "1.40 "
+              ]
+            },
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["Mt 8:2. Lu 5:12."]
+              "content": [
+                "Mt 8:2. Lu 5:12."
+              ]
             }
           ]
         }
@@ -15905,14 +18771,20 @@
               "subtype": "note_caller",
               "target": "YjVjM2Q4MDQt"
             },
-            " ", {
+            " ",
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["1.44 "]
-            }, {
+              "content": [
+                "1.44 "
+              ]
+            },
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["Lé 13:2; 14:1."]
+              "content": [
+                "Lé 13:2; 14:1."
+              ]
             }
           ]
         }
@@ -15930,14 +18802,20 @@
               "subtype": "note_caller",
               "target": "ZWRmMzE1YWQt"
             },
-            " ", {
+            " ",
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["2.1 "]
-            }, {
+              "content": [
+                "2.1 "
+              ]
+            },
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["Mt 9:1. Lu 5:17."]
+              "content": [
+                "Mt 9:1. Lu 5:17."
+              ]
             }
           ]
         }
@@ -15955,14 +18833,20 @@
               "subtype": "note_caller",
               "target": "ODJjMGRjMGYt"
             },
-            " ", {
+            " ",
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["2.3 "]
-            }, {
+              "content": [
+                "2.3 "
+              ]
+            },
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["Mt 9:1. Lu 5:18."]
+              "content": [
+                "Mt 9:1. Lu 5:18."
+              ]
             }
           ]
         }
@@ -15980,14 +18864,20 @@
               "subtype": "note_caller",
               "target": "MTJiZjZhNmIt"
             },
-            " ", {
+            " ",
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["2.7 "]
-            }, {
+              "content": [
+                "2.7 "
+              ]
+            },
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["Ps 32:5; 51:3. És 43:25."]
+              "content": [
+                "Ps 32:5; 51:3. És 43:25."
+              ]
             }
           ]
         }
@@ -16005,14 +18895,20 @@
               "subtype": "note_caller",
               "target": "YzhkNTA4MmIt"
             },
-            " ", {
+            " ",
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["2.13 "]
-            }, {
+              "content": [
+                "2.13 "
+              ]
+            },
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["Mt 9:9. Lu 5:27."]
+              "content": [
+                "Mt 9:9. Lu 5:27."
+              ]
             }
           ]
         }
@@ -16030,14 +18926,20 @@
               "subtype": "note_caller",
               "target": "OTQwZjQ4OTQt"
             },
-            " ", {
+            " ",
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["2.17 "]
-            }, {
+              "content": [
+                "2.17 "
+              ]
+            },
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["Mt 9:13; 21:31. Lu 5:32; 19:10. 1 Ti 1:15."]
+              "content": [
+                "Mt 9:13; 21:31. Lu 5:32; 19:10. 1 Ti 1:15."
+              ]
             }
           ]
         }
@@ -16055,14 +18957,20 @@
               "subtype": "note_caller",
               "target": "MjM4Mzc1NTMt"
             },
-            " ", {
+            " ",
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["2.18 "]
-            }, {
+              "content": [
+                "2.18 "
+              ]
+            },
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["Mt 9:14. Lu 5:33."]
+              "content": [
+                "Mt 9:14. Lu 5:33."
+              ]
             }
           ]
         }
@@ -16080,14 +18988,20 @@
               "subtype": "note_caller",
               "target": "OTkyOTkxMWQt"
             },
-            " ", {
+            " ",
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["2.19 "]
-            }, {
+              "content": [
+                "2.19 "
+              ]
+            },
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["És 62:5. 2 Co 11:2."]
+              "content": [
+                "És 62:5. 2 Co 11:2."
+              ]
             }
           ]
         }
@@ -16105,14 +19019,20 @@
               "subtype": "note_caller",
               "target": "ZGZiYTg4Mjct"
             },
-            " ", {
+            " ",
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["2.22 "]
-            }, {
+              "content": [
+                "2.22 "
+              ]
+            },
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["Mt 9:17."]
+              "content": [
+                "Mt 9:17."
+              ]
             }
           ]
         }
@@ -16130,14 +19050,20 @@
               "subtype": "note_caller",
               "target": "ZmRhZWJjNWMt"
             },
-            " ", {
+            " ",
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["2.23 "]
-            }, {
+              "content": [
+                "2.23 "
+              ]
+            },
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["De 23:25. Mt 12:1. Lu 6:1."]
+              "content": [
+                "De 23:25. Mt 12:1. Lu 6:1."
+              ]
             }
           ]
         }
@@ -16155,14 +19081,20 @@
               "subtype": "note_caller",
               "target": "NmZhYWM4OGQt"
             },
-            " ", {
+            " ",
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["2.24 "]
-            }, {
+              "content": [
+                "2.24 "
+              ]
+            },
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["Ex 20:10."]
+              "content": [
+                "Ex 20:10."
+              ]
             }
           ]
         }
@@ -16180,14 +19112,20 @@
               "subtype": "note_caller",
               "target": "YzY2ZjE2YTgt"
             },
-            " ", {
+            " ",
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["2.25 "]
-            }, {
+              "content": [
+                "2.25 "
+              ]
+            },
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["1 S 21:6."]
+              "content": [
+                "1 S 21:6."
+              ]
             }
           ]
         }
@@ -16205,14 +19143,20 @@
               "subtype": "note_caller",
               "target": "NWE3MTAzM2Et"
             },
-            " ", {
+            " ",
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["2.26 "]
-            }, {
+              "content": [
+                "2.26 "
+              ]
+            },
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["Lé 24:9."]
+              "content": [
+                "Lé 24:9."
+              ]
             }
           ]
         }
@@ -16230,14 +19174,20 @@
               "subtype": "note_caller",
               "target": "Zjk4ZmRmNDct"
             },
-            " ", {
+            " ",
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["2.28 "]
-            }, {
+              "content": [
+                "2.28 "
+              ]
+            },
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["Mt 12:8. Lu 6:5."]
+              "content": [
+                "Mt 12:8. Lu 6:5."
+              ]
             }
           ]
         }
@@ -16255,14 +19205,20 @@
               "subtype": "note_caller",
               "target": "ZTFiMDEyMzEt"
             },
-            " ", {
+            " ",
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["3.1 "]
-            }, {
+              "content": [
+                "3.1 "
+              ]
+            },
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["Mt 12:9. Lu 6:6."]
+              "content": [
+                "Mt 12:9. Lu 6:6."
+              ]
             }
           ]
         }
@@ -16280,14 +19236,20 @@
               "subtype": "note_caller",
               "target": "NjYxY2IyMzQt"
             },
-            " ", {
+            " ",
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["3.5 "]
-            }, {
+              "content": [
+                "3.5 "
+              ]
+            },
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["1 R 13:6."]
+              "content": [
+                "1 R 13:6."
+              ]
             }
           ]
         }
@@ -16305,14 +19267,20 @@
               "subtype": "note_caller",
               "target": "NWJhMGU4NGIt"
             },
-            " ", {
+            " ",
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["3.6 "]
-            }, {
+              "content": [
+                "3.6 "
+              ]
+            },
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["Mt 12:14. Jn 10:39; 11:53."]
+              "content": [
+                "Mt 12:14. Jn 10:39; 11:53."
+              ]
             }
           ]
         }
@@ -16330,14 +19298,20 @@
               "subtype": "note_caller",
               "target": "ZWQxY2NjZGMt"
             },
-            " ", {
+            " ",
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["3.7 "]
-            }, {
+              "content": [
+                "3.7 "
+              ]
+            },
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["Mt 4:25. Lu 6:17."]
+              "content": [
+                "Mt 4:25. Lu 6:17."
+              ]
             }
           ]
         }
@@ -16355,14 +19329,20 @@
               "subtype": "note_caller",
               "target": "MDg2MWYxZTEt"
             },
-            " ", {
+            " ",
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["3.13 "]
-            }, {
+              "content": [
+                "3.13 "
+              ]
+            },
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["Mt 10:1. Mc 6:7. Lu 6:13; 9:1."]
+              "content": [
+                "Mt 10:1. Mc 6:7. Lu 6:13; 9:1."
+              ]
             }
           ]
         }
@@ -16380,14 +19360,20 @@
               "subtype": "note_caller",
               "target": "YWQ4ZjU0NGEt"
             },
-            " ", {
+            " ",
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["3.20 "]
-            }, {
+              "content": [
+                "3.20 "
+              ]
+            },
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["Mc 6:31."]
+              "content": [
+                "Mc 6:31."
+              ]
             }
           ]
         }
@@ -16405,14 +19391,20 @@
               "subtype": "note_caller",
               "target": "YzUyNWViY2It"
             },
-            " ", {
+            " ",
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["3.22 "]
-            }, {
+              "content": [
+                "3.22 "
+              ]
+            },
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["Mt 9:34; 12:24. Lu 11:15. Jn 8:48."]
+              "content": [
+                "Mt 9:34; 12:24. Lu 11:15. Jn 8:48."
+              ]
             }
           ]
         }
@@ -16430,14 +19422,20 @@
               "subtype": "note_caller",
               "target": "YWEwNGRhMjEt"
             },
-            " ", {
+            " ",
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["3.23 "]
-            }, {
+              "content": [
+                "3.23 "
+              ]
+            },
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["Mt 12:25."]
+              "content": [
+                "Mt 12:25."
+              ]
             }
           ]
         }
@@ -16455,14 +19453,20 @@
               "subtype": "note_caller",
               "target": "NWYyYzYyYzQt"
             },
-            " ", {
+            " ",
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["3.27 "]
-            }, {
+              "content": [
+                "3.27 "
+              ]
+            },
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["Mt 12:29."]
+              "content": [
+                "Mt 12:29."
+              ]
             }
           ]
         }
@@ -16480,14 +19484,20 @@
               "subtype": "note_caller",
               "target": "NWEyNmE2YjMt"
             },
-            " ", {
+            " ",
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["3.27 "]
-            }, {
+              "content": [
+                "3.27 "
+              ]
+            },
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["Col 2:15."]
+              "content": [
+                "Col 2:15."
+              ]
             }
           ]
         }
@@ -16505,14 +19515,20 @@
               "subtype": "note_caller",
               "target": "ZTIyM2Q5YzUt"
             },
-            " ", {
+            " ",
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["3.28 "]
-            }, {
+              "content": [
+                "3.28 "
+              ]
+            },
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["1 S 2:25. Mt 12:31. Lu 12:10. 1 Jn 5:16."]
+              "content": [
+                "1 S 2:25. Mt 12:31. Lu 12:10. 1 Jn 5:16."
+              ]
             }
           ]
         }
@@ -16530,14 +19546,20 @@
               "subtype": "note_caller",
               "target": "ZDY3MDUxMjQt"
             },
-            " ", {
+            " ",
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["3.29 "]
-            }, {
+              "content": [
+                "3.29 "
+              ]
+            },
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["1 Jn 5:16."]
+              "content": [
+                "1 Jn 5:16."
+              ]
             }
           ]
         }
@@ -16555,14 +19577,20 @@
               "subtype": "note_caller",
               "target": "ZTYwZTAwMzct"
             },
-            " ", {
+            " ",
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["3.31 "]
-            }, {
+              "content": [
+                "3.31 "
+              ]
+            },
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["Mt 12:46. Lu 8:19."]
+              "content": [
+                "Mt 12:46. Lu 8:19."
+              ]
             }
           ]
         }
@@ -16580,14 +19608,20 @@
               "subtype": "note_caller",
               "target": "ZmJlNjVkMzEt"
             },
-            " ", {
+            " ",
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["3.35 "]
-            }, {
+              "content": [
+                "3.35 "
+              ]
+            },
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["Jn 15:14. 2 Co 5:16, 17."]
+              "content": [
+                "Jn 15:14. 2 Co 5:16, 17."
+              ]
             }
           ]
         }
@@ -16605,14 +19639,20 @@
               "subtype": "note_caller",
               "target": "YWFjZWE3Y2Et"
             },
-            " ", {
+            " ",
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["4.1 "]
-            }, {
+              "content": [
+                "4.1 "
+              ]
+            },
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["Mt 13:1. Lu 8:4."]
+              "content": [
+                "Mt 13:1. Lu 8:4."
+              ]
             }
           ]
         }
@@ -16630,14 +19670,20 @@
               "subtype": "note_caller",
               "target": "YjgwNWE5Yzgt"
             },
-            " ", {
+            " ",
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["4.10 "]
-            }, {
+              "content": [
+                "4.10 "
+              ]
+            },
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["Mt 13:10. Lu 8:9."]
+              "content": [
+                "Mt 13:10. Lu 8:9."
+              ]
             }
           ]
         }
@@ -16655,14 +19701,20 @@
               "subtype": "note_caller",
               "target": "NWQyNWQzZTEt"
             },
-            " ", {
+            " ",
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["4.11 "]
-            }, {
+              "content": [
+                "4.11 "
+              ]
+            },
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["Mt 11:25. 2 Co 2:14."]
+              "content": [
+                "Mt 11:25. 2 Co 2:14."
+              ]
             }
           ]
         }
@@ -16680,14 +19732,20 @@
               "subtype": "note_caller",
               "target": "YzM4OWNmMWUt"
             },
-            " ", {
+            " ",
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["4.11 "]
-            }, {
+              "content": [
+                "4.11 "
+              ]
+            },
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["2 Co 3:14."]
+              "content": [
+                "2 Co 3:14."
+              ]
             }
           ]
         }
@@ -16705,14 +19763,20 @@
               "subtype": "note_caller",
               "target": "NTFmMGJhZGYt"
             },
-            " ", {
+            " ",
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["4.12 "]
-            }, {
+              "content": [
+                "4.12 "
+              ]
+            },
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["És 6:9. Mt 13:14. Lu 8:10. Jn 12:40. Ac 28:26. Ro 11:8."]
+              "content": [
+                "És 6:9. Mt 13:14. Lu 8:10. Jn 12:40. Ac 28:26. Ro 11:8."
+              ]
             }
           ]
         }
@@ -16730,14 +19794,20 @@
               "subtype": "note_caller",
               "target": "YTFjMzk5N2Et"
             },
-            " ", {
+            " ",
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["4.14 "]
-            }, {
+              "content": [
+                "4.14 "
+              ]
+            },
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["Mt 13:19. Lu 8:11."]
+              "content": [
+                "Mt 13:19. Lu 8:11."
+              ]
             }
           ]
         }
@@ -16755,14 +19825,20 @@
               "subtype": "note_caller",
               "target": "ZWEwMzEyNDkt"
             },
-            " ", {
+            " ",
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["4.19 "]
-            }, {
+              "content": [
+                "4.19 "
+              ]
+            },
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["Mt 19:23. Mc 10:23. Lu 18:24. 1 Ti 6:9."]
+              "content": [
+                "Mt 19:23. Mc 10:23. Lu 18:24. 1 Ti 6:9."
+              ]
             }
           ]
         }
@@ -16780,14 +19856,20 @@
               "subtype": "note_caller",
               "target": "ZTU0M2ZhN2Et"
             },
-            " ", {
+            " ",
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["4.21 "]
-            }, {
+              "content": [
+                "4.21 "
+              ]
+            },
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["Mt 5:15. Lu 8:16; 11:33."]
+              "content": [
+                "Mt 5:15. Lu 8:16; 11:33."
+              ]
             }
           ]
         }
@@ -16805,14 +19887,20 @@
               "subtype": "note_caller",
               "target": "M2Y1ZDk1YWYt"
             },
-            " ", {
+            " ",
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["4.22 "]
-            }, {
+              "content": [
+                "4.22 "
+              ]
+            },
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["Job 12:22. Mt 10:26. Lu 8:17; 12:2."]
+              "content": [
+                "Job 12:22. Mt 10:26. Lu 8:17; 12:2."
+              ]
             }
           ]
         }
@@ -16830,14 +19918,20 @@
               "subtype": "note_caller",
               "target": "ZDM4MjU4MmUt"
             },
-            " ", {
+            " ",
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["4.24 "]
-            }, {
+              "content": [
+                "4.24 "
+              ]
+            },
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["Mt 7:2. Lu 6:38."]
+              "content": [
+                "Mt 7:2. Lu 6:38."
+              ]
             }
           ]
         }
@@ -16855,14 +19949,20 @@
               "subtype": "note_caller",
               "target": "ZDMzNzEyYTUt"
             },
-            " ", {
+            " ",
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["4.25 "]
-            }, {
+              "content": [
+                "4.25 "
+              ]
+            },
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["Mt 13:12; 25:29. Lu 8:18; 19:26."]
+              "content": [
+                "Mt 13:12; 25:29. Lu 8:18; 19:26."
+              ]
             }
           ]
         }
@@ -16880,14 +19980,20 @@
               "subtype": "note_caller",
               "target": "OWRlMTQ3ODkt"
             },
-            " ", {
+            " ",
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["4.30 "]
-            }, {
+              "content": [
+                "4.30 "
+              ]
+            },
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["Mt 13:31. Lu 13:18."]
+              "content": [
+                "Mt 13:31. Lu 13:18."
+              ]
             }
           ]
         }
@@ -16905,14 +20011,20 @@
               "subtype": "note_caller",
               "target": "NWIxNDU4ZTIt"
             },
-            " ", {
+            " ",
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["4.33 "]
-            }, {
+              "content": [
+                "4.33 "
+              ]
+            },
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["Mt 13:34."]
+              "content": [
+                "Mt 13:34."
+              ]
             }
           ]
         }
@@ -16930,14 +20042,20 @@
               "subtype": "note_caller",
               "target": "Yzc1ZDkyNWQt"
             },
-            " ", {
+            " ",
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["4.35 "]
-            }, {
+              "content": [
+                "4.35 "
+              ]
+            },
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["Mt 8:23. Lu 8:22."]
+              "content": [
+                "Mt 8:23. Lu 8:22."
+              ]
             }
           ]
         }
@@ -16955,14 +20073,20 @@
               "subtype": "note_caller",
               "target": "ZDJiYWRmYWQt"
             },
-            " ", {
+            " ",
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["4.39 "]
-            }, {
+              "content": [
+                "4.39 "
+              ]
+            },
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["Job 26:12. Ps 107:29. És 51:10."]
+              "content": [
+                "Job 26:12. Ps 107:29. És 51:10."
+              ]
             }
           ]
         }
@@ -16980,14 +20104,20 @@
               "subtype": "note_caller",
               "target": "ZTk3YTA2M2Yt"
             },
-            " ", {
+            " ",
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["5.1 "]
-            }, {
+              "content": [
+                "5.1 "
+              ]
+            },
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["Mt 8:28. Lu 8:26."]
+              "content": [
+                "Mt 8:28. Lu 8:26."
+              ]
             }
           ]
         }
@@ -17005,14 +20135,20 @@
               "subtype": "note_caller",
               "target": "Njc2NDk3MWUt"
             },
-            " ", {
+            " ",
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["5.17 "]
-            }, {
+              "content": [
+                "5.17 "
+              ]
+            },
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["Ac 16:39."]
+              "content": [
+                "Ac 16:39."
+              ]
             }
           ]
         }
@@ -17030,14 +20166,20 @@
               "subtype": "note_caller",
               "target": "YzFkMzk3ZWUt"
             },
-            " ", {
+            " ",
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["5.18 "]
-            }, {
+              "content": [
+                "5.18 "
+              ]
+            },
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["Lu 8:38."]
+              "content": [
+                "Lu 8:38."
+              ]
             }
           ]
         }
@@ -17055,14 +20197,20 @@
               "subtype": "note_caller",
               "target": "MTdhM2U4MWIt"
             },
-            " ", {
+            " ",
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["5.21 "]
-            }, {
+              "content": [
+                "5.21 "
+              ]
+            },
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["Lu 8:40."]
+              "content": [
+                "Lu 8:40."
+              ]
             }
           ]
         }
@@ -17080,14 +20228,20 @@
               "subtype": "note_caller",
               "target": "ZWVkNmI1MTYt"
             },
-            " ", {
+            " ",
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["5.22 "]
-            }, {
+              "content": [
+                "5.22 "
+              ]
+            },
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["Mt 9:18. Lu 8:41."]
+              "content": [
+                "Mt 9:18. Lu 8:41."
+              ]
             }
           ]
         }
@@ -17105,14 +20259,20 @@
               "subtype": "note_caller",
               "target": "ZmE1NTY5NTgt"
             },
-            " ", {
+            " ",
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["5.25 "]
-            }, {
+              "content": [
+                "5.25 "
+              ]
+            },
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["Lé 15:25. Mt 9:20. Lu 8:43."]
+              "content": [
+                "Lé 15:25. Mt 9:20. Lu 8:43."
+              ]
             }
           ]
         }
@@ -17130,14 +20290,20 @@
               "subtype": "note_caller",
               "target": "ZTE1M2UxYTYt"
             },
-            " ", {
+            " ",
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["5.34 "]
-            }, {
+              "content": [
+                "5.34 "
+              ]
+            },
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["Mt 9:22. Mc 10:52."]
+              "content": [
+                "Mt 9:22. Mc 10:52."
+              ]
             }
           ]
         }
@@ -17155,14 +20321,20 @@
               "subtype": "note_caller",
               "target": "MGVmYWYwYjYt"
             },
-            " ", {
+            " ",
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["5.35 "]
-            }, {
+              "content": [
+                "5.35 "
+              ]
+            },
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["Lu 8:49."]
+              "content": [
+                "Lu 8:49."
+              ]
             }
           ]
         }
@@ -17180,14 +20352,20 @@
               "subtype": "note_caller",
               "target": "MDkyZGFlZjEt"
             },
-            " ", {
+            " ",
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["5.39 "]
-            }, {
+              "content": [
+                "5.39 "
+              ]
+            },
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["Jn 11:11."]
+              "content": [
+                "Jn 11:11."
+              ]
             }
           ]
         }
@@ -17205,14 +20383,20 @@
               "subtype": "note_caller",
               "target": "ZTEwNGQ3MDAt"
             },
-            " ", {
+            " ",
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["6.1 "]
-            }, {
+              "content": [
+                "6.1 "
+              ]
+            },
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["Mt 13:53. Lu 4:16."]
+              "content": [
+                "Mt 13:53. Lu 4:16."
+              ]
             }
           ]
         }
@@ -17230,14 +20414,20 @@
               "subtype": "note_caller",
               "target": "MGRiNzMwYmEt"
             },
-            " ", {
+            " ",
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["6.3 "]
-            }, {
+              "content": [
+                "6.3 "
+              ]
+            },
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["Jn 6:42."]
+              "content": [
+                "Jn 6:42."
+              ]
             }
           ]
         }
@@ -17255,14 +20445,20 @@
               "subtype": "note_caller",
               "target": "Y2IyNmNkZTkt"
             },
-            " ", {
+            " ",
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["6.4 "]
-            }, {
+              "content": [
+                "6.4 "
+              ]
+            },
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["Mt 13:57. Lu 4:24. Jn 4:44."]
+              "content": [
+                "Mt 13:57. Lu 4:24. Jn 4:44."
+              ]
             }
           ]
         }
@@ -17280,14 +20476,20 @@
               "subtype": "note_caller",
               "target": "NDBmNmU1ZTct"
             },
-            " ", {
+            " ",
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["6.5 "]
-            }, {
+              "content": [
+                "6.5 "
+              ]
+            },
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["Mt 13:58."]
+              "content": [
+                "Mt 13:58."
+              ]
             }
           ]
         }
@@ -17305,14 +20507,20 @@
               "subtype": "note_caller",
               "target": "MTc0OTdhZDct"
             },
-            " ", {
+            " ",
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["6.6 "]
-            }, {
+              "content": [
+                "6.6 "
+              ]
+            },
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["Mt 9:35. Lu 13:22."]
+              "content": [
+                "Mt 9:35. Lu 13:22."
+              ]
             }
           ]
         }
@@ -17330,14 +20538,20 @@
               "subtype": "note_caller",
               "target": "ZTNkNDg0MDMt"
             },
-            " ", {
+            " ",
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["6.7 "]
-            }, {
+              "content": [
+                "6.7 "
+              ]
+            },
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["Mt 10:1. Lu 6:13; 9:1."]
+              "content": [
+                "Mt 10:1. Lu 6:13; 9:1."
+              ]
             }
           ]
         }
@@ -17355,14 +20569,20 @@
               "subtype": "note_caller",
               "target": "YjM4NTIxYmEt"
             },
-            " ", {
+            " ",
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["6.9 "]
-            }, {
+              "content": [
+                "6.9 "
+              ]
+            },
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["Ac 12:8."]
+              "content": [
+                "Ac 12:8."
+              ]
             }
           ]
         }
@@ -17380,14 +20600,20 @@
               "subtype": "note_caller",
               "target": "Y2ZmZDNkYjYt"
             },
-            " ", {
+            " ",
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["6.11 "]
-            }, {
+              "content": [
+                "6.11 "
+              ]
+            },
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["Mt 10:14. Lu 9:5."]
+              "content": [
+                "Mt 10:14. Lu 9:5."
+              ]
             }
           ]
         }
@@ -17405,14 +20631,20 @@
               "subtype": "note_caller",
               "target": "NzFhM2I1MTEt"
             },
-            " ", {
+            " ",
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["6.11 "]
-            }, {
+              "content": [
+                "6.11 "
+              ]
+            },
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["Ac 13:51; 18:6."]
+              "content": [
+                "Ac 13:51; 18:6."
+              ]
             }
           ]
         }
@@ -17430,14 +20662,20 @@
               "subtype": "note_caller",
               "target": "MjY4NTliNTAt"
             },
-            " ", {
+            " ",
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["6.13 "]
-            }, {
+              "content": [
+                "6.13 "
+              ]
+            },
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["Ja 5:14."]
+              "content": [
+                "Ja 5:14."
+              ]
             }
           ]
         }
@@ -17455,14 +20693,20 @@
               "subtype": "note_caller",
               "target": "YWFmZTI5MTYt"
             },
-            " ", {
+            " ",
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["6.14 "]
-            }, {
+              "content": [
+                "6.14 "
+              ]
+            },
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["Mt 14:1. Lu 9:7."]
+              "content": [
+                "Mt 14:1. Lu 9:7."
+              ]
             }
           ]
         }
@@ -17480,14 +20724,20 @@
               "subtype": "note_caller",
               "target": "ZDcxYzEwYmYt"
             },
-            " ", {
+            " ",
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["6.17 "]
-            }, {
+              "content": [
+                "6.17 "
+              ]
+            },
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["Mt 14:3. Lu 3:19; 9:9."]
+              "content": [
+                "Mt 14:3. Lu 3:19; 9:9."
+              ]
             }
           ]
         }
@@ -17505,14 +20755,20 @@
               "subtype": "note_caller",
               "target": "OTMxN2ZkYjMt"
             },
-            " ", {
+            " ",
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["6.18 "]
-            }, {
+              "content": [
+                "6.18 "
+              ]
+            },
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["Lé 8:16; 20:21."]
+              "content": [
+                "Lé 8:16; 20:21."
+              ]
             }
           ]
         }
@@ -17530,14 +20786,20 @@
               "subtype": "note_caller",
               "target": "MWUzYzU2ZjUt"
             },
-            " ", {
+            " ",
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["6.20 "]
-            }, {
+              "content": [
+                "6.20 "
+              ]
+            },
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["Mt 14:5; 21:26."]
+              "content": [
+                "Mt 14:5; 21:26."
+              ]
             }
           ]
         }
@@ -17555,14 +20817,20 @@
               "subtype": "note_caller",
               "target": "NzFlYTQ3OTQt"
             },
-            " ", {
+            " ",
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["6.21 "]
-            }, {
+              "content": [
+                "6.21 "
+              ]
+            },
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["Ge 40:20. Mt 14:6."]
+              "content": [
+                "Ge 40:20. Mt 14:6."
+              ]
             }
           ]
         }
@@ -17580,14 +20848,20 @@
               "subtype": "note_caller",
               "target": "YTc4OTY0OWUt"
             },
-            " ", {
+            " ",
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["6.23 "]
-            }, {
+              "content": [
+                "6.23 "
+              ]
+            },
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["Jg 11:30."]
+              "content": [
+                "Jg 11:30."
+              ]
             }
           ]
         }
@@ -17605,14 +20879,20 @@
               "subtype": "note_caller",
               "target": "N2QxZDRiZDAt"
             },
-            " ", {
+            " ",
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["6.27 "]
-            }, {
+              "content": [
+                "6.27 "
+              ]
+            },
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["Mt 14:10."]
+              "content": [
+                "Mt 14:10."
+              ]
             }
           ]
         }
@@ -17630,14 +20910,20 @@
               "subtype": "note_caller",
               "target": "NWM1N2U1M2Ut"
             },
-            " ", {
+            " ",
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["6.30 "]
-            }, {
+              "content": [
+                "6.30 "
+              ]
+            },
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["Lu 9:10."]
+              "content": [
+                "Lu 9:10."
+              ]
             }
           ]
         }
@@ -17655,14 +20941,20 @@
               "subtype": "note_caller",
               "target": "YzJhODQ0ZTct"
             },
-            " ", {
+            " ",
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["6.31 "]
-            }, {
+              "content": [
+                "6.31 "
+              ]
+            },
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["Mc 3:20."]
+              "content": [
+                "Mc 3:20."
+              ]
             }
           ]
         }
@@ -17680,14 +20972,20 @@
               "subtype": "note_caller",
               "target": "NDM0OTllMDgt"
             },
-            " ", {
+            " ",
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["6.32 "]
-            }, {
+              "content": [
+                "6.32 "
+              ]
+            },
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["Mt 14:13. Lu 9:10. Jn 6:1."]
+              "content": [
+                "Mt 14:13. Lu 9:10. Jn 6:1."
+              ]
             }
           ]
         }
@@ -17705,14 +21003,20 @@
               "subtype": "note_caller",
               "target": "NmNmOWVlMGIt"
             },
-            " ", {
+            " ",
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["6.34 "]
-            }, {
+              "content": [
+                "6.34 "
+              ]
+            },
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["Mt 9:36; 14:14."]
+              "content": [
+                "Mt 9:36; 14:14."
+              ]
             }
           ]
         }
@@ -17730,14 +21034,20 @@
               "subtype": "note_caller",
               "target": "ZGIwMzdhYmIt"
             },
-            " ", {
+            " ",
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["6.34 "]
-            }, {
+              "content": [
+                "6.34 "
+              ]
+            },
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["Jé 23:1. Éz 34:2."]
+              "content": [
+                "Jé 23:1. Éz 34:2."
+              ]
             }
           ]
         }
@@ -17755,14 +21065,20 @@
               "subtype": "note_caller",
               "target": "YzA2MGQxZDMt"
             },
-            " ", {
+            " ",
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["6.34 "]
-            }, {
+              "content": [
+                "6.34 "
+              ]
+            },
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["Lu 9:11."]
+              "content": [
+                "Lu 9:11."
+              ]
             }
           ]
         }
@@ -17780,14 +21096,20 @@
               "subtype": "note_caller",
               "target": "OWYyMDdhZDEt"
             },
-            " ", {
+            " ",
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["6.35 "]
-            }, {
+              "content": [
+                "6.35 "
+              ]
+            },
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["Mt 14:15. Lu 9:12. Jn 6:5."]
+              "content": [
+                "Mt 14:15. Lu 9:12. Jn 6:5."
+              ]
             }
           ]
         }
@@ -17805,14 +21127,20 @@
               "subtype": "note_caller",
               "target": "NDdhNjYxOGYt"
             },
-            " ", {
+            " ",
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["6.38 "]
-            }, {
+              "content": [
+                "6.38 "
+              ]
+            },
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["Mt 14:17. Lu 9:13. Jn 6:9."]
+              "content": [
+                "Mt 14:17. Lu 9:13. Jn 6:9."
+              ]
             }
           ]
         }
@@ -17830,14 +21158,20 @@
               "subtype": "note_caller",
               "target": "ZTg0YjVkMmMt"
             },
-            " ", {
+            " ",
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["6.41 "]
-            }, {
+              "content": [
+                "6.41 "
+              ]
+            },
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["Jn 17:1."]
+              "content": [
+                "Jn 17:1."
+              ]
             }
           ]
         }
@@ -17855,14 +21189,20 @@
               "subtype": "note_caller",
               "target": "MTg4ZGJkMDMt"
             },
-            " ", {
+            " ",
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["6.41 "]
-            }, {
+              "content": [
+                "6.41 "
+              ]
+            },
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["1 S 9:13."]
+              "content": [
+                "1 S 9:13."
+              ]
             }
           ]
         }
@@ -17880,14 +21220,20 @@
               "subtype": "note_caller",
               "target": "NjQ2MjU1YjIt"
             },
-            " ", {
+            " ",
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["6.45 "]
-            }, {
+              "content": [
+                "6.45 "
+              ]
+            },
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["Mt 14:22. Jn 6:17."]
+              "content": [
+                "Mt 14:22. Jn 6:17."
+              ]
             }
           ]
         }
@@ -17905,14 +21251,20 @@
               "subtype": "note_caller",
               "target": "ZDY5OTA4YWYt"
             },
-            " ", {
+            " ",
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["6.46 "]
-            }, {
+              "content": [
+                "6.46 "
+              ]
+            },
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["Mt 14:23. Lu 6:12."]
+              "content": [
+                "Mt 14:23. Lu 6:12."
+              ]
             }
           ]
         }
@@ -17930,14 +21282,20 @@
               "subtype": "note_caller",
               "target": "MTU3MjVmYmYt"
             },
-            " ", {
+            " ",
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["6.47 "]
-            }, {
+              "content": [
+                "6.47 "
+              ]
+            },
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["Mt 14:23. Jn 6:16."]
+              "content": [
+                "Mt 14:23. Jn 6:16."
+              ]
             }
           ]
         }
@@ -17955,14 +21313,20 @@
               "subtype": "note_caller",
               "target": "NmNmOTA4MzMt"
             },
-            " ", {
+            " ",
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["6.53 "]
-            }, {
+              "content": [
+                "6.53 "
+              ]
+            },
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["Mt 14:34."]
+              "content": [
+                "Mt 14:34."
+              ]
             }
           ]
         }
@@ -17980,14 +21344,20 @@
               "subtype": "note_caller",
               "target": "YjA4M2Q0M2Et"
             },
-            " ", {
+            " ",
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["7.1 "]
-            }, {
+              "content": [
+                "7.1 "
+              ]
+            },
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["Mt 15:1."]
+              "content": [
+                "Mt 15:1."
+              ]
             }
           ]
         }
@@ -18005,14 +21375,20 @@
               "subtype": "note_caller",
               "target": "YWM2ODYzMmQt"
             },
-            " ", {
+            " ",
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["7.6 "]
-            }, {
+              "content": [
+                "7.6 "
+              ]
+            },
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["És 29:13. Éz 33:31."]
+              "content": [
+                "És 29:13. Éz 33:31."
+              ]
             }
           ]
         }
@@ -18030,14 +21406,20 @@
               "subtype": "note_caller",
               "target": "ZmY5NDc5M2Mt"
             },
-            " ", {
+            " ",
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["7.7 "]
-            }, {
+              "content": [
+                "7.7 "
+              ]
+            },
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["Mt 15:9. Col 2:18, 20. Tit 1:14."]
+              "content": [
+                "Mt 15:9. Col 2:18, 20. Tit 1:14."
+              ]
             }
           ]
         }
@@ -18055,14 +21437,20 @@
               "subtype": "note_caller",
               "target": "MDM5NDViOWQt"
             },
-            " ", {
+            " ",
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["7.10 "]
-            }, {
+              "content": [
+                "7.10 "
+              ]
+            },
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["Ex 20:12. De 5:16. Ép 6:2."]
+              "content": [
+                "Ex 20:12. De 5:16. Ép 6:2."
+              ]
             }
           ]
         }
@@ -18080,14 +21468,20 @@
               "subtype": "note_caller",
               "target": "ODI4Y2Y4YjIt"
             },
-            " ", {
+            " ",
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["7.10 "]
-            }, {
+              "content": [
+                "7.10 "
+              ]
+            },
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["Ex 21:17. Lé 20:9. De 27:16. Pr 20:20."]
+              "content": [
+                "Ex 21:17. Lé 20:9. De 27:16. Pr 20:20."
+              ]
             }
           ]
         }
@@ -18105,14 +21499,20 @@
               "subtype": "note_caller",
               "target": "YzlhMmI2ZjEt"
             },
-            " ", {
+            " ",
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["7.13 "]
-            }, {
+              "content": [
+                "7.13 "
+              ]
+            },
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["Mt 15:6. 1 Ti 4:3. 2 Ti 3:2."]
+              "content": [
+                "Mt 15:6. 1 Ti 4:3. 2 Ti 3:2."
+              ]
             }
           ]
         }
@@ -18130,14 +21530,20 @@
               "subtype": "note_caller",
               "target": "OThmYTA0NjQt"
             },
-            " ", {
+            " ",
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["7.14 "]
-            }, {
+              "content": [
+                "7.14 "
+              ]
+            },
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["Mt 15:10."]
+              "content": [
+                "Mt 15:10."
+              ]
             }
           ]
         }
@@ -18155,14 +21561,20 @@
               "subtype": "note_caller",
               "target": "ODZjYWVjZDAt"
             },
-            " ", {
+            " ",
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["7.15 "]
-            }, {
+              "content": [
+                "7.15 "
+              ]
+            },
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["Ac 10:15. Ro 14:17, 20. Tit 1:15."]
+              "content": [
+                "Ac 10:15. Ro 14:17, 20. Tit 1:15."
+              ]
             }
           ]
         }
@@ -18180,14 +21592,20 @@
               "subtype": "note_caller",
               "target": "ZDAyZTZhMTkt"
             },
-            " ", {
+            " ",
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["7.17 "]
-            }, {
+              "content": [
+                "7.17 "
+              ]
+            },
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["Mt 15:15."]
+              "content": [
+                "Mt 15:15."
+              ]
             }
           ]
         }
@@ -18205,14 +21623,20 @@
               "subtype": "note_caller",
               "target": "NTZlYTNmYjYt"
             },
-            " ", {
+            " ",
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["7.21 "]
-            }, {
+              "content": [
+                "7.21 "
+              ]
+            },
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["Ge 6:5; 8:21. Pr 6:14. Jé 17:9."]
+              "content": [
+                "Ge 6:5; 8:21. Pr 6:14. Jé 17:9."
+              ]
             }
           ]
         }
@@ -18230,14 +21654,20 @@
               "subtype": "note_caller",
               "target": "ODYwYWVlNDAt"
             },
-            " ", {
+            " ",
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["7.24 "]
-            }, {
+              "content": [
+                "7.24 "
+              ]
+            },
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["Mt 15:21."]
+              "content": [
+                "Mt 15:21."
+              ]
             }
           ]
         }
@@ -18255,14 +21685,20 @@
               "subtype": "note_caller",
               "target": "MzdlMTE0MTkt"
             },
-            " ", {
+            " ",
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["7.31 "]
-            }, {
+              "content": [
+                "7.31 "
+              ]
+            },
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["Mt 15:29."]
+              "content": [
+                "Mt 15:29."
+              ]
             }
           ]
         }
@@ -18280,14 +21716,20 @@
               "subtype": "note_caller",
               "target": "YjNlN2Y4Zjkt"
             },
-            " ", {
+            " ",
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["7.32 "]
-            }, {
+              "content": [
+                "7.32 "
+              ]
+            },
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["Mt 9:32. Lu 11:14."]
+              "content": [
+                "Mt 9:32. Lu 11:14."
+              ]
             }
           ]
         }
@@ -18305,14 +21747,20 @@
               "subtype": "note_caller",
               "target": "ZDRlZGY5N2Qt"
             },
-            " ", {
+            " ",
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["7.37 "]
-            }, {
+              "content": [
+                "7.37 "
+              ]
+            },
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["Ge 1:31."]
+              "content": [
+                "Ge 1:31."
+              ]
             }
           ]
         }
@@ -18330,14 +21778,20 @@
               "subtype": "note_caller",
               "target": "ODQ0YWYyYTAt"
             },
-            " ", {
+            " ",
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["8.1 "]
-            }, {
+              "content": [
+                "8.1 "
+              ]
+            },
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["Mt 15:32."]
+              "content": [
+                "Mt 15:32."
+              ]
             }
           ]
         }
@@ -18355,14 +21809,20 @@
               "subtype": "note_caller",
               "target": "NmVkYWMyZjkt"
             },
-            " ", {
+            " ",
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["8.10 "]
-            }, {
+              "content": [
+                "8.10 "
+              ]
+            },
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["Mt 15:39."]
+              "content": [
+                "Mt 15:39."
+              ]
             }
           ]
         }
@@ -18380,14 +21840,20 @@
               "subtype": "note_caller",
               "target": "ZWMzNWE2ZmMt"
             },
-            " ", {
+            " ",
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["8.11 "]
-            }, {
+              "content": [
+                "8.11 "
+              ]
+            },
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["Mt 12:38; 16:1. Lu 11:29. Jn 6:30."]
+              "content": [
+                "Mt 12:38; 16:1. Lu 11:29. Jn 6:30."
+              ]
             }
           ]
         }
@@ -18405,14 +21871,20 @@
               "subtype": "note_caller",
               "target": "ODkxMjdjYWUt"
             },
-            " ", {
+            " ",
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["8.12 "]
-            }, {
+              "content": [
+                "8.12 "
+              ]
+            },
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["Mt 16:4."]
+              "content": [
+                "Mt 16:4."
+              ]
             }
           ]
         }
@@ -18430,14 +21902,20 @@
               "subtype": "note_caller",
               "target": "NzRhZWUzNzkt"
             },
-            " ", {
+            " ",
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["8.15 "]
-            }, {
+              "content": [
+                "8.15 "
+              ]
+            },
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["Mt 16:6. Lu 12:1."]
+              "content": [
+                "Mt 16:6. Lu 12:1."
+              ]
             }
           ]
         }
@@ -18455,14 +21933,20 @@
               "subtype": "note_caller",
               "target": "NzI4NmMyYWQt"
             },
-            " ", {
+            " ",
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["8.18 "]
-            }, {
+              "content": [
+                "8.18 "
+              ]
+            },
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["Mc 6:52."]
+              "content": [
+                "Mc 6:52."
+              ]
             }
           ]
         }
@@ -18480,14 +21964,20 @@
               "subtype": "note_caller",
               "target": "NDE3NDdlMjEt"
             },
-            " ", {
+            " ",
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["8.19 "]
-            }, {
+              "content": [
+                "8.19 "
+              ]
+            },
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["Mt 14:17, 20. Mc 6:38. Lu 9:13. Jn 6:9."]
+              "content": [
+                "Mt 14:17, 20. Mc 6:38. Lu 9:13. Jn 6:9."
+              ]
             }
           ]
         }
@@ -18505,14 +21995,20 @@
               "subtype": "note_caller",
               "target": "YmEyNmI4Y2Et"
             },
-            " ", {
+            " ",
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["8.20 "]
-            }, {
+              "content": [
+                "8.20 "
+              ]
+            },
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["Mt 15:36, 37."]
+              "content": [
+                "Mt 15:36, 37."
+              ]
             }
           ]
         }
@@ -18530,14 +22026,20 @@
               "subtype": "note_caller",
               "target": "MGRkMzc0Mzkt"
             },
-            " ", {
+            " ",
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["8.23 "]
-            }, {
+              "content": [
+                "8.23 "
+              ]
+            },
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["Mc 7:33."]
+              "content": [
+                "Mc 7:33."
+              ]
             }
           ]
         }
@@ -18555,14 +22057,20 @@
               "subtype": "note_caller",
               "target": "ZDlhYmUxNzkt"
             },
-            " ", {
+            " ",
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["8.23 "]
-            }, {
+              "content": [
+                "8.23 "
+              ]
+            },
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["Mc 7:32."]
+              "content": [
+                "Mc 7:32."
+              ]
             }
           ]
         }
@@ -18580,14 +22088,20 @@
               "subtype": "note_caller",
               "target": "MzU0OTg0YzEt"
             },
-            " ", {
+            " ",
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["8.27 "]
-            }, {
+              "content": [
+                "8.27 "
+              ]
+            },
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["Mt 16:13. Lu 9:18."]
+              "content": [
+                "Mt 16:13. Lu 9:18."
+              ]
             }
           ]
         }
@@ -18605,14 +22119,20 @@
               "subtype": "note_caller",
               "target": "ZjRhNWYwNTgt"
             },
-            " ", {
+            " ",
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["8.28 "]
-            }, {
+              "content": [
+                "8.28 "
+              ]
+            },
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["Mt 14:2."]
+              "content": [
+                "Mt 14:2."
+              ]
             }
           ]
         }
@@ -18630,14 +22150,20 @@
               "subtype": "note_caller",
               "target": "MmQ0YmJiZTQt"
             },
-            " ", {
+            " ",
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["8.29 "]
-            }, {
+              "content": [
+                "8.29 "
+              ]
+            },
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["Mt 16:16. Jn 6:69."]
+              "content": [
+                "Mt 16:16. Jn 6:69."
+              ]
             }
           ]
         }
@@ -18655,14 +22181,20 @@
               "subtype": "note_caller",
               "target": "ZTlkNDY3MWYt"
             },
-            " ", {
+            " ",
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["8.31 "]
-            }, {
+              "content": [
+                "8.31 "
+              ]
+            },
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["Mt 16:21; 17:22; 20:18. Mc 9:31; 10:33. Lu 9:22; 18:31; 24:7."]
+              "content": [
+                "Mt 16:21; 17:22; 20:18. Mc 9:31; 10:33. Lu 9:22; 18:31; 24:7."
+              ]
             }
           ]
         }
@@ -18680,14 +22212,20 @@
               "subtype": "note_caller",
               "target": "MmU3MmQ5ZDEt"
             },
-            " ", {
+            " ",
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["8.33 "]
-            }, {
+              "content": [
+                "8.33 "
+              ]
+            },
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["2 S 19:22."]
+              "content": [
+                "2 S 19:22."
+              ]
             }
           ]
         }
@@ -18705,14 +22243,20 @@
               "subtype": "note_caller",
               "target": "MDIyZTkwMTIt"
             },
-            " ", {
+            " ",
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["8.34 "]
-            }, {
+              "content": [
+                "8.34 "
+              ]
+            },
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["Mt 10:38; 16:24. Lu 9:23; 14:27."]
+              "content": [
+                "Mt 10:38; 16:24. Lu 9:23; 14:27."
+              ]
             }
           ]
         }
@@ -18730,14 +22274,20 @@
               "subtype": "note_caller",
               "target": "OTc2MmU5Zjct"
             },
-            " ", {
+            " ",
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["8.35 "]
-            }, {
+              "content": [
+                "8.35 "
+              ]
+            },
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["Mt 10:39; 16:25. Lu 9:24; 17:33. Jn 12:25."]
+              "content": [
+                "Mt 10:39; 16:25. Lu 9:24; 17:33. Jn 12:25."
+              ]
             }
           ]
         }
@@ -18755,14 +22305,20 @@
               "subtype": "note_caller",
               "target": "MGEyMTNmOTIt"
             },
-            " ", {
+            " ",
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["8.37 "]
-            }, {
+              "content": [
+                "8.37 "
+              ]
+            },
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["Ps 49:9."]
+              "content": [
+                "Ps 49:9."
+              ]
             }
           ]
         }
@@ -18780,14 +22336,20 @@
               "subtype": "note_caller",
               "target": "NzU2MmE4M2Qt"
             },
-            " ", {
+            " ",
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["8.38 "]
-            }, {
+              "content": [
+                "8.38 "
+              ]
+            },
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["Mt 10:32. Lu 9:26; 12:8. 2 Ti 2:12. 1 Jn 2:23."]
+              "content": [
+                "Mt 10:32. Lu 9:26; 12:8. 2 Ti 2:12. 1 Jn 2:23."
+              ]
             }
           ]
         }
@@ -18805,14 +22367,20 @@
               "subtype": "note_caller",
               "target": "YTc0YTViZjct"
             },
-            " ", {
+            " ",
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["9.1 "]
-            }, {
+              "content": [
+                "9.1 "
+              ]
+            },
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["Mt 16:28. Lu 9:27."]
+              "content": [
+                "Mt 16:28. Lu 9:27."
+              ]
             }
           ]
         }
@@ -18830,14 +22398,20 @@
               "subtype": "note_caller",
               "target": "YjJkOTFjODIt"
             },
-            " ", {
+            " ",
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["9.2 "]
-            }, {
+              "content": [
+                "9.2 "
+              ]
+            },
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["Mt 17:1. Lu 9:28."]
+              "content": [
+                "Mt 17:1. Lu 9:28."
+              ]
             }
           ]
         }
@@ -18855,14 +22429,20 @@
               "subtype": "note_caller",
               "target": "M2Y0ZWQyZGEt"
             },
-            " ", {
+            " ",
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["9.7 "]
-            }, {
+              "content": [
+                "9.7 "
+              ]
+            },
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["És 42:1. Mt 3:17; 17:5. Mc 1:11. Lu 3:22; 9:35. Col 1:13. 2 Pi 1:17."]
+              "content": [
+                "És 42:1. Mt 3:17; 17:5. Mc 1:11. Lu 3:22; 9:35. Col 1:13. 2 Pi 1:17."
+              ]
             }
           ]
         }
@@ -18880,14 +22460,20 @@
               "subtype": "note_caller",
               "target": "NjZlN2FiNjct"
             },
-            " ", {
+            " ",
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["9.7 "]
-            }, {
+              "content": [
+                "9.7 "
+              ]
+            },
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["De 18:19."]
+              "content": [
+                "De 18:19."
+              ]
             }
           ]
         }
@@ -18905,14 +22491,20 @@
               "subtype": "note_caller",
               "target": "ODcxZjFlYjMt"
             },
-            " ", {
+            " ",
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["9.9 "]
-            }, {
+              "content": [
+                "9.9 "
+              ]
+            },
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["Mt 17:9. Lu 9:36."]
+              "content": [
+                "Mt 17:9. Lu 9:36."
+              ]
             }
           ]
         }
@@ -18930,14 +22522,20 @@
               "subtype": "note_caller",
               "target": "MzU3NGJkOGMt"
             },
-            " ", {
+            " ",
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["9.11 "]
-            }, {
+              "content": [
+                "9.11 "
+              ]
+            },
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["Mal 4:5. Mt 11:14. Lu 1:17."]
+              "content": [
+                "Mal 4:5. Mt 11:14. Lu 1:17."
+              ]
             }
           ]
         }
@@ -18955,14 +22553,20 @@
               "subtype": "note_caller",
               "target": "Njk4NDg0NjAt"
             },
-            " ", {
+            " ",
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["9.12 "]
-            }, {
+              "content": [
+                "9.12 "
+              ]
+            },
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["Ps 22:7. És 53:4. Da 9:26."]
+              "content": [
+                "Ps 22:7. És 53:4. Da 9:26."
+              ]
             }
           ]
         }
@@ -18980,14 +22584,20 @@
               "subtype": "note_caller",
               "target": "NGMxMmRmMzIt"
             },
-            " ", {
+            " ",
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["9.13 "]
-            }, {
+              "content": [
+                "9.13 "
+              ]
+            },
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["Mal 4:5, 6."]
+              "content": [
+                "Mal 4:5, 6."
+              ]
             }
           ]
         }
@@ -19005,14 +22615,20 @@
               "subtype": "note_caller",
               "target": "MTgxMTZjZWUt"
             },
-            " ", {
+            " ",
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["9.17 "]
-            }, {
+              "content": [
+                "9.17 "
+              ]
+            },
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["Mt 17:14. Lu 9:37, 38."]
+              "content": [
+                "Mt 17:14. Lu 9:37, 38."
+              ]
             }
           ]
         }
@@ -19030,14 +22646,20 @@
               "subtype": "note_caller",
               "target": "MzM4NWU2ZWYt"
             },
-            " ", {
+            " ",
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["9.20 "]
-            }, {
+              "content": [
+                "9.20 "
+              ]
+            },
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["Mc 1:26."]
+              "content": [
+                "Mc 1:26."
+              ]
             }
           ]
         }
@@ -19055,14 +22677,20 @@
               "subtype": "note_caller",
               "target": "ZDQ5ODI4ZjMt"
             },
-            " ", {
+            " ",
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["9.23 "]
-            }, {
+              "content": [
+                "9.23 "
+              ]
+            },
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["Lu 17:6."]
+              "content": [
+                "Lu 17:6."
+              ]
             }
           ]
         }
@@ -19080,14 +22708,20 @@
               "subtype": "note_caller",
               "target": "Y2JkNzhmYmMt"
             },
-            " ", {
+            " ",
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["9.28 "]
-            }, {
+              "content": [
+                "9.28 "
+              ]
+            },
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["Mt 17:19."]
+              "content": [
+                "Mt 17:19."
+              ]
             }
           ]
         }
@@ -19105,14 +22739,20 @@
               "subtype": "note_caller",
               "target": "NDM3ZDI3ZWIt"
             },
-            " ", {
+            " ",
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["9.30 "]
-            }, {
+              "content": [
+                "9.30 "
+              ]
+            },
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["Mt 16:21; 17:22; 20:18. Mc 8:31; 10:33. Lu 9:22; 18:31; 24:7."]
+              "content": [
+                "Mt 16:21; 17:22; 20:18. Mc 8:31; 10:33. Lu 9:22; 18:31; 24:7."
+              ]
             }
           ]
         }
@@ -19130,14 +22770,20 @@
               "subtype": "note_caller",
               "target": "MGYzYzFjNTYt"
             },
-            " ", {
+            " ",
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["9.33 "]
-            }, {
+              "content": [
+                "9.33 "
+              ]
+            },
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["Mt 18:1. Lu 9:46; 22:24."]
+              "content": [
+                "Mt 18:1. Lu 9:46; 22:24."
+              ]
             }
           ]
         }
@@ -19155,14 +22801,20 @@
               "subtype": "note_caller",
               "target": "NWZlOTcyNjct"
             },
-            " ", {
+            " ",
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["9.35 "]
-            }, {
+              "content": [
+                "9.35 "
+              ]
+            },
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["Mt 20:27. Mc 10:43."]
+              "content": [
+                "Mt 20:27. Mc 10:43."
+              ]
             }
           ]
         }
@@ -19180,14 +22832,20 @@
               "subtype": "note_caller",
               "target": "NjMwYmE5ZGMt"
             },
-            " ", {
+            " ",
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["9.36 "]
-            }, {
+              "content": [
+                "9.36 "
+              ]
+            },
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["Mc 10:16."]
+              "content": [
+                "Mc 10:16."
+              ]
             }
           ]
         }
@@ -19205,14 +22863,20 @@
               "subtype": "note_caller",
               "target": "ZTYxOTIxNDYt"
             },
-            " ", {
+            " ",
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["9.37 "]
-            }, {
+              "content": [
+                "9.37 "
+              ]
+            },
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["Mt 18:5. Lu 9:48. Jn 13:20."]
+              "content": [
+                "Mt 18:5. Lu 9:48. Jn 13:20."
+              ]
             }
           ]
         }
@@ -19230,14 +22894,20 @@
               "subtype": "note_caller",
               "target": "Y2E5OTdlM2Et"
             },
-            " ", {
+            " ",
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["9.38 "]
-            }, {
+              "content": [
+                "9.38 "
+              ]
+            },
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["Lu 9:49."]
+              "content": [
+                "Lu 9:49."
+              ]
             }
           ]
         }
@@ -19255,14 +22925,20 @@
               "subtype": "note_caller",
               "target": "NGVmNjE2NmUt"
             },
-            " ", {
+            " ",
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["9.39 "]
-            }, {
+              "content": [
+                "9.39 "
+              ]
+            },
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["1 Co 12:3."]
+              "content": [
+                "1 Co 12:3."
+              ]
             }
           ]
         }
@@ -19280,14 +22956,20 @@
               "subtype": "note_caller",
               "target": "NzZjZjgxOGYt"
             },
-            " ", {
+            " ",
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["9.41 "]
-            }, {
+              "content": [
+                "9.41 "
+              ]
+            },
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["Mt 10:42."]
+              "content": [
+                "Mt 10:42."
+              ]
             }
           ]
         }
@@ -19305,14 +22987,20 @@
               "subtype": "note_caller",
               "target": "OWZiYWRhMDkt"
             },
-            " ", {
+            " ",
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["9.42 "]
-            }, {
+              "content": [
+                "9.42 "
+              ]
+            },
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["Mt 18:6. Lu 17:2."]
+              "content": [
+                "Mt 18:6. Lu 17:2."
+              ]
             }
           ]
         }
@@ -19330,14 +23018,20 @@
               "subtype": "note_caller",
               "target": "ZjFkZTQ3ZTMt"
             },
-            " ", {
+            " ",
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["9.43 "]
-            }, {
+              "content": [
+                "9.43 "
+              ]
+            },
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["De 13:6. Mt 5:30; 18:8."]
+              "content": [
+                "De 13:6. Mt 5:30; 18:8."
+              ]
             }
           ]
         }
@@ -19355,14 +23049,20 @@
               "subtype": "note_caller",
               "target": "YTZhNDVjYmMt"
             },
-            " ", {
+            " ",
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["9.49 "]
-            }, {
+              "content": [
+                "9.49 "
+              ]
+            },
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["Lé 2:13."]
+              "content": [
+                "Lé 2:13."
+              ]
             }
           ]
         }
@@ -19380,14 +23080,20 @@
               "subtype": "note_caller",
               "target": "ZjkyNzQwNDkt"
             },
-            " ", {
+            " ",
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["9.50 "]
-            }, {
+              "content": [
+                "9.50 "
+              ]
+            },
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["Mt 5:13. Lu 14:34."]
+              "content": [
+                "Mt 5:13. Lu 14:34."
+              ]
             }
           ]
         }
@@ -19405,14 +23111,20 @@
               "subtype": "note_caller",
               "target": "NWEwOGZlMmYt"
             },
-            " ", {
+            " ",
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["9.51 "]
-            }, {
+              "content": [
+                "9.51 "
+              ]
+            },
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["Ro 12:18. Hé 12:14."]
+              "content": [
+                "Ro 12:18. Hé 12:14."
+              ]
             }
           ]
         }
@@ -19430,14 +23142,20 @@
               "subtype": "note_caller",
               "target": "OTY1ZTY3YjUt"
             },
-            " ", {
+            " ",
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["10.1 "]
-            }, {
+              "content": [
+                "10.1 "
+              ]
+            },
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["Mt 19:1."]
+              "content": [
+                "Mt 19:1."
+              ]
             }
           ]
         }
@@ -19455,14 +23173,20 @@
               "subtype": "note_caller",
               "target": "ZGNhNjY4NmYt"
             },
-            " ", {
+            " ",
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["10.4 "]
-            }, {
+              "content": [
+                "10.4 "
+              ]
+            },
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["De 24:1. Jé 3:1. Mt 5:31."]
+              "content": [
+                "De 24:1. Jé 3:1. Mt 5:31."
+              ]
             }
           ]
         }
@@ -19480,14 +23204,20 @@
               "subtype": "note_caller",
               "target": "YzFhOWU0ZWMt"
             },
-            " ", {
+            " ",
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["10.6 "]
-            }, {
+              "content": [
+                "10.6 "
+              ]
+            },
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["Ge 1:27. Mt 19:4."]
+              "content": [
+                "Ge 1:27. Mt 19:4."
+              ]
             }
           ]
         }
@@ -19505,14 +23235,20 @@
               "subtype": "note_caller",
               "target": "NzM5MDkyNGMt"
             },
-            " ", {
+            " ",
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["10.7 "]
-            }, {
+              "content": [
+                "10.7 "
+              ]
+            },
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["Ge 2:24. 1 Co 6:16. Ép 5:31."]
+              "content": [
+                "Ge 2:24. 1 Co 6:16. Ép 5:31."
+              ]
             }
           ]
         }
@@ -19530,14 +23266,20 @@
               "subtype": "note_caller",
               "target": "NjRlMjg2YjUt"
             },
-            " ", {
+            " ",
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["10.9 "]
-            }, {
+              "content": [
+                "10.9 "
+              ]
+            },
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["1 Co 7:10."]
+              "content": [
+                "1 Co 7:10."
+              ]
             }
           ]
         }
@@ -19555,14 +23297,20 @@
               "subtype": "note_caller",
               "target": "MTJiOTRlNTMt"
             },
-            " ", {
+            " ",
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["10.11 "]
-            }, {
+              "content": [
+                "10.11 "
+              ]
+            },
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["Mt 5:32; 19:9. Lu 16:18. 1 Co 7:10."]
+              "content": [
+                "Mt 5:32; 19:9. Lu 16:18. 1 Co 7:10."
+              ]
             }
           ]
         }
@@ -19580,14 +23328,20 @@
               "subtype": "note_caller",
               "target": "Yjg5NWU3ZmMt"
             },
-            " ", {
+            " ",
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["10.13 "]
-            }, {
+              "content": [
+                "10.13 "
+              ]
+            },
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["Mt 9:13. Lu 18:15."]
+              "content": [
+                "Mt 9:13. Lu 18:15."
+              ]
             }
           ]
         }
@@ -19605,14 +23359,20 @@
               "subtype": "note_caller",
               "target": "NTAyZDUxNTgt"
             },
-            " ", {
+            " ",
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["10.14 "]
-            }, {
+              "content": [
+                "10.14 "
+              ]
+            },
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["Mt 18:3; 19:14. 1 Co 14:20. 1 Pi 2:2."]
+              "content": [
+                "Mt 18:3; 19:14. 1 Co 14:20. 1 Pi 2:2."
+              ]
             }
           ]
         }
@@ -19630,14 +23390,20 @@
               "subtype": "note_caller",
               "target": "ODNlZmNmYjMt"
             },
-            " ", {
+            " ",
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["10.16 "]
-            }, {
+              "content": [
+                "10.16 "
+              ]
+            },
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["Mt 19:15. Mc 9:36."]
+              "content": [
+                "Mt 19:15. Mc 9:36."
+              ]
             }
           ]
         }
@@ -19655,14 +23421,20 @@
               "subtype": "note_caller",
               "target": "OWY3OTMyMGIt"
             },
-            " ", {
+            " ",
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["10.17 "]
-            }, {
+              "content": [
+                "10.17 "
+              ]
+            },
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["Mt 19:16. Lu 18:18."]
+              "content": [
+                "Mt 19:16. Lu 18:18."
+              ]
             }
           ]
         }
@@ -19680,14 +23452,20 @@
               "subtype": "note_caller",
               "target": "ZjhhZjI5MWMt"
             },
-            " ", {
+            " ",
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["10.19 "]
-            }, {
+              "content": [
+                "10.19 "
+              ]
+            },
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["Ex 20:13; 21:12. De 5:17. Ro 13:9."]
+              "content": [
+                "Ex 20:13; 21:12. De 5:17. Ro 13:9."
+              ]
             }
           ]
         }
@@ -19705,14 +23483,20 @@
               "subtype": "note_caller",
               "target": "MzFiZjI3N2Ut"
             },
-            " ", {
+            " ",
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["10.21 "]
-            }, {
+              "content": [
+                "10.21 "
+              ]
+            },
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["Mt 6:19. Lu 12:33; 16:9. 1 Ti 6:17."]
+              "content": [
+                "Mt 6:19. Lu 12:33; 16:9. 1 Ti 6:17."
+              ]
             }
           ]
         }
@@ -19730,14 +23514,20 @@
               "subtype": "note_caller",
               "target": "OGI1YjM0MjQt"
             },
-            " ", {
+            " ",
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["10.23 "]
-            }, {
+              "content": [
+                "10.23 "
+              ]
+            },
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["Pr 11:28. Mt 19:23. Lu 18:24."]
+              "content": [
+                "Pr 11:28. Mt 19:23. Lu 18:24."
+              ]
             }
           ]
         }
@@ -19755,14 +23545,20 @@
               "subtype": "note_caller",
               "target": "MDRjMjNjYWMt"
             },
-            " ", {
+            " ",
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["10.27 "]
-            }, {
+              "content": [
+                "10.27 "
+              ]
+            },
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["Job 42:2. Jé 32:17. Za 8:6. Lu 1:37."]
+              "content": [
+                "Job 42:2. Jé 32:17. Za 8:6. Lu 1:37."
+              ]
             }
           ]
         }
@@ -19780,14 +23576,20 @@
               "subtype": "note_caller",
               "target": "NDAzMGRhYmEt"
             },
-            " ", {
+            " ",
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["10.28 "]
-            }, {
+              "content": [
+                "10.28 "
+              ]
+            },
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["Mt 4:20; 19:27. Lu 5:11; 18:28."]
+              "content": [
+                "Mt 4:20; 19:27. Lu 5:11; 18:28."
+              ]
             }
           ]
         }
@@ -19805,14 +23607,20 @@
               "subtype": "note_caller",
               "target": "NTFkMjEzYjct"
             },
-            " ", {
+            " ",
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["10.31 "]
-            }, {
+              "content": [
+                "10.31 "
+              ]
+            },
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["Mt 19:30; 20:16. Lu 13:30."]
+              "content": [
+                "Mt 19:30; 20:16. Lu 13:30."
+              ]
             }
           ]
         }
@@ -19830,14 +23638,20 @@
               "subtype": "note_caller",
               "target": "NzczMDQ4NTkt"
             },
-            " ", {
+            " ",
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["10.32 "]
-            }, {
+              "content": [
+                "10.32 "
+              ]
+            },
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["Mt 16:21; 17:22; 20:18. Mc 8:31; 9:31. Lu 9:22; 18:31; 24:7."]
+              "content": [
+                "Mt 16:21; 17:22; 20:18. Mc 8:31; 9:31. Lu 9:22; 18:31; 24:7."
+              ]
             }
           ]
         }
@@ -19855,14 +23669,20 @@
               "subtype": "note_caller",
               "target": "ZWY0NzQ1NWUt"
             },
-            " ", {
+            " ",
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["10.35 "]
-            }, {
+              "content": [
+                "10.35 "
+              ]
+            },
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["Mt 20:20."]
+              "content": [
+                "Mt 20:20."
+              ]
             }
           ]
         }
@@ -19880,14 +23700,20 @@
               "subtype": "note_caller",
               "target": "N2E1NGZiYjYt"
             },
-            " ", {
+            " ",
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["10.38 "]
-            }, {
+              "content": [
+                "10.38 "
+              ]
+            },
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["Mt 20:22. Lu 12:50."]
+              "content": [
+                "Mt 20:22. Lu 12:50."
+              ]
             }
           ]
         }
@@ -19905,14 +23731,20 @@
               "subtype": "note_caller",
               "target": "OGI3MWYxZjYt"
             },
-            " ", {
+            " ",
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["10.40 "]
-            }, {
+              "content": [
+                "10.40 "
+              ]
+            },
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["Mt 20:25."]
+              "content": [
+                "Mt 20:25."
+              ]
             }
           ]
         }
@@ -19930,14 +23762,20 @@
               "subtype": "note_caller",
               "target": "MTM2MmI0ZmMt"
             },
-            " ", {
+            " ",
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["10.41 "]
-            }, {
+              "content": [
+                "10.41 "
+              ]
+            },
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["Mt 20:24."]
+              "content": [
+                "Mt 20:24."
+              ]
             }
           ]
         }
@@ -19955,14 +23793,20 @@
               "subtype": "note_caller",
               "target": "MjVlMDI3MTkt"
             },
-            " ", {
+            " ",
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["10.42 "]
-            }, {
+              "content": [
+                "10.42 "
+              ]
+            },
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["Mt 20:25. Lu 22:25."]
+              "content": [
+                "Mt 20:25. Lu 22:25."
+              ]
             }
           ]
         }
@@ -19980,14 +23824,20 @@
               "subtype": "note_caller",
               "target": "N2YyMTE1Zjkt"
             },
-            " ", {
+            " ",
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["10.43 "]
-            }, {
+              "content": [
+                "10.43 "
+              ]
+            },
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["1 Pi 5:3."]
+              "content": [
+                "1 Pi 5:3."
+              ]
             }
           ]
         }
@@ -20005,14 +23855,20 @@
               "subtype": "note_caller",
               "target": "MzNkYzFkYzYt"
             },
-            " ", {
+            " ",
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["10.45 "]
-            }, {
+              "content": [
+                "10.45 "
+              ]
+            },
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["Jn 13:14. Ph 2:7."]
+              "content": [
+                "Jn 13:14. Ph 2:7."
+              ]
             }
           ]
         }
@@ -20030,14 +23886,20 @@
               "subtype": "note_caller",
               "target": "YzA3NzE1MTYt"
             },
-            " ", {
+            " ",
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["10.45 "]
-            }, {
+              "content": [
+                "10.45 "
+              ]
+            },
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["Ép 1:7. Col 1:14. 1 Ti 2:6. Tit 2:14."]
+              "content": [
+                "Ép 1:7. Col 1:14. 1 Ti 2:6. Tit 2:14."
+              ]
             }
           ]
         }
@@ -20055,14 +23917,20 @@
               "subtype": "note_caller",
               "target": "YWUzOWE3MTIt"
             },
-            " ", {
+            " ",
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["10.46 "]
-            }, {
+              "content": [
+                "10.46 "
+              ]
+            },
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["Mt 20:29. Lu 18:35."]
+              "content": [
+                "Mt 20:29. Lu 18:35."
+              ]
             }
           ]
         }
@@ -20080,14 +23948,20 @@
               "subtype": "note_caller",
               "target": "ZmZiNDg3MGQt"
             },
-            " ", {
+            " ",
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["10.52 "]
-            }, {
+              "content": [
+                "10.52 "
+              ]
+            },
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["Mt 9:22. Mc 5:34."]
+              "content": [
+                "Mt 9:22. Mc 5:34."
+              ]
             }
           ]
         }
@@ -20105,14 +23979,20 @@
               "subtype": "note_caller",
               "target": "ZDU1YmI1MzEt"
             },
-            " ", {
+            " ",
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["11.1 "]
-            }, {
+              "content": [
+                "11.1 "
+              ]
+            },
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["Mt 21:1. Lu 19:29."]
+              "content": [
+                "Mt 21:1. Lu 19:29."
+              ]
             }
           ]
         }
@@ -20130,14 +24010,20 @@
               "subtype": "note_caller",
               "target": "YTM2NjU2YTQt"
             },
-            " ", {
+            " ",
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["11.7 "]
-            }, {
+              "content": [
+                "11.7 "
+              ]
+            },
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["Jn 12:14."]
+              "content": [
+                "Jn 12:14."
+              ]
             }
           ]
         }
@@ -20155,14 +24041,20 @@
               "subtype": "note_caller",
               "target": "NjYyMDExNzQt"
             },
-            " ", {
+            " ",
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["11.7 "]
-            }, {
+              "content": [
+                "11.7 "
+              ]
+            },
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["2 R 9:13."]
+              "content": [
+                "2 R 9:13."
+              ]
             }
           ]
         }
@@ -20180,14 +24072,20 @@
               "subtype": "note_caller",
               "target": "NDMwNjRiYjMt"
             },
-            " ", {
+            " ",
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["11.9 "]
-            }, {
+              "content": [
+                "11.9 "
+              ]
+            },
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["Ps 118:26."]
+              "content": [
+                "Ps 118:26."
+              ]
             }
           ]
         }
@@ -20205,14 +24103,20 @@
               "subtype": "note_caller",
               "target": "ZWY2YzVhNGIt"
             },
-            " ", {
+            " ",
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["11.11 "]
-            }, {
+              "content": [
+                "11.11 "
+              ]
+            },
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["Mt 21:12, 14. Lu 19:45. Jn 2:14."]
+              "content": [
+                "Mt 21:12, 14. Lu 19:45. Jn 2:14."
+              ]
             }
           ]
         }
@@ -20230,14 +24134,20 @@
               "subtype": "note_caller",
               "target": "NzQ2MzYxMDYt"
             },
-            " ", {
+            " ",
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["11.12 "]
-            }, {
+              "content": [
+                "11.12 "
+              ]
+            },
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["Mt 21:18."]
+              "content": [
+                "Mt 21:18."
+              ]
             }
           ]
         }
@@ -20255,14 +24165,20 @@
               "subtype": "note_caller",
               "target": "NTRkMWI3ZDUt"
             },
-            " ", {
+            " ",
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["11.15 "]
-            }, {
+              "content": [
+                "11.15 "
+              ]
+            },
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["Mt 21:12. Lu 19:45. Jn 2:14."]
+              "content": [
+                "Mt 21:12. Lu 19:45. Jn 2:14."
+              ]
             }
           ]
         }
@@ -20280,14 +24196,20 @@
               "subtype": "note_caller",
               "target": "ZDZmNTUzZGUt"
             },
-            " ", {
+            " ",
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["11.17 "]
-            }, {
+              "content": [
+                "11.17 "
+              ]
+            },
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["Mt 21:13. Lu 19:46."]
+              "content": [
+                "Mt 21:13. Lu 19:46."
+              ]
             }
           ]
         }
@@ -20305,14 +24227,20 @@
               "subtype": "note_caller",
               "target": "ODc1OGNkZmIt"
             },
-            " ", {
+            " ",
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["11.17 "]
-            }, {
+              "content": [
+                "11.17 "
+              ]
+            },
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["1 R 8:29. És 56:7."]
+              "content": [
+                "1 R 8:29. És 56:7."
+              ]
             }
           ]
         }
@@ -20330,14 +24258,20 @@
               "subtype": "note_caller",
               "target": "MjFiOGJjYzEt"
             },
-            " ", {
+            " ",
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["11.17 "]
-            }, {
+              "content": [
+                "11.17 "
+              ]
+            },
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["Jé 7:11."]
+              "content": [
+                "Jé 7:11."
+              ]
             }
           ]
         }
@@ -20355,14 +24289,20 @@
               "subtype": "note_caller",
               "target": "NGIxODYwNTEt"
             },
-            " ", {
+            " ",
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["11.18 "]
-            }, {
+              "content": [
+                "11.18 "
+              ]
+            },
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["Jn 7:19."]
+              "content": [
+                "Jn 7:19."
+              ]
             }
           ]
         }
@@ -20380,14 +24320,20 @@
               "subtype": "note_caller",
               "target": "ZDk5YzQ0OTgt"
             },
-            " ", {
+            " ",
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["11.23 "]
-            }, {
+              "content": [
+                "11.23 "
+              ]
+            },
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["Mt 17:20; 21:21. Lu 17:6."]
+              "content": [
+                "Mt 17:20; 21:21. Lu 17:6."
+              ]
             }
           ]
         }
@@ -20405,14 +24351,20 @@
               "subtype": "note_caller",
               "target": "MDQ4YTE2N2Ut"
             },
-            " ", {
+            " ",
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["11.24 "]
-            }, {
+              "content": [
+                "11.24 "
+              ]
+            },
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["Jé 29:12. Mt 7:7. Lu 11:9. Jn 14:13; 15:7; 16:24. Ja 1:5, 6. 1 Jn 3:22; 5:14."]
+              "content": [
+                "Jé 29:12. Mt 7:7. Lu 11:9. Jn 14:13; 15:7; 16:24. Ja 1:5, 6. 1 Jn 3:22; 5:14."
+              ]
             }
           ]
         }
@@ -20430,14 +24382,20 @@
               "subtype": "note_caller",
               "target": "NmYzNGNhODgt"
             },
-            " ", {
+            " ",
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["11.25 "]
-            }, {
+              "content": [
+                "11.25 "
+              ]
+            },
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["Mt 6:14. Col 3:13."]
+              "content": [
+                "Mt 6:14. Col 3:13."
+              ]
             }
           ]
         }
@@ -20455,14 +24413,20 @@
               "subtype": "note_caller",
               "target": "M2U3YjFiNGQt"
             },
-            " ", {
+            " ",
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["11.26 "]
-            }, {
+              "content": [
+                "11.26 "
+              ]
+            },
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["Mt 18:35."]
+              "content": [
+                "Mt 18:35."
+              ]
             }
           ]
         }
@@ -20480,14 +24444,20 @@
               "subtype": "note_caller",
               "target": "N2ZiMDY0YmMt"
             },
-            " ", {
+            " ",
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["11.27 "]
-            }, {
+              "content": [
+                "11.27 "
+              ]
+            },
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["Mt 21:23. Lu 20:1."]
+              "content": [
+                "Mt 21:23. Lu 20:1."
+              ]
             }
           ]
         }
@@ -20505,14 +24475,20 @@
               "subtype": "note_caller",
               "target": "Mjk0Yzk4OTIt"
             },
-            " ", {
+            " ",
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["11.28 "]
-            }, {
+              "content": [
+                "11.28 "
+              ]
+            },
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["Ex 2:14. Ac 4:7; 7:27."]
+              "content": [
+                "Ex 2:14. Ac 4:7; 7:27."
+              ]
             }
           ]
         }
@@ -20530,14 +24506,20 @@
               "subtype": "note_caller",
               "target": "YzAxMTAxMTgt"
             },
-            " ", {
+            " ",
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["11.32 "]
-            }, {
+              "content": [
+                "11.32 "
+              ]
+            },
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["Mt 14:5. Mc 6:20."]
+              "content": [
+                "Mt 14:5. Mc 6:20."
+              ]
             }
           ]
         }
@@ -20555,14 +24537,20 @@
               "subtype": "note_caller",
               "target": "Y2U3YWQ1NGIt"
             },
-            " ", {
+            " ",
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["12.1 "]
-            }, {
+              "content": [
+                "12.1 "
+              ]
+            },
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["Mt 21:33. Lu 20:9."]
+              "content": [
+                "Mt 21:33. Lu 20:9."
+              ]
             }
           ]
         }
@@ -20580,14 +24568,20 @@
               "subtype": "note_caller",
               "target": "OWE1NDJlYjct"
             },
-            " ", {
+            " ",
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["12.1 "]
-            }, {
+              "content": [
+                "12.1 "
+              ]
+            },
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["Ps 80:9. És 5:1. Jé 2:21; 12:10."]
+              "content": [
+                "Ps 80:9. És 5:1. Jé 2:21; 12:10."
+              ]
             }
           ]
         }
@@ -20605,14 +24599,20 @@
               "subtype": "note_caller",
               "target": "YzZiNDY5Njkt"
             },
-            " ", {
+            " ",
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["12.7 "]
-            }, {
+              "content": [
+                "12.7 "
+              ]
+            },
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["Ps 2:8."]
+              "content": [
+                "Ps 2:8."
+              ]
             }
           ]
         }
@@ -20630,14 +24630,20 @@
               "subtype": "note_caller",
               "target": "NGYxNzBmMTEt"
             },
-            " ", {
+            " ",
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["12.7 "]
-            }, {
+              "content": [
+                "12.7 "
+              ]
+            },
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["Ge 37:18. Mt 26:3. Jn 11:53."]
+              "content": [
+                "Ge 37:18. Mt 26:3. Jn 11:53."
+              ]
             }
           ]
         }
@@ -20655,14 +24661,20 @@
               "subtype": "note_caller",
               "target": "YzkyZGU3NjEt"
             },
-            " ", {
+            " ",
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["12.10 "]
-            }, {
+              "content": [
+                "12.10 "
+              ]
+            },
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["Ps 118:22. És 28:16. Mt 21:42. Lu 20:17. Ac 4:11. Ro 9:33. 1 Pi 2:6."]
+              "content": [
+                "Ps 118:22. És 28:16. Mt 21:42. Lu 20:17. Ac 4:11. Ro 9:33. 1 Pi 2:6."
+              ]
             }
           ]
         }
@@ -20680,14 +24692,20 @@
               "subtype": "note_caller",
               "target": "ZGVmZDQ3Y2Mt"
             },
-            " ", {
+            " ",
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["12.13 "]
-            }, {
+              "content": [
+                "12.13 "
+              ]
+            },
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["Mt 22:15. Lu 20:20."]
+              "content": [
+                "Mt 22:15. Lu 20:20."
+              ]
             }
           ]
         }
@@ -20705,14 +24723,20 @@
               "subtype": "note_caller",
               "target": "NmIyNTI5YTEt"
             },
-            " ", {
+            " ",
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["12.17 "]
-            }, {
+              "content": [
+                "12.17 "
+              ]
+            },
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["Mt 17:25; 22:21. Ro 13:7."]
+              "content": [
+                "Mt 17:25; 22:21. Ro 13:7."
+              ]
             }
           ]
         }
@@ -20730,14 +24754,20 @@
               "subtype": "note_caller",
               "target": "YzE5Y2ZhOTQt"
             },
-            " ", {
+            " ",
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["12.18 "]
-            }, {
+              "content": [
+                "12.18 "
+              ]
+            },
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["Mt 22:23. Lu 20:27. Ac 23:8."]
+              "content": [
+                "Mt 22:23. Lu 20:27. Ac 23:8."
+              ]
             }
           ]
         }
@@ -20755,14 +24785,20 @@
               "subtype": "note_caller",
               "target": "MDI4OThjYjUt"
             },
-            " ", {
+            " ",
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["12.19 "]
-            }, {
+              "content": [
+                "12.19 "
+              ]
+            },
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["De 25:5, 6."]
+              "content": [
+                "De 25:5, 6."
+              ]
             }
           ]
         }
@@ -20780,14 +24816,20 @@
               "subtype": "note_caller",
               "target": "ZmFjY2Y3ZDQt"
             },
-            " ", {
+            " ",
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["12.25 "]
-            }, {
+              "content": [
+                "12.25 "
+              ]
+            },
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["Mt 22:30. 1 Jn 3:2."]
+              "content": [
+                "Mt 22:30. 1 Jn 3:2."
+              ]
             }
           ]
         }
@@ -20805,14 +24847,20 @@
               "subtype": "note_caller",
               "target": "OWE1ZDllNGUt"
             },
-            " ", {
+            " ",
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["12.26 "]
-            }, {
+              "content": [
+                "12.26 "
+              ]
+            },
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["Ex 3:6. Mt 22:31, 32. Ac 7:32. Hé 11:16."]
+              "content": [
+                "Ex 3:6. Mt 22:31, 32. Ac 7:32. Hé 11:16."
+              ]
             }
           ]
         }
@@ -20830,14 +24878,20 @@
               "subtype": "note_caller",
               "target": "MjA1Y2Q5MDEt"
             },
-            " ", {
+            " ",
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["12.28 "]
-            }, {
+              "content": [
+                "12.28 "
+              ]
+            },
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["Mt 22:34. Lu 10:25."]
+              "content": [
+                "Mt 22:34. Lu 10:25."
+              ]
             }
           ]
         }
@@ -20855,14 +24909,20 @@
               "subtype": "note_caller",
               "target": "YzA1MDY4ZGMt"
             },
-            " ", {
+            " ",
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["12.29 "]
-            }, {
+              "content": [
+                "12.29 "
+              ]
+            },
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["De 6:4; 10:12. Lu 10:27."]
+              "content": [
+                "De 6:4; 10:12. Lu 10:27."
+              ]
             }
           ]
         }
@@ -20880,14 +24940,20 @@
               "subtype": "note_caller",
               "target": "YzdkYzY2ZTIt"
             },
-            " ", {
+            " ",
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["12.31 "]
-            }, {
+              "content": [
+                "12.31 "
+              ]
+            },
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["Lé 19:18. Mt 22:39. Ro 13:9. Ga 5:14. Ja 2:8."]
+              "content": [
+                "Lé 19:18. Mt 22:39. Ro 13:9. Ga 5:14. Ja 2:8."
+              ]
             }
           ]
         }
@@ -20905,14 +24971,20 @@
               "subtype": "note_caller",
               "target": "NDNiMDQ1MGMt"
             },
-            " ", {
+            " ",
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["12.35 "]
-            }, {
+              "content": [
+                "12.35 "
+              ]
+            },
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["Mt 22:41. Lu 20:41."]
+              "content": [
+                "Mt 22:41. Lu 20:41."
+              ]
             }
           ]
         }
@@ -20930,14 +25002,20 @@
               "subtype": "note_caller",
               "target": "NDM5YjdmZjct"
             },
-            " ", {
+            " ",
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["12.36 "]
-            }, {
+              "content": [
+                "12.36 "
+              ]
+            },
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["Ps 110:1. Ac 2:34. 1 Co 15:25. Hé 1:13; 10:13."]
+              "content": [
+                "Ps 110:1. Ac 2:34. 1 Co 15:25. Hé 1:13; 10:13."
+              ]
             }
           ]
         }
@@ -20955,14 +25033,20 @@
               "subtype": "note_caller",
               "target": "MmZkNzI1YjUt"
             },
-            " ", {
+            " ",
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["12.38 "]
-            }, {
+              "content": [
+                "12.38 "
+              ]
+            },
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["Mt 23:5, 6. Lu 11:43; 20:46."]
+              "content": [
+                "Mt 23:5, 6. Lu 11:43; 20:46."
+              ]
             }
           ]
         }
@@ -20980,14 +25064,20 @@
               "subtype": "note_caller",
               "target": "ZmU0ZjdiNjct"
             },
-            " ", {
+            " ",
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["12.40 "]
-            }, {
+              "content": [
+                "12.40 "
+              ]
+            },
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["Mt 23:14. Lu 20:47. 2 Ti 3:6. Tit 1:11."]
+              "content": [
+                "Mt 23:14. Lu 20:47. 2 Ti 3:6. Tit 1:11."
+              ]
             }
           ]
         }
@@ -21005,14 +25095,20 @@
               "subtype": "note_caller",
               "target": "MjZiMmJjMjEt"
             },
-            " ", {
+            " ",
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["12.41 "]
-            }, {
+              "content": [
+                "12.41 "
+              ]
+            },
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["Lu 21:1."]
+              "content": [
+                "Lu 21:1."
+              ]
             }
           ]
         }
@@ -21030,14 +25126,20 @@
               "subtype": "note_caller",
               "target": "MTg4MzNmMTAt"
             },
-            " ", {
+            " ",
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["12.41 "]
-            }, {
+              "content": [
+                "12.41 "
+              ]
+            },
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["2 R 12:9."]
+              "content": [
+                "2 R 12:9."
+              ]
             }
           ]
         }
@@ -21055,14 +25157,20 @@
               "subtype": "note_caller",
               "target": "ZTFlMjhjZjAt"
             },
-            " ", {
+            " ",
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["12.43 "]
-            }, {
+              "content": [
+                "12.43 "
+              ]
+            },
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["2 Co 8:12."]
+              "content": [
+                "2 Co 8:12."
+              ]
             }
           ]
         }
@@ -21080,14 +25188,20 @@
               "subtype": "note_caller",
               "target": "YWQ3NzQwYmEt"
             },
-            " ", {
+            " ",
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["13.1 "]
-            }, {
+              "content": [
+                "13.1 "
+              ]
+            },
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["Mt 24:1. Lu 21:5."]
+              "content": [
+                "Mt 24:1. Lu 21:5."
+              ]
             }
           ]
         }
@@ -21105,14 +25219,20 @@
               "subtype": "note_caller",
               "target": "MDAxNmNiODQt"
             },
-            " ", {
+            " ",
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["13.2 "]
-            }, {
+              "content": [
+                "13.2 "
+              ]
+            },
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["1 R 9:7, 8. Mi 3:12. Lu 19:44."]
+              "content": [
+                "1 R 9:7, 8. Mi 3:12. Lu 19:44."
+              ]
             }
           ]
         }
@@ -21130,14 +25250,20 @@
               "subtype": "note_caller",
               "target": "MmQ3YWIyNmEt"
             },
-            " ", {
+            " ",
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["13.3 "]
-            }, {
+              "content": [
+                "13.3 "
+              ]
+            },
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["Mt 24:3. Lu 21:7."]
+              "content": [
+                "Mt 24:3. Lu 21:7."
+              ]
             }
           ]
         }
@@ -21155,14 +25281,20 @@
               "subtype": "note_caller",
               "target": "OGJhMjlkNWEt"
             },
-            " ", {
+            " ",
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["13.4 "]
-            }, {
+              "content": [
+                "13.4 "
+              ]
+            },
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["Ac 1:6."]
+              "content": [
+                "Ac 1:6."
+              ]
             }
           ]
         }
@@ -21180,14 +25312,20 @@
               "subtype": "note_caller",
               "target": "YjQ3ZmEyNTct"
             },
-            " ", {
+            " ",
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["13.5 "]
-            }, {
+              "content": [
+                "13.5 "
+              ]
+            },
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["Jé 29:8. Ép 5:6. 2 Th 2:2, 3. 1 Jn 4:1."]
+              "content": [
+                "Jé 29:8. Ép 5:6. 2 Th 2:2, 3. 1 Jn 4:1."
+              ]
             }
           ]
         }
@@ -21205,14 +25343,20 @@
               "subtype": "note_caller",
               "target": "NGFmNTMxNzkt"
             },
-            " ", {
+            " ",
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["13.6 "]
-            }, {
+              "content": [
+                "13.6 "
+              ]
+            },
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["Jé 14:14; 23:21."]
+              "content": [
+                "Jé 14:14; 23:21."
+              ]
             }
           ]
         }
@@ -21230,14 +25374,20 @@
               "subtype": "note_caller",
               "target": "ZmViMjUxMzQt"
             },
-            " ", {
+            " ",
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["13.8 "]
-            }, {
+              "content": [
+                "13.8 "
+              ]
+            },
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["És 19:2."]
+              "content": [
+                "És 19:2."
+              ]
             }
           ]
         }
@@ -21255,14 +25405,20 @@
               "subtype": "note_caller",
               "target": "NzA3MjFmY2Mt"
             },
-            " ", {
+            " ",
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["13.9 "]
-            }, {
+              "content": [
+                "13.9 "
+              ]
+            },
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["Mt 10:17; 24:9. Lu 21:12. Jn 15:19; 16:2. Ap 2:10."]
+              "content": [
+                "Mt 10:17; 24:9. Lu 21:12. Jn 15:19; 16:2. Ap 2:10."
+              ]
             }
           ]
         }
@@ -21280,14 +25436,20 @@
               "subtype": "note_caller",
               "target": "YWY4MGFiZjIt"
             },
-            " ", {
+            " ",
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["13.11 "]
-            }, {
+              "content": [
+                "13.11 "
+              ]
+            },
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["Mt 10:19. Lu 12:11; 21:14."]
+              "content": [
+                "Mt 10:19. Lu 12:11; 21:14."
+              ]
             }
           ]
         }
@@ -21305,14 +25467,20 @@
               "subtype": "note_caller",
               "target": "YTQ3ODljYmIt"
             },
-            " ", {
+            " ",
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["13.12 "]
-            }, {
+              "content": [
+                "13.12 "
+              ]
+            },
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["Éz 38:21. Mi 7:6."]
+              "content": [
+                "Éz 38:21. Mi 7:6."
+              ]
             }
           ]
         }
@@ -21330,14 +25498,20 @@
               "subtype": "note_caller",
               "target": "YmU2ODdhMmEt"
             },
-            " ", {
+            " ",
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["13.13 "]
-            }, {
+              "content": [
+                "13.13 "
+              ]
+            },
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["Mt 10:22; 24:13. Lu 21:19. Ap 2:7, 10."]
+              "content": [
+                "Mt 10:22; 24:13. Lu 21:19. Ap 2:7, 10."
+              ]
             }
           ]
         }
@@ -21355,14 +25529,20 @@
               "subtype": "note_caller",
               "target": "ZWEwYTA5MmMt"
             },
-            " ", {
+            " ",
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["13.14 "]
-            }, {
+              "content": [
+                "13.14 "
+              ]
+            },
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["Mt 24:15. Lu 21:10."]
+              "content": [
+                "Mt 24:15. Lu 21:10."
+              ]
             }
           ]
         }
@@ -21380,14 +25560,20 @@
               "subtype": "note_caller",
               "target": "YmQ3MjNlMDgt"
             },
-            " ", {
+            " ",
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["13.14 "]
-            }, {
+              "content": [
+                "13.14 "
+              ]
+            },
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["Lu 21:21."]
+              "content": [
+                "Lu 21:21."
+              ]
             }
           ]
         }
@@ -21405,14 +25591,20 @@
               "subtype": "note_caller",
               "target": "MjNlYWQ0Y2Ut"
             },
-            " ", {
+            " ",
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["13.21 "]
-            }, {
+              "content": [
+                "13.21 "
+              ]
+            },
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["Mt 24:23. Lu 21:8."]
+              "content": [
+                "Mt 24:23. Lu 21:8."
+              ]
             }
           ]
         }
@@ -21430,14 +25622,20 @@
               "subtype": "note_caller",
               "target": "Y2VhN2Q1ZWUt"
             },
-            " ", {
+            " ",
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["13.22 "]
-            }, {
+              "content": [
+                "13.22 "
+              ]
+            },
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["De 13:1. 2 Th 2:11."]
+              "content": [
+                "De 13:1. 2 Th 2:11."
+              ]
             }
           ]
         }
@@ -21455,14 +25653,20 @@
               "subtype": "note_caller",
               "target": "YmE1ZTE0Y2Yt"
             },
-            " ", {
+            " ",
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["13.24 "]
-            }, {
+              "content": [
+                "13.24 "
+              ]
+            },
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["És 13:10. Éz 32:7. Joë 2:31; 3:15. Mt 24:29. Lu 21:25. Ap 6:12."]
+              "content": [
+                "És 13:10. Éz 32:7. Joë 2:31; 3:15. Mt 24:29. Lu 21:25. Ap 6:12."
+              ]
             }
           ]
         }
@@ -21480,14 +25684,20 @@
               "subtype": "note_caller",
               "target": "YmQxOWE4ZmMt"
             },
-            " ", {
+            " ",
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["13.26 "]
-            }, {
+              "content": [
+                "13.26 "
+              ]
+            },
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["Da 7:10. Mt 16:27; 24:30. Mc 14:62. Lu 21:27. Ac 1:11. 1 Th 4:15. 2 Th 1:10. Ap 1:7."]
+              "content": [
+                "Da 7:10. Mt 16:27; 24:30. Mc 14:62. Lu 21:27. Ac 1:11. 1 Th 4:15. 2 Th 1:10. Ap 1:7."
+              ]
             }
           ]
         }
@@ -21505,14 +25715,20 @@
               "subtype": "note_caller",
               "target": "YTc2MzFhNjEt"
             },
-            " ", {
+            " ",
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["13.28 "]
-            }, {
+              "content": [
+                "13.28 "
+              ]
+            },
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["Mt 24:32. Lu 21:29."]
+              "content": [
+                "Mt 24:32. Lu 21:29."
+              ]
             }
           ]
         }
@@ -21530,14 +25746,20 @@
               "subtype": "note_caller",
               "target": "ODA3ZmYzYzEt"
             },
-            " ", {
+            " ",
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["13.31 "]
-            }, {
+              "content": [
+                "13.31 "
+              ]
+            },
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["Ps 102:27. És 40:8; 51:6. Hé 1:11."]
+              "content": [
+                "Ps 102:27. És 40:8; 51:6. Hé 1:11."
+              ]
             }
           ]
         }
@@ -21555,14 +25777,20 @@
               "subtype": "note_caller",
               "target": "MDE1NzgxODUt"
             },
-            " ", {
+            " ",
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["13.32 "]
-            }, {
+              "content": [
+                "13.32 "
+              ]
+            },
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["Mt 24:36. Ac 1:7."]
+              "content": [
+                "Mt 24:36. Ac 1:7."
+              ]
             }
           ]
         }
@@ -21580,14 +25808,20 @@
               "subtype": "note_caller",
               "target": "MmNmNjMzYzYt"
             },
-            " ", {
+            " ",
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["13.33 "]
-            }, {
+              "content": [
+                "13.33 "
+              ]
+            },
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["Mt 24:42; 25:13. Lu 12:40; 21:36. 1 Th 5:6."]
+              "content": [
+                "Mt 24:42; 25:13. Lu 12:40; 21:36. 1 Th 5:6."
+              ]
             }
           ]
         }
@@ -21605,14 +25839,20 @@
               "subtype": "note_caller",
               "target": "MmJhMGZhYWEt"
             },
-            " ", {
+            " ",
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["14.1 "]
-            }, {
+              "content": [
+                "14.1 "
+              ]
+            },
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["Mt 26:2. Lu 22:1. Jn 11:55; 13:1."]
+              "content": [
+                "Mt 26:2. Lu 22:1. Jn 11:55; 13:1."
+              ]
             }
           ]
         }
@@ -21630,14 +25870,20 @@
               "subtype": "note_caller",
               "target": "NWMxZGExYTMt"
             },
-            " ", {
+            " ",
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["14.3 "]
-            }, {
+              "content": [
+                "14.3 "
+              ]
+            },
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["Mt 26:6. Lu 7:37. Jn 11:2; 12:3."]
+              "content": [
+                "Mt 26:6. Lu 7:37. Jn 11:2; 12:3."
+              ]
             }
           ]
         }
@@ -21655,14 +25901,20 @@
               "subtype": "note_caller",
               "target": "NzMwMzkxMjEt"
             },
-            " ", {
+            " ",
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["14.7 "]
-            }, {
+              "content": [
+                "14.7 "
+              ]
+            },
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["De 15:11."]
+              "content": [
+                "De 15:11."
+              ]
             }
           ]
         }
@@ -21680,14 +25932,20 @@
               "subtype": "note_caller",
               "target": "ZWU1ZDA4ZGEt"
             },
-            " ", {
+            " ",
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["14.10 "]
-            }, {
+              "content": [
+                "14.10 "
+              ]
+            },
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["Mt 26:14. Lu 22:4."]
+              "content": [
+                "Mt 26:14. Lu 22:4."
+              ]
             }
           ]
         }
@@ -21705,14 +25963,20 @@
               "subtype": "note_caller",
               "target": "ZWFmOTgxZWYt"
             },
-            " ", {
+            " ",
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["14.12 "]
-            }, {
+              "content": [
+                "14.12 "
+              ]
+            },
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["Mt 26:17. Lu 22:7."]
+              "content": [
+                "Mt 26:17. Lu 22:7."
+              ]
             }
           ]
         }
@@ -21730,14 +25994,20 @@
               "subtype": "note_caller",
               "target": "YWM2NzNlZmIt"
             },
-            " ", {
+            " ",
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["14.12 "]
-            }, {
+              "content": [
+                "14.12 "
+              ]
+            },
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["Ex 12:17."]
+              "content": [
+                "Ex 12:17."
+              ]
             }
           ]
         }
@@ -21755,14 +26025,20 @@
               "subtype": "note_caller",
               "target": "OWI3OTdlYWIt"
             },
-            " ", {
+            " ",
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["14.17 "]
-            }, {
+              "content": [
+                "14.17 "
+              ]
+            },
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["Mt 26:20. Lu 22:14."]
+              "content": [
+                "Mt 26:20. Lu 22:14."
+              ]
             }
           ]
         }
@@ -21780,14 +26056,20 @@
               "subtype": "note_caller",
               "target": "ODM2NDJjYzAt"
             },
-            " ", {
+            " ",
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["14.18 "]
-            }, {
+              "content": [
+                "14.18 "
+              ]
+            },
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["Ps 41:10. Ac 1:17."]
+              "content": [
+                "Ps 41:10. Ac 1:17."
+              ]
             }
           ]
         }
@@ -21805,14 +26087,20 @@
               "subtype": "note_caller",
               "target": "YTMyNTMzMWYt"
             },
-            " ", {
+            " ",
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["14.22 "]
-            }, {
+              "content": [
+                "14.22 "
+              ]
+            },
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["Mt 26:26. Lu 22:19. 1 Co 11:23."]
+              "content": [
+                "Mt 26:26. Lu 22:19. 1 Co 11:23."
+              ]
             }
           ]
         }
@@ -21830,14 +26118,20 @@
               "subtype": "note_caller",
               "target": "MDA0MWMzYWMt"
             },
-            " ", {
+            " ",
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["14.27 "]
-            }, {
+              "content": [
+                "14.27 "
+              ]
+            },
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["Mt 26:31. Jn 16:32."]
+              "content": [
+                "Mt 26:31. Jn 16:32."
+              ]
             }
           ]
         }
@@ -21855,14 +26149,20 @@
               "subtype": "note_caller",
               "target": "Yjg5ZTRjMDQt"
             },
-            " ", {
+            " ",
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["14.27 "]
-            }, {
+              "content": [
+                "14.27 "
+              ]
+            },
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["Za 13:7."]
+              "content": [
+                "Za 13:7."
+              ]
             }
           ]
         }
@@ -21880,14 +26180,20 @@
               "subtype": "note_caller",
               "target": "ZGMxMjg5YjQt"
             },
-            " ", {
+            " ",
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["14.28 "]
-            }, {
+              "content": [
+                "14.28 "
+              ]
+            },
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["Mt 26:32; 28:10. Mc 16:7."]
+              "content": [
+                "Mt 26:32; 28:10. Mc 16:7."
+              ]
             }
           ]
         }
@@ -21905,14 +26211,20 @@
               "subtype": "note_caller",
               "target": "ZjFiZjg4MmUt"
             },
-            " ", {
+            " ",
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["14.30 "]
-            }, {
+              "content": [
+                "14.30 "
+              ]
+            },
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["Mt 26:34. Lu 22:34. Jn 13:38."]
+              "content": [
+                "Mt 26:34. Lu 22:34. Jn 13:38."
+              ]
             }
           ]
         }
@@ -21930,14 +26242,20 @@
               "subtype": "note_caller",
               "target": "ZTg0YTkyNTQt"
             },
-            " ", {
+            " ",
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["14.31 "]
-            }, {
+              "content": [
+                "14.31 "
+              ]
+            },
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["Jn 13:37."]
+              "content": [
+                "Jn 13:37."
+              ]
             }
           ]
         }
@@ -21955,14 +26273,20 @@
               "subtype": "note_caller",
               "target": "YTk4NWQyZDgt"
             },
-            " ", {
+            " ",
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["14.32 "]
-            }, {
+              "content": [
+                "14.32 "
+              ]
+            },
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["Mt 26:36. Lu 22:39. Jn 18:1."]
+              "content": [
+                "Mt 26:36. Lu 22:39. Jn 18:1."
+              ]
             }
           ]
         }
@@ -21980,14 +26304,20 @@
               "subtype": "note_caller",
               "target": "YTZhYWU1OGQt"
             },
-            " ", {
+            " ",
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["14.34 "]
-            }, {
+              "content": [
+                "14.34 "
+              ]
+            },
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["Jn 12:27."]
+              "content": [
+                "Jn 12:27."
+              ]
             }
           ]
         }
@@ -22005,14 +26335,20 @@
               "subtype": "note_caller",
               "target": "OTk1ZDhkY2Ut"
             },
-            " ", {
+            " ",
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["14.35 "]
-            }, {
+              "content": [
+                "14.35 "
+              ]
+            },
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["Lu 22:41."]
+              "content": [
+                "Lu 22:41."
+              ]
             }
           ]
         }
@@ -22030,14 +26366,20 @@
               "subtype": "note_caller",
               "target": "OGEwNWYwYzEt"
             },
-            " ", {
+            " ",
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["14.36 "]
-            }, {
+              "content": [
+                "14.36 "
+              ]
+            },
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["Jn 6:38."]
+              "content": [
+                "Jn 6:38."
+              ]
             }
           ]
         }
@@ -22055,14 +26397,20 @@
               "subtype": "note_caller",
               "target": "NGRmYjllY2Qt"
             },
-            " ", {
+            " ",
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["14.37 "]
-            }, {
+              "content": [
+                "14.37 "
+              ]
+            },
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["Mt 26:40. Lu 22:45."]
+              "content": [
+                "Mt 26:40. Lu 22:45."
+              ]
             }
           ]
         }
@@ -22080,14 +26428,20 @@
               "subtype": "note_caller",
               "target": "ODYzZTc1NTYt"
             },
-            " ", {
+            " ",
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["14.38 "]
-            }, {
+              "content": [
+                "14.38 "
+              ]
+            },
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["Ga 5:17."]
+              "content": [
+                "Ga 5:17."
+              ]
             }
           ]
         }
@@ -22105,14 +26459,20 @@
               "subtype": "note_caller",
               "target": "Yjk4MmRjYjAt"
             },
-            " ", {
+            " ",
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["14.43 "]
-            }, {
+              "content": [
+                "14.43 "
+              ]
+            },
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["Mt 26:47. Lu 22:47. Jn 18:3."]
+              "content": [
+                "Mt 26:47. Lu 22:47. Jn 18:3."
+              ]
             }
           ]
         }
@@ -22130,14 +26490,20 @@
               "subtype": "note_caller",
               "target": "NjNmN2UzNWQt"
             },
-            " ", {
+            " ",
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["14.45 "]
-            }, {
+              "content": [
+                "14.45 "
+              ]
+            },
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["2 S 20:9."]
+              "content": [
+                "2 S 20:9."
+              ]
             }
           ]
         }
@@ -22155,14 +26521,20 @@
               "subtype": "note_caller",
               "target": "ZjFkODJhM2Yt"
             },
-            " ", {
+            " ",
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["14.49 "]
-            }, {
+              "content": [
+                "14.49 "
+              ]
+            },
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["Ps 22:7; 69:10. Lu 24:25."]
+              "content": [
+                "Ps 22:7; 69:10. Lu 24:25."
+              ]
             }
           ]
         }
@@ -22180,14 +26552,20 @@
               "subtype": "note_caller",
               "target": "MWUzOTY2MTQt"
             },
-            " ", {
+            " ",
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["14.50 "]
-            }, {
+              "content": [
+                "14.50 "
+              ]
+            },
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["Job 19:13. Ps 88:9."]
+              "content": [
+                "Job 19:13. Ps 88:9."
+              ]
             }
           ]
         }
@@ -22205,14 +26583,20 @@
               "subtype": "note_caller",
               "target": "MWM3ZmNjMzAt"
             },
-            " ", {
+            " ",
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["14.53 "]
-            }, {
+              "content": [
+                "14.53 "
+              ]
+            },
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["Mt 26:57. Lu 22:54. Jn 18:13, 24."]
+              "content": [
+                "Mt 26:57. Lu 22:54. Jn 18:13, 24."
+              ]
             }
           ]
         }
@@ -22230,14 +26614,20 @@
               "subtype": "note_caller",
               "target": "NmMwMGM5Y2Yt"
             },
-            " ", {
+            " ",
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["14.55 "]
-            }, {
+              "content": [
+                "14.55 "
+              ]
+            },
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["Mt 26:59. Ac 6:13."]
+              "content": [
+                "Mt 26:59. Ac 6:13."
+              ]
             }
           ]
         }
@@ -22255,14 +26645,20 @@
               "subtype": "note_caller",
               "target": "YjkxYzY5MDYt"
             },
-            " ", {
+            " ",
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["14.58 "]
-            }, {
+              "content": [
+                "14.58 "
+              ]
+            },
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["Mc 15:29. Jn 2:19."]
+              "content": [
+                "Mc 15:29. Jn 2:19."
+              ]
             }
           ]
         }
@@ -22280,14 +26676,20 @@
               "subtype": "note_caller",
               "target": "MDFmNTJmNWYt"
             },
-            " ", {
+            " ",
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["14.60 "]
-            }, {
+              "content": [
+                "14.60 "
+              ]
+            },
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["Mt 26:62."]
+              "content": [
+                "Mt 26:62."
+              ]
             }
           ]
         }
@@ -22305,14 +26707,20 @@
               "subtype": "note_caller",
               "target": "MGZhNjdkZjQt"
             },
-            " ", {
+            " ",
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["14.61 "]
-            }, {
+              "content": [
+                "14.61 "
+              ]
+            },
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["És 53:7. Ac 8:32."]
+              "content": [
+                "És 53:7. Ac 8:32."
+              ]
             }
           ]
         }
@@ -22330,14 +26738,20 @@
               "subtype": "note_caller",
               "target": "MDA4ZDZkNjAt"
             },
-            " ", {
+            " ",
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["14.62 "]
-            }, {
+              "content": [
+                "14.62 "
+              ]
+            },
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["Da 7:13. Mt 16:27; 24:30; 25:31. Lu 21:27. Ac 1:17. 1 Th 4:16. 2 Th 1:10. Ap 1:1."]
+              "content": [
+                "Da 7:13. Mt 16:27; 24:30; 25:31. Lu 21:27. Ac 1:17. 1 Th 4:16. 2 Th 1:10. Ap 1:1."
+              ]
             }
           ]
         }
@@ -22355,14 +26769,20 @@
               "subtype": "note_caller",
               "target": "Yjc2ZDg0YTQt"
             },
-            " ", {
+            " ",
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["14.65 "]
-            }, {
+              "content": [
+                "14.65 "
+              ]
+            },
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["Job 16:10. És 50:6. Jn 19:3."]
+              "content": [
+                "Job 16:10. És 50:6. Jn 19:3."
+              ]
             }
           ]
         }
@@ -22380,14 +26800,20 @@
               "subtype": "note_caller",
               "target": "OTkzMmJlZWYt"
             },
-            " ", {
+            " ",
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["14.66 "]
-            }, {
+              "content": [
+                "14.66 "
+              ]
+            },
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["Mt 26:58, 69. Lu 22:55. Jn 18:16, 17."]
+              "content": [
+                "Mt 26:58, 69. Lu 22:55. Jn 18:16, 17."
+              ]
             }
           ]
         }
@@ -22405,14 +26831,20 @@
               "subtype": "note_caller",
               "target": "Y2QwYWI5ZDUt"
             },
-            " ", {
+            " ",
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["14.69 "]
-            }, {
+              "content": [
+                "14.69 "
+              ]
+            },
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["Mt 26:71. Lu 22:58. Jn 18:25."]
+              "content": [
+                "Mt 26:71. Lu 22:58. Jn 18:25."
+              ]
             }
           ]
         }
@@ -22430,14 +26862,20 @@
               "subtype": "note_caller",
               "target": "N2VjZGQ1OWIt"
             },
-            " ", {
+            " ",
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["14.72 "]
-            }, {
+              "content": [
+                "14.72 "
+              ]
+            },
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["Mt 26:34, 75. Lu 22:61. Jn 13:38; 18:27."]
+              "content": [
+                "Mt 26:34, 75. Lu 22:61. Jn 13:38; 18:27."
+              ]
             }
           ]
         }
@@ -22455,14 +26893,20 @@
               "subtype": "note_caller",
               "target": "MzY5NjUzYmUt"
             },
-            " ", {
+            " ",
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["15.1 "]
-            }, {
+              "content": [
+                "15.1 "
+              ]
+            },
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["Ps 2:2. Mt 27:1. Lu 22:66; 23:1. Jn 18:28."]
+              "content": [
+                "Ps 2:2. Mt 27:1. Lu 22:66; 23:1. Jn 18:28."
+              ]
             }
           ]
         }
@@ -22480,14 +26924,20 @@
               "subtype": "note_caller",
               "target": "ZWFhZWZiYjIt"
             },
-            " ", {
+            " ",
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["15.1 "]
-            }, {
+              "content": [
+                "15.1 "
+              ]
+            },
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["Ac 3:13."]
+              "content": [
+                "Ac 3:13."
+              ]
             }
           ]
         }
@@ -22505,14 +26955,20 @@
               "subtype": "note_caller",
               "target": "YTg0YzYwODct"
             },
-            " ", {
+            " ",
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["15.2 "]
-            }, {
+              "content": [
+                "15.2 "
+              ]
+            },
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["Mt 27:11. Lu 23:3. Jn 18:33."]
+              "content": [
+                "Mt 27:11. Lu 23:3. Jn 18:33."
+              ]
             }
           ]
         }
@@ -22530,14 +26986,20 @@
               "subtype": "note_caller",
               "target": "NzA0NGI5NWYt"
             },
-            " ", {
+            " ",
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["15.4 "]
-            }, {
+              "content": [
+                "15.4 "
+              ]
+            },
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["Mt 27:13. Jn 19:10."]
+              "content": [
+                "Mt 27:13. Jn 19:10."
+              ]
             }
           ]
         }
@@ -22555,14 +27017,20 @@
               "subtype": "note_caller",
               "target": "MDA4ZWRjYTUt"
             },
-            " ", {
+            " ",
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["15.6 "]
-            }, {
+              "content": [
+                "15.6 "
+              ]
+            },
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["Mt 27:15. Lu 23:17. Jn 18:39."]
+              "content": [
+                "Mt 27:15. Lu 23:17. Jn 18:39."
+              ]
             }
           ]
         }
@@ -22580,14 +27048,20 @@
               "subtype": "note_caller",
               "target": "OGE4ODU0M2Et"
             },
-            " ", {
+            " ",
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["15.7 "]
-            }, {
+              "content": [
+                "15.7 "
+              ]
+            },
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["Mt 27:16. Lu 23:19. Jn 18:40."]
+              "content": [
+                "Mt 27:16. Lu 23:19. Jn 18:40."
+              ]
             }
           ]
         }
@@ -22605,14 +27079,20 @@
               "subtype": "note_caller",
               "target": "Mzg5MjAwZDUt"
             },
-            " ", {
+            " ",
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["15.11 "]
-            }, {
+              "content": [
+                "15.11 "
+              ]
+            },
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["Mt 27:20. Lu 23:18. Jn 18:40. Ac 3:14."]
+              "content": [
+                "Mt 27:20. Lu 23:18. Jn 18:40. Ac 3:14."
+              ]
             }
           ]
         }
@@ -22630,14 +27110,20 @@
               "subtype": "note_caller",
               "target": "OTEyMzY1ZGIt"
             },
-            " ", {
+            " ",
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["15.15 "]
-            }, {
+              "content": [
+                "15.15 "
+              ]
+            },
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["Mt 27:26. Jn 19:1."]
+              "content": [
+                "Mt 27:26. Jn 19:1."
+              ]
             }
           ]
         }
@@ -22655,14 +27141,20 @@
               "subtype": "note_caller",
               "target": "NWQzN2YyYzgt"
             },
-            " ", {
+            " ",
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["15.16 "]
-            }, {
+              "content": [
+                "15.16 "
+              ]
+            },
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["Mt 27:27. Jn 19:2."]
+              "content": [
+                "Mt 27:27. Jn 19:2."
+              ]
             }
           ]
         }
@@ -22680,14 +27172,20 @@
               "subtype": "note_caller",
               "target": "MjYyMmZmNzIt"
             },
-            " ", {
+            " ",
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["15.21 "]
-            }, {
+              "content": [
+                "15.21 "
+              ]
+            },
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["Mt 27:32. Lu 23:26."]
+              "content": [
+                "Mt 27:32. Lu 23:26."
+              ]
             }
           ]
         }
@@ -22705,14 +27203,20 @@
               "subtype": "note_caller",
               "target": "ZDQzOWNhNWMt"
             },
-            " ", {
+            " ",
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["15.22 "]
-            }, {
+              "content": [
+                "15.22 "
+              ]
+            },
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["Mt 27:33. Lu 23:33. Jn 19:17."]
+              "content": [
+                "Mt 27:33. Lu 23:33. Jn 19:17."
+              ]
             }
           ]
         }
@@ -22730,14 +27234,20 @@
               "subtype": "note_caller",
               "target": "MTI1NWQ3MGUt"
             },
-            " ", {
+            " ",
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["15.24 "]
-            }, {
+              "content": [
+                "15.24 "
+              ]
+            },
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["Mt 27:35. Lu 23:34. Jn 19:23."]
+              "content": [
+                "Mt 27:35. Lu 23:34. Jn 19:23."
+              ]
             }
           ]
         }
@@ -22755,14 +27265,20 @@
               "subtype": "note_caller",
               "target": "ZDY5ZmJhZTMt"
             },
-            " ", {
+            " ",
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["15.24 "]
-            }, {
+              "content": [
+                "15.24 "
+              ]
+            },
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["Ps 22:19."]
+              "content": [
+                "Ps 22:19."
+              ]
             }
           ]
         }
@@ -22780,14 +27296,20 @@
               "subtype": "note_caller",
               "target": "MzMzN2U4NWQt"
             },
-            " ", {
+            " ",
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["15.26 "]
-            }, {
+              "content": [
+                "15.26 "
+              ]
+            },
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["Mt 27:37. Lu 23:38. Jn 19:19."]
+              "content": [
+                "Mt 27:37. Lu 23:38. Jn 19:19."
+              ]
             }
           ]
         }
@@ -22805,14 +27327,20 @@
               "subtype": "note_caller",
               "target": "MzQyYzYwZTgt"
             },
-            " ", {
+            " ",
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["15.28 "]
-            }, {
+              "content": [
+                "15.28 "
+              ]
+            },
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["És 53:12. Lu 22:37."]
+              "content": [
+                "És 53:12. Lu 22:37."
+              ]
             }
           ]
         }
@@ -22830,14 +27358,20 @@
               "subtype": "note_caller",
               "target": "NDMwZjNiMDgt"
             },
-            " ", {
+            " ",
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["15.29 "]
-            }, {
+              "content": [
+                "15.29 "
+              ]
+            },
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["Ps 22:8; 69:21; 109:25. Mt 27:39. Lu 23:35."]
+              "content": [
+                "Ps 22:8; 69:21; 109:25. Mt 27:39. Lu 23:35."
+              ]
             }
           ]
         }
@@ -22855,14 +27389,20 @@
               "subtype": "note_caller",
               "target": "ZmY2MWJiZGEt"
             },
-            " ", {
+            " ",
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["15.29 "]
-            }, {
+              "content": [
+                "15.29 "
+              ]
+            },
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["Jn 2:19."]
+              "content": [
+                "Jn 2:19."
+              ]
             }
           ]
         }
@@ -22880,14 +27420,20 @@
               "subtype": "note_caller",
               "target": "OWQ5YjIzYzAt"
             },
-            " ", {
+            " ",
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["15.33 "]
-            }, {
+              "content": [
+                "15.33 "
+              ]
+            },
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["Mt 27:45. Lu 23:44."]
+              "content": [
+                "Mt 27:45. Lu 23:44."
+              ]
             }
           ]
         }
@@ -22905,14 +27451,20 @@
               "subtype": "note_caller",
               "target": "YTEyODZiZGMt"
             },
-            " ", {
+            " ",
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["15.34 "]
-            }, {
+              "content": [
+                "15.34 "
+              ]
+            },
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["Ps 22:2. Mt 27:46."]
+              "content": [
+                "Ps 22:2. Mt 27:46."
+              ]
             }
           ]
         }
@@ -22930,14 +27482,20 @@
               "subtype": "note_caller",
               "target": "YzZhNWExZDEt"
             },
-            " ", {
+            " ",
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["15.36 "]
-            }, {
+              "content": [
+                "15.36 "
+              ]
+            },
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["Ps 69:22. Jn 19:29."]
+              "content": [
+                "Ps 69:22. Jn 19:29."
+              ]
             }
           ]
         }
@@ -22955,14 +27513,20 @@
               "subtype": "note_caller",
               "target": "MmJmYThhNTEt"
             },
-            " ", {
+            " ",
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["15.38 "]
-            }, {
+              "content": [
+                "15.38 "
+              ]
+            },
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["2 Co 3:14. Mt 27:51. Lu 23:45."]
+              "content": [
+                "2 Co 3:14. Mt 27:51. Lu 23:45."
+              ]
             }
           ]
         }
@@ -22980,14 +27544,20 @@
               "subtype": "note_caller",
               "target": "NGE3M2ZmN2Qt"
             },
-            " ", {
+            " ",
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["15.39 "]
-            }, {
+              "content": [
+                "15.39 "
+              ]
+            },
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["Mt 27:54. Lu 23:47."]
+              "content": [
+                "Mt 27:54. Lu 23:47."
+              ]
             }
           ]
         }
@@ -23005,14 +27575,20 @@
               "subtype": "note_caller",
               "target": "OWZkODY3ZGUt"
             },
-            " ", {
+            " ",
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["15.40 "]
-            }, {
+              "content": [
+                "15.40 "
+              ]
+            },
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["Mt 27:55. Lu 23:49."]
+              "content": [
+                "Mt 27:55. Lu 23:49."
+              ]
             }
           ]
         }
@@ -23030,14 +27606,20 @@
               "subtype": "note_caller",
               "target": "OWRkMzA1OTIt"
             },
-            " ", {
+            " ",
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["15.40 "]
-            }, {
+              "content": [
+                "15.40 "
+              ]
+            },
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["Ps 38:12."]
+              "content": [
+                "Ps 38:12."
+              ]
             }
           ]
         }
@@ -23055,14 +27637,20 @@
               "subtype": "note_caller",
               "target": "OTM4ZTgzYWMt"
             },
-            " ", {
+            " ",
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["15.41 "]
-            }, {
+              "content": [
+                "15.41 "
+              ]
+            },
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["Lu 8:2, 3."]
+              "content": [
+                "Lu 8:2, 3."
+              ]
             }
           ]
         }
@@ -23080,14 +27668,20 @@
               "subtype": "note_caller",
               "target": "NDIwMWZiNzct"
             },
-            " ", {
+            " ",
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["15.42 "]
-            }, {
+              "content": [
+                "15.42 "
+              ]
+            },
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["Mt 27:57. Lu 23:50. Jn 19:38."]
+              "content": [
+                "Mt 27:57. Lu 23:50. Jn 19:38."
+              ]
             }
           ]
         }
@@ -23105,14 +27699,20 @@
               "subtype": "note_caller",
               "target": "NjZmZjEzMzgt"
             },
-            " ", {
+            " ",
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["15.46 "]
-            }, {
+              "content": [
+                "15.46 "
+              ]
+            },
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["Mt 12:40; 26:12; 27:60. Lu 23:53."]
+              "content": [
+                "Mt 12:40; 26:12; 27:60. Lu 23:53."
+              ]
             }
           ]
         }
@@ -23130,14 +27730,20 @@
               "subtype": "note_caller",
               "target": "MGYyYWNlNjAt"
             },
-            " ", {
+            " ",
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["16.1 "]
-            }, {
+              "content": [
+                "16.1 "
+              ]
+            },
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["Mt 28:1. Lu 24:1. Jn 20:1."]
+              "content": [
+                "Mt 28:1. Lu 24:1. Jn 20:1."
+              ]
             }
           ]
         }
@@ -23155,14 +27761,20 @@
               "subtype": "note_caller",
               "target": "MjhkMjIzNWQt"
             },
-            " ", {
+            " ",
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["16.5 "]
-            }, {
+              "content": [
+                "16.5 "
+              ]
+            },
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["Mt 28:2. Jn 20:12."]
+              "content": [
+                "Mt 28:2. Jn 20:12."
+              ]
             }
           ]
         }
@@ -23180,14 +27792,20 @@
               "subtype": "note_caller",
               "target": "MzM2NWFlOTEt"
             },
-            " ", {
+            " ",
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["16.6 "]
-            }, {
+              "content": [
+                "16.6 "
+              ]
+            },
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["Mt 28:5. Lu 24:5."]
+              "content": [
+                "Mt 28:5. Lu 24:5."
+              ]
             }
           ]
         }
@@ -23205,14 +27823,20 @@
               "subtype": "note_caller",
               "target": "YTQ2NTU3Mzkt"
             },
-            " ", {
+            " ",
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["16.7 "]
-            }, {
+              "content": [
+                "16.7 "
+              ]
+            },
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["Ac 1:3; 13:31. 1 Co 15:5."]
+              "content": [
+                "Ac 1:3; 13:31. 1 Co 15:5."
+              ]
             }
           ]
         }
@@ -23230,14 +27854,20 @@
               "subtype": "note_caller",
               "target": "MGYzNjU2M2Yt"
             },
-            " ", {
+            " ",
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["16.7 "]
-            }, {
+              "content": [
+                "16.7 "
+              ]
+            },
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["Mt 26:32; 28:10. Mc 14:28."]
+              "content": [
+                "Mt 26:32; 28:10. Mc 14:28."
+              ]
             }
           ]
         }
@@ -23255,14 +27885,20 @@
               "subtype": "note_caller",
               "target": "MDQ3NTcxMWUt"
             },
-            " ", {
+            " ",
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["16.8 "]
-            }, {
+              "content": [
+                "16.8 "
+              ]
+            },
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["Mt 28:8. Lu 24:9. Jn 20:18."]
+              "content": [
+                "Mt 28:8. Lu 24:9. Jn 20:18."
+              ]
             }
           ]
         }
@@ -23280,14 +27916,20 @@
               "subtype": "note_caller",
               "target": "YzJkYTZjZjgt"
             },
-            " ", {
+            " ",
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["16.9 "]
-            }, {
+              "content": [
+                "16.9 "
+              ]
+            },
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["Jn 20:14, 16."]
+              "content": [
+                "Jn 20:14, 16."
+              ]
             }
           ]
         }
@@ -23305,14 +27947,20 @@
               "subtype": "note_caller",
               "target": "NjNkNDA0NDQt"
             },
-            " ", {
+            " ",
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["16.9 "]
-            }, {
+              "content": [
+                "16.9 "
+              ]
+            },
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["Lu 8:2."]
+              "content": [
+                "Lu 8:2."
+              ]
             }
           ]
         }
@@ -23330,14 +27978,20 @@
               "subtype": "note_caller",
               "target": "YWJlYzJhNzct"
             },
-            " ", {
+            " ",
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["16.12 "]
-            }, {
+              "content": [
+                "16.12 "
+              ]
+            },
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["Lu 24:13."]
+              "content": [
+                "Lu 24:13."
+              ]
             }
           ]
         }
@@ -23355,14 +28009,20 @@
               "subtype": "note_caller",
               "target": "ZWE4MWNmMWMt"
             },
-            " ", {
+            " ",
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["16.14 "]
-            }, {
+              "content": [
+                "16.14 "
+              ]
+            },
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["Lu 24:36. Jn 20:19. 1 Co 15:5."]
+              "content": [
+                "Lu 24:36. Jn 20:19. 1 Co 15:5."
+              ]
             }
           ]
         }
@@ -23380,14 +28040,20 @@
               "subtype": "note_caller",
               "target": "YjQzOWU2NTIt"
             },
-            " ", {
+            " ",
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["16.15 "]
-            }, {
+              "content": [
+                "16.15 "
+              ]
+            },
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["Mt 28:19. Jn 15:16."]
+              "content": [
+                "Mt 28:19. Jn 15:16."
+              ]
             }
           ]
         }
@@ -23405,14 +28071,20 @@
               "subtype": "note_caller",
               "target": "ZTFmZGU4N2Et"
             },
-            " ", {
+            " ",
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["16.16 "]
-            }, {
+              "content": [
+                "16.16 "
+              ]
+            },
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["Jn 3:18; 12:48."]
+              "content": [
+                "Jn 3:18; 12:48."
+              ]
             }
           ]
         }
@@ -23430,14 +28102,20 @@
               "subtype": "note_caller",
               "target": "N2M5MzEyNDYt"
             },
-            " ", {
+            " ",
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["16.17 "]
-            }, {
+              "content": [
+                "16.17 "
+              ]
+            },
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["Lu 10:17. Ac 5:16; 8:7; 16:18; 19:12."]
+              "content": [
+                "Lu 10:17. Ac 5:16; 8:7; 16:18; 19:12."
+              ]
             }
           ]
         }
@@ -23455,14 +28133,20 @@
               "subtype": "note_caller",
               "target": "Y2U3MjVhOWEt"
             },
-            " ", {
+            " ",
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["16.17 "]
-            }, {
+              "content": [
+                "16.17 "
+              ]
+            },
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["Ac 2:4; 10:46; 19:6."]
+              "content": [
+                "Ac 2:4; 10:46; 19:6."
+              ]
             }
           ]
         }
@@ -23480,14 +28164,20 @@
               "subtype": "note_caller",
               "target": "N2Y0NDRjMGYt"
             },
-            " ", {
+            " ",
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["16.18 "]
-            }, {
+              "content": [
+                "16.18 "
+              ]
+            },
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["Lu 10:19. Ac 28:5."]
+              "content": [
+                "Lu 10:19. Ac 28:5."
+              ]
             }
           ]
         }
@@ -23505,14 +28195,20 @@
               "subtype": "note_caller",
               "target": "OTQ0NGY4NDEt"
             },
-            " ", {
+            " ",
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["16.18 "]
-            }, {
+              "content": [
+                "16.18 "
+              ]
+            },
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["Ac 28:8."]
+              "content": [
+                "Ac 28:8."
+              ]
             }
           ]
         }
@@ -23530,14 +28226,20 @@
               "subtype": "note_caller",
               "target": "MzYxNTk4YmQt"
             },
-            " ", {
+            " ",
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["16.19 "]
-            }, {
+              "content": [
+                "16.19 "
+              ]
+            },
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["Lu 24:50, 51. Ac 1:9."]
+              "content": [
+                "Lu 24:50, 51. Ac 1:9."
+              ]
             }
           ]
         }
@@ -23555,14 +28257,20 @@
               "subtype": "note_caller",
               "target": "MTA4MWEzMzEt"
             },
-            " ", {
+            " ",
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["16.20 "]
-            }, {
+              "content": [
+                "16.20 "
+              ]
+            },
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["Ac 1:2. 1 Ti 3:16."]
+              "content": [
+                "Ac 1:2. 1 Ti 3:16."
+              ]
             }
           ]
         }
@@ -23580,14 +28288,20 @@
               "subtype": "note_caller",
               "target": "NDAzMTVjYjIt"
             },
-            " ", {
+            " ",
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["16.20 "]
-            }, {
+              "content": [
+                "16.20 "
+              ]
+            },
+            {
               "type": "wrapper",
               "subtype": "usfm:span",
-              "content": ["Ac 14:3. Hé 2:4."]
+              "content": [
+                "Ac 14:3. Hé 2:4."
+              ]
             }
           ]
         }


### PR DESCRIPTION
@samueljd @klappy @mvahowe This commit allows the htmlMap to have custom context as well as contain information about each Perf element's ancesters.

Basic htmlMap example:

```js
//htmlmap.js

export default (context) => ({

  mark: {

    chapter: ({ atts, parent }) => {

      context.lastChap = atts.number;

      return {

        classList: [

          "mark",

          "chapter",

          `chapter-${atts.number}`,

          `parent-${parent.subtype}`,

        ],

        id: `chapter-${atts.number}`,

      };

    },

    verses: ({ atts, parent }) => {

      return {

        classList: [

          "mark",

          "verse",

          `verse-${atts.number}`,

          `ref-ch${context.lastChap}v${atts.number}`,

          `parent-${parent.subtype}`,

        ],

        id: `verse-${atts.number}`,

      };

    },

  },

});
```

Notice the exported map is now a callback function that returns json, this callback function has a context object as argument that can be modified as needed. In this case we use the context to store the lastChapter read. If the context is not needed, you may pass to the htmlMap parameter of Epitelete-Perf-Html constructor, an object or data imported from a JSON file:
```
constructor({ proskomma = null, docSetId, htmlMap, options = {} })
```